### PR TITLE
More cosmetic changes

### DIFF
--- a/Colimit-code/Aux/AuxPaths-v2.agda
+++ b/Colimit-code/Aux/AuxPaths-v2.agda
@@ -11,10 +11,12 @@ module _ {ℓ₁ ℓ₂} {A : Type ℓ₁} {B : Type ℓ₂} {f : A → B} {x : 
     → ! (ap f R) ∙ ap (f ∘ g) Q ∙ S == ! (ap f (! (ap g Q) ∙ R)) ∙ S
   E₁-v2 idp = idp
 
-  E₂-v2 : {y : A} {p q : x == y} (R : p == q) (S : f x == z) → ! (ap f q)  ∙ S == ! (ap f p) ∙ S ∙ idp
+  E₂-v2 : {y : A} {p q : x == y} (R : p == q) (S : f x == z)
+    → ! (ap f q)  ∙ S == ! (ap f p) ∙ S ∙ idp
   E₂-v2 idp idp = idp
 
-module _ {ℓ₁ ℓ₂ k l} {A : Type ℓ₁} {B : Type ℓ₂} {f : A → B} {C : Type k} {D : Type l} {h : C → A} {v : C → D} {u : D → B} where
+module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄} {A : Type ℓ₁} {B : Type ℓ₂} {f : A → B} {C : Type ℓ₃} {D : Type ℓ₄}
+  {h : C → A} {v : C → D} {u : D → B} where
 
   E₃-v2 : (q : (z : C) →  u (v z) == f (h z)) {x y : C} (p : x == y) {S : h x == h y} (T : ap h p == S)
     → ! (ap u (ap v p)) ∙ q x ∙ ap f S == q y
@@ -32,7 +34,7 @@ module _ {ℓ₁ ℓ₂ ℓ₃} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type �
     → p ∙ q ∙ ap f (! (ap g u) ∙ v) == p ∙ q ∙ s ∙ ! (! R ∙ ap (f ∘ g) u ∙ s)
   O₂ idp idp idp idp = idp
 
-module _ {ℓ₁ ℓ₂ k l} {A : Type ℓ₁} {B : Type ℓ₂} {f : A → B} {C : Type k} {D : Type l} {h : C → A} {v : C → D} {u : D → B} {c : C} where
+module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄} {A : Type ℓ₁} {B : Type ℓ₂} {f : A → B} {C : Type ℓ₃} {D : Type ℓ₄} {h : C → A} {v : C → D} {u : D → B} {c : C} where
 
   O₄ : (q : (x : C) → f (h x) == u (v x)) {d : C} (p : c == d) {S : v c == v d} (R : ap v p == S)
     → q c == ap f (ap h p) ∙ q d ∙ ! (ap u S)
@@ -48,26 +50,40 @@ module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄} {A : Type ℓ₁} {B : Type ℓ₂} {C : 
 
   abstract
 
-    𝕐 : {c d : D} (Q : c == d) {x : A} (R₁ : h c == x) {z : B} (S : g (h d) == z) {p : h d == x} (R₂ : p == ! (ap h Q) ∙ R₁) {w : C} (fₚ : f z == w)
-      → ! (ap (λ q → ! (ap (f ∘ g) p) ∙ (ap f S ∙ fₚ) ∙ q) (ap ! (ap (λ q → q ∙ fₚ) (ap (ap f) (E₂-v2 {p = p} R₂ S))))) ∙
-        ! (ap (λ q → ! (ap (f ∘ g) p) ∙ (ap f S ∙ fₚ) ∙ q) (ap ! (ap (λ q → q ∙ fₚ) (ap (ap f) (E₁-v2 {g = h} {R = R₁} Q))))) ∙
-        ! (ap (λ q → ! (ap (f ∘ g) p) ∙ (ap f S ∙ fₚ) ∙ q) (ap ! (ap-cp-revR f (g ∘ h) Q (ap g R₁)))) ∙
-        Δ-red Q (ap f (ap g R₁)) (ap f S ∙ fₚ) R₁ (ap (λ q → ! (ap (f ∘ g) q)) R₂) ∙ cmp-inv-l {f = g} {g = f} R₁
-      == inv-canc-cmp f g p S fₚ
+    𝕐 : {c d : D} (Q : c == d) {x : A} (R₁ : h c == x) {z : B} (S : g (h d) == z) {p : h d == x}
+      (R₂ : p == ! (ap h Q) ∙ R₁) {w : C} (fₚ : f z == w)
+      →
+      ! (ap (λ q → ! (ap (f ∘ g) p) ∙ (ap f S ∙ fₚ) ∙ q) (ap ! (ap (λ q → q ∙ fₚ) (ap (ap f) (E₂-v2 {p = p} R₂ S))))) ∙
+      ! (ap (λ q → ! (ap (f ∘ g) p) ∙ (ap f S ∙ fₚ) ∙ q) (ap ! (ap (λ q → q ∙ fₚ) (ap (ap f) (E₁-v2 {g = h} {R = R₁} Q))))) ∙
+      ! (ap (λ q → ! (ap (f ∘ g) p) ∙ (ap f S ∙ fₚ) ∙ q) (ap ! (ap-cp-revR f (g ∘ h) Q (ap g R₁)))) ∙
+      Δ-red Q (ap f (ap g R₁)) (ap f S ∙ fₚ) R₁ (ap (λ q → ! (ap (f ∘ g) q)) R₂) ∙ cmp-inv-l {f = g} {g = f} R₁
+        ==
+      inv-canc-cmp f g p S fₚ
     𝕐 idp idp idp idp idp = idp 
 
-module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄ ℓ₅} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type ℓ₃} {D : Type ℓ₄} {E : Type ℓ₅} {τ : A → B} {h : C → A} {v : C → D} {u : D → B} {f : B → E} where
+module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄ ℓ₅} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type ℓ₃} {D : Type ℓ₄} {E : Type ℓ₅}
+  {τ : A → B} {h : C → A} {v : C → D} {u : D → B} {f : B → E} where
 
   abstract
 
     𝕏 : {x y : C} (p : x == y) {S : h x == h y} (T : ap h p == S) (r : (z : C) →  u (v z) == τ (h z)) {k : A → E} (fₚ : f ∘ τ ∼ k)
-      →  ! (ap (λ q → ! (ap (f ∘ u) (ap v p)) ∙ q ∙ ap k S ∙ ! (ap f (r y) ∙ fₚ (h y))) (O₄ {f = f ∘ u} {h = v} {u = k} (λ z → ap f (r z) ∙ fₚ (h z)) p T)) ∙
-        ! (ap (λ q → ! (ap (f ∘ u) (ap v p)) ∙ (ap f (r x) ∙ fₚ (h x)) ∙ ap k S ∙ q) (ap ! (ap (λ q → q ∙ fₚ (h y)) (ap (ap f) (E₃-v2 {f = τ} {v = v} {u = u} r p T)))))
-      == cmp-helper {f = f} p S r fₚ
-    𝕏 {x = x} idp idp r {k = k} fₚ = IndFunHom {P = λ g F → 
-      !(ap (λ q → q ∙ ! (ap f (r x) ∙ F (h x))) (! (∙-unit-r (ap f (r x) ∙ F (h x))))) ∙ ! (ap (λ q → (ap f (r x) ∙ F (h x)) ∙ q) (ap ! (ap (λ q → q ∙ F (h x))
-        (ap (ap f) (∙-unit-r (r x))))))
-      == cmp-helper {v = v} {u = u} {f = f} idp idp r {k = g} F} (ap-pth-unitr {τ = τ} {h = h} {v = v} {u = u} {f = f} x r ∙
-        ! (IndFunHom-β {P = λ _ G → ((ap f (r x) ∙ G (h x)) ∙ idp) ∙ ! (ap f (r x) ∙ G (h x)) == (ap f (r x) ∙ G (h x)) ∙ ! (ap f (r x ∙ idp) ∙ G (h x))}
-          (CMPH.coher1 {τ = τ} {h = h} {v = v} {u = u} {x = x} idp idp r (λ x₁ → idp) idp idp (r x) ∙
-            CMPH.coher2 {τ = τ} {h = h} {v = v} {u = u} {x = x} idp idp r (λ x₁ → idp) idp idp (r x) ))) k fₚ
+      →
+      ! (ap (λ q → ! (ap (f ∘ u) (ap v p)) ∙ q ∙ ap k S ∙ ! (ap f (r y) ∙ fₚ (h y)))
+          (O₄ {f = f ∘ u} {h = v} {u = k} (λ z → ap f (r z) ∙ fₚ (h z)) p T)) ∙
+      ! (ap (λ q → ! (ap (f ∘ u) (ap v p)) ∙ (ap f (r x) ∙ fₚ (h x)) ∙ ap k S ∙ q)
+          (ap ! (ap (λ q → q ∙ fₚ (h y)) (ap (ap f) (E₃-v2 {f = τ} {v = v} {u = u} r p T)))))
+        ==
+      cmp-helper {f = f} p S r fₚ
+    𝕏 {x = x} idp idp r {k = k} fₚ =
+      IndFunHom
+        {P = λ g F →
+          ! (ap (λ q → q ∙ ! (ap f (r x) ∙ F (h x))) (! (∙-unit-r (ap f (r x) ∙ F (h x))))) ∙
+          ! (ap (λ q → (ap f (r x) ∙ F (h x)) ∙ q) (ap ! (ap (λ q → q ∙ F (h x))
+            (ap (ap f) (∙-unit-r (r x))))))
+            ==
+          cmp-helper {v = v} {u = u} {f = f} idp idp r {k = g} F} (ap-pth-unitr {τ = τ} {h = h} {v = v} {u = u} {f = f} x r ∙
+          ! (IndFunHom-β
+              {P = λ _ G → ((ap f (r x) ∙ G (h x)) ∙ idp) ∙ ! (ap f (r x) ∙ G (h x)) == (ap f (r x) ∙ G (h x)) ∙ ! (ap f (r x ∙ idp) ∙ G (h x))}
+              (CMPH.coher1 {τ = τ} {h = h} {v = v} {u = u} {x = x} idp idp r (λ x₁ → idp) idp idp (r x) ∙
+                CMPH.coher2 {τ = τ} {h = h} {v = v} {u = u} {x = x} idp idp r (λ x₁ → idp) idp idp (r x) )))
+              k fₚ

--- a/Colimit-code/Aux/AuxPaths-v2.agda
+++ b/Colimit-code/Aux/AuxPaths-v2.agda
@@ -46,10 +46,16 @@ module _ {ℓ₁ ℓ₂ ℓ₃} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type �
     → ! (ap f (ap h K)) ∙ s ∙ (ap f (ap h K) ∙ r ∙ idp) ∙ ! r  == transport (λ x → f (h x) == f (h x)) K s
   O₅ s idp idp = ∙-unit-r s
 
+module _ {ℓ₁ ℓ₂ ℓ₃} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type ℓ₃} {g : B → A} {f : A → C}  where
+
+  Δ-red : {t u : B} (v : t == u) {c : C} (R : f (g t) == c) {d : C} (σ : f (g u) == d) {z : A} (D : g t == z)
+    {W : f z == f (g u)} (τ : W == ! (ap f (! (ap g v) ∙ D)))
+    → W ∙ σ ∙ ! (! R ∙ (ap (f ∘ g) v) ∙ σ) == ! (ap f D) ∙ R
+  Δ-red idp idp idp idp idp = idp
+
 module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type ℓ₃} {D : Type ℓ₄} {h : D → A} {g : A → B} {f : B → C} where
 
   abstract
-
     𝕐 : {c d : D} (Q : c == d) {x : A} (R₁ : h c == x) {z : B} (S : g (h d) == z) {p : h d == x}
       (R₂ : p == ! (ap h Q) ∙ R₁) {w : C} (fₚ : f z == w)
       →
@@ -65,7 +71,6 @@ module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄ ℓ₅} {A : Type ℓ₁} {B : Type ℓ₂
   {τ : A → B} {h : C → A} {v : C → D} {u : D → B} {f : B → E} where
 
   abstract
-
     𝕏 : {x y : C} (p : x == y) {S : h x == h y} (T : ap h p == S) (r : (z : C) →  u (v z) == τ (h z)) {k : A → E} (fₚ : f ∘ τ ∼ k)
       →
       ! (ap (λ q → ! (ap (f ∘ u) (ap v p)) ∙ q ∙ ap k S ∙ ! (ap f (r y) ∙ fₚ (h y)))

--- a/Colimit-code/Aux/AuxPaths.agda
+++ b/Colimit-code/Aux/AuxPaths.agda
@@ -4,15 +4,17 @@ open import lib.Basics
 
 module AuxPaths where
 
-module _ {ℓ₁ ℓ₂} {A : Type ℓ₁} {B : Type ℓ₂} {f : A → B} {x : A} {z : B} where
+module _ {ℓ₁ ℓ₂ ℓ₃} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type ℓ₃} {f : A → B} {x : A} {z : B} where
 
-  E₁ : ∀ {ℓ₃} {C : Type ℓ₃} {g : C → A} {c d : C} {R : g c == x} (Q : c == d) (S : f (g d) == z)
+  E₁ : {g : C → A} {c d : C} {R : g c == x} (Q : c == d) (S : f (g d) == z)
     → ! (ap f R) ∙ ap (f ∘ g) Q ∙ S == ! (ap f (! (ap g Q) ∙ R)) ∙ S ∙ idp
   E₁ idp idp = idp
 
-module _ {ℓ₁ ℓ₂ k l} {A : Type ℓ₁} {B : Type ℓ₂} {f : A → B} {C : Type k} {D : Type l} {h : C → A} {v : C → D} {u : D → B} where
+module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄} {A : Type ℓ₁} {B : Type ℓ₂} {f : A → B} {C : Type ℓ₃} {D : Type ℓ₄}
+  {h : C → A} {v : C → D} {u : D → B} where
 
-  E₃ : (q : (z : C) →  u (v z) == f (h z)) {x y : C} (p : x == y) {S : v x == v y} (T : ap v p == S) (L : (z : C) → f (h z) == f (h z)) 
+  E₃ : (q : (z : C) →  u (v z) == f (h z)) {x y : C} (p : x == y) {S : v x == v y}
+    (T : ap v p == S) (L : (z : C) → f (h z) == f (h z)) 
     → ! (ap u S) ∙ q x ∙ L x ∙ ap f (ap h p) == q y ∙ L y
   E₃ q {x = x} idp idp L = ap (λ p → q x ∙ p) (∙-unit-r (L x)) 
 
@@ -24,19 +26,25 @@ module _ {ℓ₁ ℓ₂ ℓ₃} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type �
 
 module _ {i j} {A : Type i} {B : Type j} {f g h : A →  B} {F : (x : A) → f x == g x} {G : (x : A) → g x == h x} where
 
-  apd-∙-r : {x y : A} (κ : x == y) → transport (λ z → f z == h z) κ (F x ∙ G x) == transport (λ z → f z == g z) κ (F x) ∙ G y
+  apd-∙-r : {x y : A} (κ : x == y)
+    → transport (λ z → f z == h z) κ (F x ∙ G x) == transport (λ z → f z == g z) κ (F x) ∙ G y
   apd-∙-r idp = idp
 
-  apd-∙-r-coher : {x y : A} (κ : x == y) → apd-tr (λ z → F z ∙ G z) κ ◃∎ =ₛ apd-∙-r κ ◃∙ ap (λ p → p ∙ G y) (apd-tr F κ) ◃∎
+  apd-∙-r-coher : {x y : A} (κ : x == y)
+    → apd-tr (λ z → F z ∙ G z) κ ◃∎ =ₛ apd-∙-r κ ◃∙ ap (λ p → p ∙ G y) (apd-tr F κ) ◃∎
   apd-∙-r-coher idp = =ₛ-in idp
 
-module _ {i j k} {A : Type i} {B : Type j} {C : Type k} {g h : A → B} {f : A → C} (ψ : B →  C) {F : (x : A) → f x == ψ (g x)} {G : (x : A) → h x == g x} where
+module _ {i j k} {A : Type i} {B : Type j} {C : Type k} {g h : A → B} {f : A → C} (ψ : B →  C)
+  {F : (x : A) → f x == ψ (g x)} {G : (x : A) → h x == g x} where
 
-  apd-ap-∙-l : {x y : A} (κ : x == y) → transport (λ z →  f z == ψ (h z)) κ (F x ∙ ap ψ (! (G x))) == F y ∙ ap ψ (! (transport (λ z → h z == g z) κ (G x)))
+  apd-ap-∙-l : {x y : A} (κ : x == y)
+    → transport (λ z →  f z == ψ (h z)) κ (F x ∙ ap ψ (! (G x))) == F y ∙ ap ψ (! (transport (λ z → h z == g z) κ (G x)))
   apd-ap-∙-l idp = idp
 
-  apd-ap-∙-l-coher : {x y : A} (κ : x == y) → apd-tr (λ z → F z ∙ ap ψ (! (G z))) κ ◃∎  =ₛ apd-ap-∙-l κ ◃∙ ap (λ p → F y ∙ ap ψ (! p)) (apd-tr G κ) ◃∎
+  apd-ap-∙-l-coher : {x y : A} (κ : x == y)
+    → apd-tr (λ z → F z ∙ ap ψ (! (G z))) κ ◃∎ =ₛ apd-ap-∙-l κ ◃∙ ap (λ p → F y ∙ ap ψ (! p)) (apd-tr G κ) ◃∎
   apd-ap-∙-l-coher idp = =ₛ-in idp
 
-  apd-ap-∙-l-! : {x y : A} (κ : x == y) → transport (λ z →  ψ (h z) == f z) κ (! (F x ∙ ap ψ (! (G x)))) == ! (F y ∙ ap ψ (! (transport (λ z → h z == g z) κ (G x))))
+  apd-ap-∙-l-! : {x y : A} (κ : x == y)
+    → transport (λ z →  ψ (h z) == f z) κ (! (F x ∙ ap ψ (! (G x)))) == ! (F y ∙ ap ψ (! (transport (λ z → h z == g z) κ (G x))))
   apd-ap-∙-l-! idp = idp

--- a/Colimit-code/Aux/Cocone-switch.agda
+++ b/Colimit-code/Aux/Cocone-switch.agda
@@ -13,7 +13,7 @@ module Cocone-switch where
 module _ {ℓ} {A : Type ℓ} {x y z : A} where
 
   rew-LR=rew-RL : {p₁ : x == y} {q₁ : y == z} {p₂ : x == y} (T : p₁ == p₂) {q₂ : y == z} (R : q₁ == q₂)
-    →  ap (λ z → p₁ ∙ z) R ◃∙ ap (λ z → z ∙ q₂) T ◃∎ =ₛ ap (λ z → z ∙ q₁) T ◃∙ ap (λ z → p₂ ∙ z) R ◃∎
+    → ap (λ z → p₁ ∙ z) R ◃∙ ap (λ z → z ∙ q₂) T ◃∎ =ₛ ap (λ z → z ∙ q₁) T ◃∙ ap (λ z → p₂ ∙ z) R ◃∎
   rew-LR=rew-RL {p₁ = idp} {q₁ = idp} idp idp = =ₛ-in idp
 
 module CC-switch {ℓv ℓe ℓ} {Γ : Graph ℓv ℓe} {A : Type ℓ} {ℓd} (F : CosDiag ℓd ℓ A Γ) {ℓc} (T : Coslice ℓc ℓ A) where
@@ -35,14 +35,14 @@ module CC-switch {ℓv ℓe ℓ} {Γ : Graph ℓv ℓe} {A : Type ℓ} {ℓd} (F
       ap (λ p → p ∙ ! (snd (r i) a)) (ap (λ p → ! (ap (fun T) p)) (id-βr g a)) ◃∎
 
     abstract
-
       κ=κ-switch : κ-switch =ₛ η (comp K) (comTri K) i j g a
-      κ=κ-switch = κ-switch
-                     =ₛ⟨ 2 & 2 & rew-LR=rew-RL (ap (λ p → ! (ap (fun T) p)) (id-βr g a)) (ap ! (snd (comTri K g) a)) ⟩
-                   H₁ (cglue g a) (! (snd (r j) a)) (ψ-βr g a) ◃∙
-                   H₂ (snd (F <#> g) a) (snd (r j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a)) ◃∙
-                   ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap ((recc r (comTri K)) ∘ cin j) (snd (F <#> g) a) ∙ (snd (r j) a)))
-                     (ap (λ p → ! (ap (fun T) p)) (id-βr g a)) ◃∙
-                   ap (λ z → z) (ap ! (snd (comTri K g) a)) ◃∎
-                     =ₛ₁⟨ 3 & 1 & ap-idf (ap ! (snd (comTri K g) a)) ⟩
-                   η (comp K) (comTri K) i j g a ∎ₛ
+      κ=κ-switch =
+        κ-switch
+          =ₛ⟨ 2 & 2 & rew-LR=rew-RL (ap (λ p → ! (ap (fun T) p)) (id-βr g a)) (ap ! (snd (comTri K g) a)) ⟩
+        H₁ (cglue g a) (! (snd (r j) a)) (ψ-βr g a) ◃∙
+        H₂ (snd (F <#> g) a) (snd (r j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a)) ◃∙
+        ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap ((recc r (comTri K)) ∘ cin j) (snd (F <#> g) a) ∙ (snd (r j) a)))
+          (ap (λ p → ! (ap (fun T) p)) (id-βr g a)) ◃∙
+        ap (λ z → z) (ap ! (snd (comTri K g) a)) ◃∎
+          =ₛ₁⟨ 3 & 1 & ap-idf (ap ! (snd (comTri K g) a)) ⟩
+        η (comp K) (comTri K) i j g a ∎ₛ

--- a/Colimit-code/Aux/Cocone-v2.agda
+++ b/Colimit-code/Aux/Cocone-v2.agda
@@ -24,13 +24,14 @@ module CC-v2-Constr {ℓv ℓe ℓ ℓd} {Γ : Graph ℓv ℓe} {A : Type ℓ} (
   open Maps F public
 
   ϵ-v2 : ! (ap right (cglue g (fun (F # i) a))) ∙ ap (right {d = SpCos} ∘ cin j) (snd (F <#> g) a) ∙ ! (glue (cin j a)) =-= ! (glue (cin i a))
-  ϵ-v2 = ! (ap right  (cglue g (fun (F # i) a))) ∙ (ap (right ∘ cin j) (snd (F <#> g) a)) ∙ (! (glue (cin j a)))
-           =⟪ E₁-v2 (snd (F <#> g) a) ⟫
-         ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a))
-           =⟪ E₂-v2 (ψ-βr g a) (! (glue (cin j a))) ⟫
-         ! (ap right (ap ψ (cglue g a))) ∙ ! (glue (cin j a)) ∙ idp
-           =⟪ E₃-v2 {f = left} (λ x → ! (glue x)) (cglue g a) (id-βr g a) ⟫
-         ! (glue (cin i a)) ∎∎
+  ϵ-v2 =
+    ! (ap right  (cglue g (fun (F # i) a))) ∙ (ap (right ∘ cin j) (snd (F <#> g) a)) ∙ (! (glue (cin j a)))
+      =⟪ E₁-v2 (snd (F <#> g) a) ⟫
+    ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a))
+      =⟪ E₂-v2 (ψ-βr g a) (! (glue (cin j a))) ⟫
+    ! (ap right (ap ψ (cglue g a))) ∙ ! (glue (cin j a)) ∙ idp
+      =⟪ E₃-v2 {f = left} (λ x → ! (glue x)) (cglue g a) (id-βr g a) ⟫
+    ! (glue (cin i a)) ∎∎
 
   E-eq-helper : {z : P} (q : right (ψ (cin j a)) == z)
     →  E₁ {f = right} {g = cin j} idp q == E₂-v2 {f = right} {p = ap ψ (cglue g a)} idp q
@@ -38,26 +39,30 @@ module CC-v2-Constr {ℓv ℓe ℓ ℓd} {Γ : Graph ℓv ℓe} {A : Type ℓ} (
 
   E-eq : (q : (z : Colim (ConsDiag Γ A)) →  right {d = SpCos} (ψ z) == left ([id] z)) {x : ty (F # j)} (σ : x == fun (F # j) a)
     (T₁ : ap [id] (cglue g a) == idp) (R : cin j x == ψ (cin i a)) (T₂ : ap ψ (cglue g a) == ! (ap (cin j) σ) ∙ R)
-    → E₁ σ (q (cin j a)) ◃∙ ! (ap (λ p → ! (ap right (! (ap (cin j) σ) ∙ R)) ∙ q (cin j a) ∙ p) (ap (ap left) T₁)) ◃∙
-      E₃ q (cglue g a) T₂ (λ z → idp) ◃∙
-      ∙-unit-r (q (cin i a)) ◃∎
+    →
+    E₁ σ (q (cin j a)) ◃∙ ! (ap (λ p → ! (ap right (! (ap (cin j) σ) ∙ R)) ∙ q (cin j a) ∙ p) (ap (ap left) T₁)) ◃∙
+    E₃ q (cglue g a) T₂ (λ z → idp) ◃∙
+    ∙-unit-r (q (cin i a)) ◃∎
       =ₛ
     E₁-v2 σ ◃∙ E₂-v2 T₂ (q (cin j a)) ◃∙ E₃-v2 {f = left} q (cglue g a) T₁ ◃∎
   E-eq q idp T₁ R T₂ = =ₛ-in (lemma R T₂)
     where
       lemma : (r : ψ (cin j a) == ψ (cin i a)) (τ : ap ψ (cglue g a) == r)
-        → E₁ {f = right} {g = cin j} idp (q (cin j a)) ∙ ! (ap (λ p → ! (ap right r) ∙ q (cin j a) ∙ p) (ap (ap left) T₁)) ∙
-          E₃ q (cglue g a) τ (λ z → idp) ∙ ∙-unit-r (q (cin i a))
-        == E₂-v2 τ (q (cin j a)) ∙ E₃-v2 {f = left} {u = right} q (cglue g a) T₁
-      lemma r idp = ap (λ p → p ∙ ! (ap (λ p → ! (ap right (ap ψ (cglue g a))) ∙ q (cin j a) ∙ p) (ap (ap left) T₁)) ∙
-        E₃ q (cglue g a) idp (λ z → idp) ∙ ∙-unit-r (q (cin i a))) (E-eq-helper (q (cin j a))) ∙
+        →
+        E₁ {f = right} {g = cin j} idp (q (cin j a)) ∙ ! (ap (λ p → ! (ap right r) ∙ q (cin j a) ∙ p) (ap (ap left) T₁)) ∙
+        E₃ q (cglue g a) τ (λ z → idp) ∙ ∙-unit-r (q (cin i a))
+          ==
+        E₂-v2 τ (q (cin j a)) ∙ E₃-v2 {f = left} {u = right} q (cglue g a) T₁
+      lemma r idp =
+        ap (λ p → p ∙ ! (ap (λ p → ! (ap right (ap ψ (cglue g a))) ∙ q (cin j a) ∙ p) (ap (ap left) T₁)) ∙
+             E₃ q (cglue g a) idp (λ z → idp) ∙ ∙-unit-r (q (cin i a)))
+           (E-eq-helper (q (cin j a))) ∙
         ap (λ p → E₂-v2 {f = right} {p = ap ψ (cglue g a)} idp (q (cin j a)) ∙ p) (lemma2 (cglue g a) T₁)
-          where
-            lemma2 : {y : Colim (ConsDiag Γ A)} (c : (cin j a) == y) {v : a == [id] y} (t : ap [id] c == v)
-              → ! (ap (λ p → ! (ap right (ap ψ c)) ∙ q (cin j a) ∙ p) (ap (ap left) t)) ∙ E₃ q c idp (λ z → idp) ∙ ∙-unit-r (q y) == E₃-v2 q c t
-            lemma2 idp idp = idp
+        where
+          lemma2 : {y : Colim (ConsDiag Γ A)} (c : (cin j a) == y) {v : a == [id] y} (t : ap [id] c == v)
+            → ! (ap (λ p → ! (ap right (ap ψ c)) ∙ q (cin j a) ∙ p) (ap (ap left) t)) ∙ E₃ q c idp (λ z → idp) ∙ ∙-unit-r (q y) == E₃-v2 q c t
+          lemma2 idp idp = idp
 
   abstract
-
     ϵ-Eq : ϵ g g a =ₛ ϵ-v2
     ϵ-Eq = E-eq (λ z → (! (glue z))) (snd (F <#> g) a) (id-βr g a) (cglue g (fun (F # i) a)) (ψ-βr g a)

--- a/Colimit-code/Aux/Cocone.agda
+++ b/Colimit-code/Aux/Cocone.agda
@@ -14,14 +14,14 @@ module Cocone where
 
 module _ {ℓ₁ ℓ₂} {B : Type ℓ₁} {D : Type ℓ₂} {u : D → B} where
 
-  H₁ : ∀ {k l} {C : Type k} {A : Type l} {h : C → A} {f : A → B} {v : C → D} {c d : C} (Q : c == d) (s : f (h c) == u (v c))
-    {q : v c == v d} (R : ap v Q == q) →
-    transport (λ x → f (h x) == u (v x)) Q s == ! (ap f (ap h Q)) ∙ s ∙ ap u q
+  H₁ : ∀ {k l} {C : Type k} {A : Type l} {h : C → A} {f : A → B} {v : C → D}
+    {c d : C} (Q : c == d) (s : f (h c) == u (v c)) {q : v c == v d} (R : ap v Q == q)
+    → transport (λ x → f (h x) == u (v x)) Q s == ! (ap f (ap h Q)) ∙ s ∙ ap u q
   H₁ idp s idp = ! (∙-unit-r s)
 
-  H₂ : ∀ {ℓ₃} {E : Type ℓ₃} {x y : B} {g : E → D} {d e : E} (t : d == e) (q : u (g e) == y) {p : x == y} {z : D} (s : g d == z)
-    {R : u (g d) == u z} (T : ap u s == R) →
-    p ∙ ! q ∙ ap u (! (ap g t) ∙ s) == p ∙ ! (! R ∙ ap (u ∘ g) t ∙ q)
+  H₂ : ∀ {ℓ₃} {E : Type ℓ₃} {x y : B} {g : E → D} {d e : E} (t : d == e) (q : u (g e) == y)
+    {p : x == y} {z : D} (s : g d == z) {R : u (g d) == u z} (T : ap u s == R)
+    → p ∙ ! q ∙ ap u (! (ap g t) ∙ s) == p ∙ ! (! R ∙ ap (u ∘ g) t ∙ q)
   H₂ idp q {p = p} idp idp = ap (λ r → p ∙ r) (∙-unit-r (! q))
 
 module Id {ℓv ℓe ℓ} (Γ : Graph ℓv ℓe) (A : Type ℓ) where
@@ -63,7 +63,7 @@ module Id {ℓv ℓe ℓ} (Γ : Graph ℓv ℓe) (A : Type ℓ) where
           =⟪ E₁ (snd (F <#> g) a) (! (glue (cin j a))) ⟫
         ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ idp
           =⟪ ! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p)
-            (ap (ap left) (id-βr g a))) ⟫
+               (ap (ap left) (id-βr g a))) ⟫
         ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ ap left (ap [id] (cglue g a))
           =⟪ E₃ (λ x → ! (glue x)) (cglue g a) (ψ-βr g a) (λ x → idp) ⟫
         ! (glue (cin i a)) ∙ idp
@@ -75,7 +75,8 @@ module Id {ℓv ℓe ℓ} (Γ : Graph ℓv ℓe) (A : Type ℓ) where
       reccForg : (CosCocone A F T) → Colim (DiagForg A Γ F) → ty T
       reccForg (r & K) = colimR (λ i → fst (r i)) (λ i j g → fst (K g))
 
-      recc-βr : ∀ (C : CosCocone A F T) {i j : Obj Γ} (g : Hom Γ i j) (x : ty (F # i)) → ap (reccForg C) (cglue g x) == fst (comTri C g) x
+      recc-βr : ∀ (C : CosCocone A F T) {i j : Obj Γ} (g : Hom Γ i j) (x : ty (F # i))
+        → ap (reccForg C) (cglue g x) == fst (comTri C g) x
       recc-βr C g x = cglue-βr (comp (ForgCoc C)) (λ i j g → fst (comTri C g)) g x
 
       recCosCoc : (CosCocone A F T) → (< A > (Cos P left) *→ T)
@@ -85,22 +86,23 @@ module Id {ℓv ℓe ℓ} (Γ : Graph ℓv ℓe) (A : Type ℓ) where
           recc = reccForg (r & K)
 
           σ : (x : Colim (ConsDiag Γ A)) → fun T ([id] x) == recc (ψ x)
-          σ = colimE (λ i → (λ a → ! (snd (r i) a)))
-            (λ i → (λ j → (λ g → (λ a →   from-transp-g (λ z → fun T ([id] z) == recc (ψ z)) (cglue g a) (↯ (η i j g a))))))
-              module _ where
-                η : (i j : Obj Γ) (g : Hom Γ i j) (a : A) →
-                  transport (λ z → fun T ([id] z) == recc (ψ z)) (cglue g a) (! (snd (r j) a)) =-= ! (snd (r i) a)
-                η i j g a =
-                  transport (λ z →  fun T ([id] z) == recc (ψ z)) (cglue g a) (! (snd (r j) a))
-                    =⟪ H₁ (cglue g a) (! (snd (r j) a)) (ψ-βr g a) ⟫
-                  ! (ap (fun T) (ap [id] (cglue g a))) ∙ (! (snd (r j) a)) ∙ ap recc (! (ap (cin j) (snd (F <#> g) a)) ∙ (cglue g (fun (F # i) a)))
-                    =⟪ H₂ (snd (F <#> g) a) (snd (r j) a) (cglue g (fun (F # i) a)) (recc-βr (r & K) g (fun (F # i) a)) ⟫
-                  ! (ap (fun T) (ap [id] (cglue g a))) ∙ ! (! (fst (K g) (fun (F # i) a)) ∙ ap (recc ∘ cin j) (snd (F <#> g) a) ∙ (snd (r j) a))
-                    =⟪ ap (λ p → p ∙ ! (! (fst (K g) (fun (F # i) a)) ∙ ap (recc ∘ cin j) (snd (F <#> g) a) ∙ (snd (r j) a)))
-                      (ap (λ p → ! (ap (fun T) p)) (id-βr g a)) ⟫
-                  ! (! (fst (K g) (fun (F # i) a)) ∙ ap (recc ∘ cin j) (snd (F <#> g) a) ∙ (snd (r j) a))
-                    =⟪ ap ! (snd (K g) a) ⟫
-                  ! (snd (r i) a) ∎∎
+          σ =
+            colimE (λ i → (λ a → ! (snd (r i) a)))
+              (λ i j g a → from-transp-g (λ z → fun T ([id] z) == recc (ψ z)) (cglue g a) (↯ (η i j g a)))
+            module _ where
+              η : (i j : Obj Γ) (g : Hom Γ i j) (a : A) →
+                transport (λ z → fun T ([id] z) == recc (ψ z)) (cglue g a) (! (snd (r j) a)) =-= ! (snd (r i) a)
+              η i j g a =
+                transport (λ z →  fun T ([id] z) == recc (ψ z)) (cglue g a) (! (snd (r j) a))
+                  =⟪ H₁ (cglue g a) (! (snd (r j) a)) (ψ-βr g a) ⟫
+                ! (ap (fun T) (ap [id] (cglue g a))) ∙ (! (snd (r j) a)) ∙ ap recc (! (ap (cin j) (snd (F <#> g) a)) ∙ (cglue g (fun (F # i) a)))
+                  =⟪ H₂ (snd (F <#> g) a) (snd (r j) a) (cglue g (fun (F # i) a)) (recc-βr (r & K) g (fun (F # i) a)) ⟫
+                ! (ap (fun T) (ap [id] (cglue g a))) ∙ ! (! (fst (K g) (fun (F # i) a)) ∙ ap (recc ∘ cin j) (snd (F <#> g) a) ∙ (snd (r j) a))
+                  =⟪ ap (λ p → p ∙ ! (! (fst (K g) (fun (F # i) a)) ∙ ap (recc ∘ cin j) (snd (F <#> g) a) ∙ (snd (r j) a)))
+                       (ap (λ p → ! (ap (fun T) p)) (id-βr g a)) ⟫
+                ! (! (fst (K g) (fun (F # i) a)) ∙ ap (recc ∘ cin j) (snd (F <#> g) a) ∙ (snd (r j) a))
+                  =⟪ ap ! (snd (K g) a) ⟫
+                ! (snd (r i) a) ∎∎
       snd (recCosCoc x) a = idp
 
       FPrecc-βr = λ (C : CosCocone A F T) → PushoutRec.glue-β {d = SpCos} (fun T) (recc (comp C) (comTri C)) (σ (comp C) (comTri C))
@@ -110,8 +112,10 @@ module Id {ℓv ℓe ℓ} (Γ : Graph ℓv ℓe) (A : Type ℓ) where
         abstract
 
           σ-β : ∀ {i j} g a → apd-tr (σ (comp C) (comTri C)) (cglue g a) == ↯ (η (comp C) (comTri C) i j g a)
-          σ-β {i} {j} g a = apd-to-tr (λ x → fun T ([id] x) == recc (comp C) (comTri C) (ψ x)) (σ (comp C) (comTri C)) (cglue g a)
-            (↯ (η (comp C) (comTri C) i j g a))
-            (cglue-β (λ i → (λ a → ! (snd (comp C i) a)))
-            (λ i → (λ j → ( λ g → (λ a →  from-transp-g (λ z → fun T ([id] z) == recc (comp C) (comTri C) (ψ z))
-            (cglue g a) (↯ (η (comp C) (comTri C) i j g a)))))) g a)
+          σ-β {i} {j} g a =
+            apd-to-tr
+              (λ x → fun T ([id] x) == recc (comp C) (comTri C) (ψ x)) (σ (comp C) (comTri C)) (cglue g a)
+              (↯ (η (comp C) (comTri C) i j g a))
+              (cglue-β (λ i → (λ a → ! (snd (comp C i) a)))
+                (λ i → (λ j → ( λ g → (λ a →  from-transp-g (λ z → fun T ([id] z) == recc (comp C) (comTri C) (ψ z))
+                  (cglue g a) (↯ (η (comp C) (comTri C) i j g a)))))) g a)

--- a/Colimit-code/Aux/Colim.agda
+++ b/Colimit-code/Aux/Colim.agda
@@ -16,9 +16,9 @@ module _ {ℓv ℓe}  where
 
     postulate  -- HIT
       cin : (i : Obj Γ) → D # i → Colim D
-      cglue : {i j : Obj Γ} → (g : Hom Γ i j) → (x : D # i) → cin j ((D <#> g) x) == cin i x
+      cglue : {i j : Obj Γ} (g : Hom Γ i j) (x : D # i) → cin j ((D <#> g) x) == cin i x
 
-  module ColimElim {ℓd l} {Γ : Graph ℓv ℓe} {D : Diag ℓd Γ} {P : Colim {ℓd = ℓd} {Γ = Γ} D → Type l}
+  module ColimElim {ℓd ℓ} {Γ : Graph ℓv ℓe} {D : Diag ℓd Γ} {P : Colim {ℓd = ℓd} {Γ = Γ} D → Type ℓ}
     (cin* : (i : Obj Γ) (x : D # i) → P (cin i x))
     (cglue* : (i j : Obj Γ) (g : Hom Γ i j) (x : D # i)
       → cin* j ((D <#> g) x) == cin* i x [ P ↓ cglue {i = i} {j = j} g x ])
@@ -36,7 +36,7 @@ module _ {ℓv ℓe}  where
 
   module _ {Γ : Graph ℓv ℓe} where
 
-    ColimMapEq : ∀ {ℓd l} {D : Diag ℓd Γ} {V : Type l} (h₁ h₂ : Colim D → V)
+    ColimMapEq : ∀ {ℓd ℓ} {D : Diag ℓd Γ} {V : Type ℓ} (h₁ h₂ : Colim D → V)
       (H : (i : Obj Γ) → h₁ ∘ cin i ∼ h₂ ∘ cin i)
       → ((i j : Obj Γ) (g : Hom Γ i j) (x : D # i)
         → ! (ap h₁ (cglue g x)) ∙ H j ((D <#> g) x) ∙ ap h₂ (cglue g x)  == H i x )
@@ -45,7 +45,7 @@ module _ {ℓv ℓe}  where
       (λ i → λ j → λ g → λ x → from-transp (λ x → h₁ x == h₂ x) (cglue g x)
         (transp-pth (cglue g x) (H j ((D <#> g) x)) ∙ (S i j g x))  ) 
 
-    module ColimRec {ℓd l} {D : Diag ℓd Γ} {V : Type l}
+    module ColimRec {ℓd ℓ} {D : Diag ℓd Γ} {V : Type ℓ}
       (cin* : (i : Obj Γ) → (D # i) → V)
       (cglue* :  (i j : Obj Γ) (g : Hom Γ i j) (x : D # i)
         → cin* j ((D <#> g) x) == cin* i x)
@@ -71,8 +71,9 @@ module _ {ℓv ℓe}  where
     ColMap : Colim F → Colim G
     ColMap = M.colimR
 
-    MapComp : {i j : Obj Γ} (g : Hom Γ i j) (x : F # i) → ap ColMap (cglue {i = i} {j = j} g x) ==
-      ! (ap (cin j) (comSq M g x)) ∙ (cglue {i = i} {j = j} g (nat M i x) )
+    MapComp : {i j : Obj Γ} (g : Hom Γ i j) (x : F # i)
+      →
+      ap ColMap (cglue {i = i} {j = j} g x) == ! (ap (cin j) (comSq M g x)) ∙ (cglue {i = i} {j = j} g (nat M i x))
     MapComp g x = M.cglue-βr g x
 
   open ColimitMap public

--- a/Colimit-code/Aux/Coslice.agda
+++ b/Colimit-code/Aux/Coslice.agda
@@ -15,7 +15,7 @@ record Coslice (i j : ULevel) (A : Type j) : Type (lmax (lsucc i) j) where
     fun : A → ty
 open Coslice public
 
-Cos : ∀ {i j} {A : Type j} (X : Type i) →  (A → X) →  Coslice i j A
+Cos : ∀ {i j} {A : Type j} (X : Type i) → (A → X) → Coslice i j A
 Cos = *[_,_]
 
 infixr 30 <_>_*→_
@@ -23,25 +23,25 @@ infixr 30 <_>_*→_
 < A > *[ X , f ] *→ *[ Y , g ] = Σ (X → Y) (λ h → ((a : A) → h (f a) == g a))
 
 infixr 40 <_>_∘_
-<_>_∘_ : ∀ {j i k l} (A : Type j) {X : Coslice i j A} {Y : Coslice k j A} {Z : Coslice l j A} →
-  < A > Y *→ Z → < A > X *→ Y → < A > X *→ Z
+<_>_∘_ : ∀ {j i k l} (A : Type j) {X : Coslice i j A} {Y : Coslice k j A} {Z : Coslice l j A}
+  → < A > Y *→ Z → < A > X *→ Y → < A > X *→ Z
 < A > (g , q) ∘ (f , p) = (g ∘ f , λ a → ap g (p a) ∙ q a) 
 
 infixr 30 [_,_]_∼_
 [_,_]_∼_ :  ∀ {i j k} (A : Type j) (X : Coslice i j A) {Y : Coslice k j A} →
   < A > X *→ Y → < A > X *→ Y → Type (lmax (lmax i k) j)    
-[ A , *[ X , f ] ] ( h₁ , p₁ )∼( h₂ , p₂ ) = Σ ((x : X) → h₁ x == h₂ x)
-  (λ H → ((a : A) →  (! (H (f a)) ∙ (p₁ a) == p₂ a)))
+[ A , *[ X , f ] ] ( h₁ , p₁ )∼( h₂ , p₂ ) =
+  Σ ((x : X) → h₁ x == h₂ x) (λ H → ((a : A) →  (! (H (f a)) ∙ (p₁ a) == p₂ a)))
 
-module MapsCos {j : ULevel} (A : Type j) where
+module MapsCos {j} (A : Type j) where
 
   infixr 30 _*→_
   _*→_ : ∀ {i k} → Coslice i j A → Coslice k j A → Type (lmax (lmax i k) j)
   *[ X , f ] *→ *[ Y , g ] = < A > *[ X , f ] *→ *[ Y , g ] 
 
   infixr 40 _∘*_
-  _∘*_ : ∀ {i k l} {X : Coslice i j A} {Y : Coslice k j A} {Z : Coslice l j A} →
-    < A > Y *→ Z → < A > X *→ Y → < A > X *→ Z
+  _∘*_ : ∀ {i k l} {X : Coslice i j A} {Y : Coslice k j A} {Z : Coslice l j A}
+    → < A > Y *→ Z → < A > X *→ Y → < A > X *→ Z
   g ∘* f = < A > g ∘ f 
 
   infixr 30 <_>_∼_
@@ -59,7 +59,8 @@ module MapsCos {j : ULevel} (A : Type j) where
 
   -- post-composition
   post-∘*-∼ : ∀ {i k l} {X : Coslice i j A} {Y : Coslice k j A} {Z : Coslice l j A}
-    {h₁ h₂ : X *→ Y} (f : Y *→ Z) → < X > h₁ ∼ h₂ → < X > f ∘* h₁ ∼ f ∘* h₂ 
+    {h₁ h₂ : X *→ Y} (f : Y *→ Z)
+    → < X > h₁ ∼ h₂ → < X > f ∘* h₁ ∼ f ∘* h₂ 
   fst (post-∘*-∼ f H) x = ap (fst f) (fst H x)
   snd (post-∘*-∼ {X = X} {h₁ = h₁} f H) a = 
     ap (λ p → p ∙ ap (fst f) (snd h₁ a) ∙ snd f a) (!-ap (fst f) (fst H (fun X a))) ∙ 
@@ -73,15 +74,14 @@ module MapsCos {j : ULevel} (A : Type j) where
   fst (pre-∘*-∼ f H) x = fst H (fst f x)
   snd (pre-∘*-∼ {X = X} {Z = Z} {h₁ = h₁} {h₂} f H) a =
     (! (∙-assoc (! (fst H (fst f (fun Z a)))) (ap (fst h₁) (snd f a)) (snd h₁ a)) ∙
-      ap (λ p → p ∙ snd h₁ a) (hmtpy-nat-!-sq (fst H) (snd f a)) ∙
-      ∙-assoc (ap (fst h₂) (snd f a)) (! (fst H (fun X a))) (snd h₁ a)) ∙
+    ap (λ p → p ∙ snd h₁ a) (hmtpy-nat-!-sq (fst H) (snd f a)) ∙
+    ∙-assoc (ap (fst h₂) (snd f a)) (! (fst H (fun X a))) (snd h₁ a)) ∙
     ap (λ p → ap (fst h₂) (snd f a) ∙ p) (snd H a)
 
   -- concatenation
   infixr 40 _∼∘-cos_
-  _∼∘-cos_ : ∀ {i k} {X : Coslice i j A} {Y : Coslice k j A} →
-    {h₁ h₂ h₃ : X *→ Y} →
-    < X > h₁ ∼ h₂ → < X > h₂ ∼ h₃ → < X > h₁ ∼ h₃
+  _∼∘-cos_ : ∀ {i k} {X : Coslice i j A} {Y : Coslice k j A} {h₁ h₂ h₃ : X *→ Y}
+    → < X > h₁ ∼ h₂ → < X > h₂ ∼ h₃ → < X > h₁ ∼ h₃
   _∼∘-cos_ {X = X} {h₁ = h₁} (H₁ , H₂) (K₁ , K₂) =
     (λ x → H₁ x ∙ K₁ x) ,
     (λ a →
@@ -90,8 +90,7 @@ module MapsCos {j : ULevel} (A : Type j) where
       ap (λ p → ! (K₁ (fun X a)) ∙ p) (H₂ a) ∙ K₂ a)
 
   -- identity
-  cos∼id : ∀ {i k} {X : Coslice i j A} {Y : Coslice k j A} (h : X *→ Y)
-    → < X > h ∼ h
+  cos∼id : ∀ {i k} {X : Coslice i j A} {Y : Coslice k j A} (h : X *→ Y) → < X > h ∼ h
   fst (cos∼id h) = λ x → idp
   snd (cos∼id h) = λ a → idp
 

--- a/Colimit-code/Aux/Diagram.agda
+++ b/Colimit-code/Aux/Diagram.agda
@@ -26,8 +26,7 @@ Hom (CosGr i j A) X Y = < A > X *→ Y
 
 -- Graph homomorphisms
 
-record GraphHom (G  : Graph ℓv  ℓe) (G' : Graph ℓv' ℓe')
-                : Type (lmax (lmax ℓv ℓe) (lmax ℓv' ℓe')) where
+record GraphHom (G  : Graph ℓv  ℓe) (G' : Graph ℓv' ℓe') : Type (lmax (lmax ℓv ℓe) (lmax ℓv' ℓe')) where
   field
     _#_ : Obj G → Obj G'
     _<#>_ : ∀ {x y : Obj G} → Hom G x y → Hom G' (_#_ x) (_#_ y)
@@ -57,7 +56,7 @@ DiagForg : ∀ {i j} (A : Type j) (G : Graph ℓv ℓe) → CosDiag i j A G → 
 -- Maps of diagrams
 
 record DiagMor {G : Graph ℓv ℓe} (F : Diag ℓd G) (F' : Diag ℓd' G)
-         : Type (lmax (lmax ℓv ℓe) (lmax ℓd ℓd')) where
+  : Type (lmax (lmax ℓv ℓe) (lmax ℓd ℓd')) where
   constructor Δ
   field
     nat : ∀ (x : Obj G) → F # x → F' # x
@@ -65,20 +64,22 @@ record DiagMor {G : Graph ℓv ℓe} (F : Diag ℓd G) (F' : Diag ℓd' G)
 
 open DiagMor public
 
-record CosDiagMor {G : Graph ℓv ℓe} {ℓ₁ ℓ₂ ℓ₃} (A : Type ℓ₁) (F : CosDiag ℓ₂ ℓ₁ A G) (F' : CosDiag ℓ₃ ℓ₁ A G) 
-         : Type (lmax (lmax (lmax ℓv ℓe) (lmax (lsucc ℓ₂) ℓ₁)) (lmax (lmax ℓv ℓe) (lmax ℓ₃ ℓ₁))) where
+record CosDiagMor {G : Graph ℓv ℓe} {ℓ₁ ℓ₂ ℓ₃} (A : Type ℓ₁) (F : CosDiag ℓ₂ ℓ₁ A G) (F' : CosDiag ℓ₃ ℓ₁ A G)
+  : Type (lmax (lmax (lmax ℓv ℓe) (lmax (lsucc ℓ₂) ℓ₁)) (lmax (lmax ℓv ℓe) (lmax ℓ₃ ℓ₁))) where
   field
     nat : ∀ (i : Obj G) → < A > F # i *→ F' # i
-    comSq : ∀ {i j : Obj G} (g : Hom G i j) (z : ty (F # i)) →  fst (F' <#> g) (fst (nat i) z) == fst (nat j) (fst (F <#> g) z)
-    comSq-coher : {i j : Obj G} (g : Hom G i j) (a : A) → comSq g (fun (F # i) a) ==
-      ap (fst (F' <#> g)) (snd (nat i) a) ∙ snd (F' <#> g) a ∙ ! (snd (nat j) a) ∙ ! (ap (fst (nat j)) (snd (F <#> g) a))
+    comSq : ∀ {i j : Obj G} (g : Hom G i j) (z : ty (F # i)) → fst (F' <#> g) (fst (nat i) z) == fst (nat j) (fst (F <#> g) z)
+    comSq-coher : {i j : Obj G} (g : Hom G i j) (a : A)
+      → comSq g (fun (F # i) a)
+          ==
+        ap (fst (F' <#> g)) (snd (nat i) a) ∙ snd (F' <#> g) a ∙ ! (snd (nat j) a) ∙ ! (ap (fst (nat j)) (snd (F <#> g) a))
 
 open CosDiagMor public
 
 -- Cocones under diagrams
 
 record Cocone {i k} {G : Graph ℓv ℓe} (F : Diag i G) (C : Type k)
-         : Type (lmax k (lmax (lmax ℓv ℓe) i)) where
+  : Type (lmax k (lmax (lmax ℓv ℓe) i)) where
   constructor _&_
   field
     comp : (x : Obj G) → F # x → C
@@ -87,7 +88,7 @@ record Cocone {i k} {G : Graph ℓv ℓe} (F : Diag i G) (C : Type k)
 open Cocone public
 
 record CosCocone {i j k} (A : Type j) {G : Graph ℓv ℓe} (F : CosDiag i j A G) (C : Coslice k j A)
-         : Type (lmax k (lmax (lmax ℓv ℓe) (lmax i j))) where
+  : Type (lmax k (lmax (lmax ℓv ℓe) (lmax i j))) where
   constructor _&_
   field
     comp : (x : Obj G) → < A > (F # x) *→ C
@@ -105,6 +106,8 @@ module _ {ℓi ℓj k} {A : Type ℓj} {Γ : Graph ℓv ℓe} {F : CosDiag ℓi 
 
   PostComp : ∀ {k'} {D : Coslice k' ℓj A} → CosCocone A F C → (< A > C *→ D) →  CosCocone A F D
   comp (PostComp K (f , fₚ)) i = f ∘ (fst (comp K i)) , λ a → ap f (snd (comp K i) a) ∙ fₚ a 
-  comTri (PostComp K (f , fₚ)) {y = j} {x = i} g = (λ x → ap f (fst (comTri K g) x)) ,
-    λ a → ap-cp-revR f (fst (comp K j)) (snd (F <#> g) a) (fst (comTri K g) (fun (F # i) a)) ∙
+  comTri (PostComp K (f , fₚ)) {y = j} {x = i} g =
+    (λ x → ap f (fst (comTri K g) x)) ,
+    λ a →
+      ap-cp-revR f (fst (comp K j)) (snd (F <#> g) a) (fst (comTri K g) (fun (F # i) a)) ∙
       ap (λ p → p ∙ fₚ a) (ap (ap f) (snd (comTri K g) a))

--- a/Colimit-code/Aux/FTID-Cos.agda
+++ b/Colimit-code/Aux/FTID-Cos.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting  #-}
+{-# OPTIONS --without-K --rewriting #-}
 
 -- Coordinate description of A-cocone identity
 
@@ -14,7 +14,8 @@ module FTID-Cos where
 
 module _ {ℓ₁ ℓ₂} {A : Type ℓ₁} {B : Type ℓ₂} {f g : A → B} where
 
-  long-path-red : {x y : A} (p : x == y) {z : B} (q₁ : g y == z) (q₂ : f y  == z) {w : B} (P : f x == w) {v : B} (C : w == v)
+  long-path-red : {x y : A} (p : x == y) {z : B} (q₁ : g y == z) (q₂ : f y  == z)
+    {w : B} (P : f x == w) {v : B} (C : w == v)
     → ! ((ap g p ∙ (q₁ ∙ ! q₂) ∙ ! (ap f p)) ∙ P ∙ C) ∙ ap g p ∙ q₁ == ! C ∙ ! P ∙ ap f p ∙ q₂
   long-path-red idp q₁ q₂ P idp = !-∙-!-rid-∙-rid P q₁ q₂ 
 
@@ -27,17 +28,20 @@ module _ {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type ℓ} (F : Co
     Ξ : (i j : Obj Γ) (g : Hom Γ i j) (a : A) → ! (! (W j (fst (F <#> g) (fun (F # i) a))) ∙ fst (comTri K₁ g) (fun (F # i) a) ∙ W i (fun (F # i) a)) ∙
       ap (fst (comp K₂ j)) (snd (F <#> g) a) ∙ snd (comp K₂ j) a =-= snd (comp K₂ i) a
     Ξ i j g a =
-      ! (! (W j (fst (F <#> g) (fun (F # i) a))) ∙ fst (comTri K₁ g) (fun (F # i) a) ∙ W i (fun (F # i) a)) ∙ ap (fst (comp K₂ j))
-        (snd (F <#> g) a) ∙ snd (comp K₂ j) a
-        =⟪ ap (λ p → ! (p ∙  fst (comTri K₁ g) (fun (F # i) a) ∙ W i (fun (F # i) a)) ∙ ap (fst (comp K₂ j)) (snd (F <#> g) a) ∙ snd (comp K₂ j) a)
-          (hmtpy-nat-rev (W j) (snd (F <#> g) a) (snd (comp K₁ j) a)) ⟫
-      ! ((ap (fst (comp K₂ j)) (snd (F <#> g) a) ∙ ((! (W j (fun (F # j) a)) ∙ snd (comp K₁ j) a) ∙ ! (snd (comp K₁ j) a)) ∙
-        ! (ap (fst (comp K₁ j)) (snd (F <#> g) a))) ∙ fst (comTri K₁ g) (fun (F # i) a) ∙ W i (fun (F # i) a)) ∙
-          ap (fst (comp K₂ j)) (snd (F <#> g) a) ∙ snd (comp K₂ j) a
+      ! (! (W j (fst (F <#> g) (fun (F # i) a))) ∙ fst (comTri K₁ g) (fun (F # i) a) ∙ W i (fun (F # i) a)) ∙
+      ap (fst (comp K₂ j)) (snd (F <#> g) a) ∙
+      snd (comp K₂ j) a
+        =⟪ ap (λ p → ! (p ∙ fst (comTri K₁ g) (fun (F # i) a) ∙ W i (fun (F # i) a)) ∙ ap (fst (comp K₂ j)) (snd (F <#> g) a) ∙ snd (comp K₂ j) a)
+             (hmtpy-nat-rev (W j) (snd (F <#> g) a) (snd (comp K₁ j) a)) ⟫
+      ! ((ap (fst (comp K₂ j)) (snd (F <#> g) a) ∙ ((! (W j (fun (F # j) a)) ∙ snd (comp K₁ j) a) ∙ ! (snd (comp K₁ j) a)) ∙ ! (ap (fst (comp K₁ j)) (snd (F <#> g) a))) ∙
+        fst (comTri K₁ g) (fun (F # i) a) ∙ W i (fun (F # i) a)) ∙
+      ap (fst (comp K₂ j)) (snd (F <#> g) a) ∙ snd (comp K₂ j) a
         =⟪ ap (λ p → ! ((ap (fst (comp K₂ j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp K₁ j) a)) ∙ ! (ap (fst (comp K₁ j)) (snd (F <#> g) a))) ∙
-          fst (comTri K₁ g) (fun (F # i) a) ∙ W i (fun (F # i) a)) ∙ ap (fst (comp K₂ j)) (snd (F <#> g) a) ∙ snd (comp K₂ j) a) (u j a) ⟫
+             fst (comTri K₁ g) (fun (F # i) a) ∙ W i (fun (F # i) a)) ∙ ap (fst (comp K₂ j)) (snd (F <#> g) a) ∙ snd (comp K₂ j) a)
+           (u j a) ⟫
       ! ((ap (fst (comp K₂ j)) (snd (F <#> g) a) ∙ (snd (comp K₂ j) a ∙ ! (snd (comp K₁ j) a)) ∙ ! (ap (fst (comp K₁ j)) (snd (F <#> g) a))) ∙
-        fst (comTri K₁ g) (fun (F # i) a) ∙ W i (fun (F # i) a)) ∙ ap (fst (comp K₂ j)) (snd (F <#> g) a) ∙ snd (comp K₂ j) a
+        fst (comTri K₁ g) (fun (F # i) a) ∙ W i (fun (F # i) a)) ∙
+      ap (fst (comp K₂ j)) (snd (F <#> g) a) ∙ snd (comp K₂ j) a
         =⟪ long-path-red (snd (F <#> g) a) (snd (comp K₂ j) a) (snd (comp K₁ j) a) (fst (comTri K₁ g) (fun (F # i) a)) (W i (fun (F # i) a)) ⟫
       ! (W i (fun (F # i) a)) ∙ ! (fst (comTri K₁ g) (fun (F # i) a)) ∙ ap (fst (comp K₁ j)) (snd (F <#> g) a) ∙ snd (comp K₁ j) a
         =⟪ ap (λ p → ! (W i (fun (F # i) a)) ∙ p) (snd (comTri K₁ g) a) ⟫
@@ -46,9 +50,10 @@ module _ {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type ℓ} (F : Co
       snd (comp K₂ i) a ∎∎
     field
       Λ : {i j : Obj Γ} (g : Hom Γ i j) →
-        Σ ((x : ty (F # i)) → ! (W j (fst (F <#> g) x)) ∙ fst (comTri K₁ g) x ∙ W i x == fst (comTri K₂ g) x) (λ R → ((a : A) →
-          ! (ap (λ p → ! p ∙ ap (fst (comp K₂ j)) (snd (F <#> g) a) ∙ snd (comp K₂ j) a) (R (fun (F # i) a))) ◃∙
-          Ξ i j g a =ₛ snd (comTri K₂ g) a ◃∎))
+        Σ ((x : ty (F # i)) → ! (W j (fst (F <#> g) x)) ∙ fst (comTri K₁ g) x ∙ W i x == fst (comTri K₂ g) x)
+          (λ R → ((a : A) →
+            ! (ap (λ p → ! p ∙ ap (fst (comp K₂ j)) (snd (F <#> g) a) ∙ snd (comp K₂ j) a) (R (fun (F # i) a))) ◃∙
+            Ξ i j g a =ₛ snd (comTri K₂ g) a ◃∎))
         
   open CosCocEq public
 
@@ -76,12 +81,16 @@ module _ {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type ℓ} (F : Co
 
   CosCocEq-tot : Type (lmax ℓc (lmax (lmax ℓv ℓe) (lmax ℓd ℓ)))
   CosCocEq-tot =
-    Σ ((i : Obj Γ) → (Σ (F # i *→  T) (λ g →  < F # i > comp K₁ i ∼ g))) (λ H → ((i j : Obj Γ) (g : Hom Γ i j) →
-      Σ (Σ (fst (fst (H j)) ∘ fst (F <#> g) ∼ fst (fst (H i)))
-        (λ K → (x : ty (F # i)) → ! (fst (snd (H j)) (fst (F <#> g) x)) ∙ fst (comTri K₁ g) x ∙ fst (snd (H i)) x == K x))
-        (λ (K , R) → Σ ((a : A) → ! (K (fun (F # i) a)) ∙ ap (fst (fst (H j))) (snd (F <#> g) a) ∙ snd (fst (H j)) a  == snd (fst (H i)) a)
-        (λ J → ((a : A) →  ! (ap (λ p → ! p ∙ ap (fst (fst (H j))) (snd (F <#> g) a) ∙ snd (fst (H j)) a) (R (fun (F # i) a))) ∙
-          ↯ (ϕ H i j g a) == J a)))))
+    Σ ((i : Obj Γ) → (Σ (F # i *→  T) (λ g →  < F # i > comp K₁ i ∼ g)))
+      (λ H → ((i j : Obj Γ) (g : Hom Γ i j) →
+        Σ (Σ (fst (fst (H j)) ∘ fst (F <#> g) ∼ fst (fst (H i)))
+            (λ K → (x : ty (F # i)) → ! (fst (snd (H j)) (fst (F <#> g) x)) ∙ fst (comTri K₁ g) x ∙ fst (snd (H i)) x == K x))
+          (λ (K , R) →
+            Σ ((a : A) → ! (K (fun (F # i) a)) ∙ ap (fst (fst (H j))) (snd (F <#> g) a) ∙ snd (fst (H j)) a  == snd (fst (H i)) a)
+              (λ J →
+                ((a : A) →
+                  ! (ap (λ p → ! p ∙ ap (fst (fst (H j))) (snd (F <#> g) a) ∙ snd (fst (H j)) a) (R (fun (F # i) a))) ∙
+                  ↯ (ϕ H i j g a) == J a)))))
     module CCEq-Σ where
       ϕ : (H : _) (i j : Obj Γ) (g : Hom Γ i j) (a : A) →
         ! (! (fst (snd (H j)) (fst (F <#> g) (fun (F # i) a))) ∙ fst (comTri K₁ g) (fun (F # i) a) ∙ fst (snd (H i)) (fun (F # i) a)) ∙
@@ -89,19 +98,20 @@ module _ {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type ℓ} (F : Co
         =-=  snd (fst (H i)) a
       ϕ H i j g a =
         ! (! (fst (snd (H j)) (fst (F <#> g) (fun (F # i) a))) ∙ fst (comTri K₁ g) (fun (F # i) a) ∙ fst (snd (H i)) (fun (F # i) a)) ∙
+        ap (fst (fst (H j))) (snd (F <#> g) a) ∙ snd (fst (H j)) a
+          =⟪ ap (λ p → ! (p ∙  fst (comTri K₁ g) (fun (F # i) a) ∙ fst (snd (H i)) (fun (F # i) a)) ∙ ap (fst (fst (H j))) (snd (F <#> g) a) ∙ snd (fst (H j)) a)
+               (hmtpy-nat-rev (fst (snd (H j))) (snd (F <#> g) a) (snd (comp K₁ j) a)) ⟫
+        ! ((ap (fst (fst (H j))) (snd (F <#> g) a) ∙ ((! (fst (snd (H j)) (fun (F # j) a)) ∙ snd (comp K₁ j) a) ∙ ! (snd (comp K₁ j) a)) ∙ ! (ap (fst (comp K₁ j)) (snd (F <#> g) a))) ∙
+          fst (comTri K₁ g) (fun (F # i) a) ∙ fst (snd (H i)) (fun (F # i) a)) ∙
           ap (fst (fst (H j))) (snd (F <#> g) a) ∙ snd (fst (H j)) a
-          =⟪ ap (λ p → ! (p ∙  fst (comTri K₁ g) (fun (F # i) a) ∙ fst (snd (H i)) (fun (F # i) a)) ∙ ap (fst (fst (H j))) (snd (F <#> g) a) ∙
-            snd (fst (H j)) a) (hmtpy-nat-rev (fst (snd (H j))) (snd (F <#> g) a) (snd (comp K₁ j) a)) ⟫
-        ! ((ap (fst (fst (H j))) (snd (F <#> g) a) ∙ ((! (fst (snd (H j)) (fun (F # j) a)) ∙ snd (comp K₁ j) a) ∙ ! (snd (comp K₁ j) a)) ∙
-          ! (ap (fst (comp K₁ j)) (snd (F <#> g) a))) ∙ fst (comTri K₁ g) (fun (F # i) a) ∙ fst (snd (H i)) (fun (F # i) a)) ∙
-          ap (fst (fst (H j))) (snd (F <#> g) a) ∙ snd (fst (H j)) a
-          =⟪ ap (λ p → ! ((ap (fst (fst (H j))) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp K₁ j) a)) ∙ ! (ap (fst (comp K₁ j)) (snd (F <#> g) a))) ∙
-            fst (comTri K₁ g) (fun (F # i) a) ∙ fst (snd (H i)) (fun (F # i) a)) ∙
-              ap (fst (fst (H j))) (snd (F <#> g) a) ∙ snd (fst (H j)) a) (snd (snd (H j)) a) ⟫
+          =⟪ ap
+               (λ p →
+                 ! ((ap (fst (fst (H j))) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp K₁ j) a)) ∙ ! (ap (fst (comp K₁ j)) (snd (F <#> g) a))) ∙
+                   fst (comTri K₁ g) (fun (F # i) a) ∙ fst (snd (H i)) (fun (F # i) a)) ∙
+                 ap (fst (fst (H j))) (snd (F <#> g) a) ∙ snd (fst (H j)) a) (snd (snd (H j)) a) ⟫
         ! ((ap (fst (fst (H j))) (snd (F <#> g) a) ∙ (snd (fst (H j)) a ∙ ! (snd (comp K₁ j) a)) ∙ ! (ap (fst (comp K₁ j)) (snd (F <#> g) a))) ∙
           fst (comTri K₁ g) (fun (F # i) a) ∙ fst (snd (H i)) (fun (F # i) a)) ∙ ap (fst (fst (H j))) (snd (F <#> g) a) ∙ snd (fst (H j)) a
-          =⟪ long-path-red (snd (F <#> g) a) (snd (fst (H j)) a) (snd (comp K₁ j) a) (fst (comTri K₁ g) (fun (F # i) a))
-            (fst (snd (H i)) (fun (F # i) a)) ⟫
+          =⟪ long-path-red (snd (F <#> g) a) (snd (fst (H j)) a) (snd (comp K₁ j) a) (fst (comTri K₁ g) (fun (F # i) a)) (fst (snd (H i)) (fun (F # i) a)) ⟫
         ! (fst (snd (H i)) (fun (F # i) a)) ∙ ! (fst (comTri K₁ g) (fun (F # i) a)) ∙ ap (fst (comp K₁ j)) (snd (F <#> g) a) ∙ snd (comp K₁ j) a
           =⟪ ap (λ p → ! (fst (snd (H i)) (fun (F # i) a)) ∙ p) (snd (comTri K₁ g) a) ⟫
         ! (fst (snd (H i)) (fun (F # i) a)) ∙ snd (comp K₁ i) a
@@ -110,18 +120,25 @@ module _ {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type ℓ} (F : Co
 
   CosCocEq-tot-contr : is-contr (CosCocEq-tot)
   CosCocEq-tot-contr =
-    equiv-preserves-level ((Σ-contr-red (Π-level (λ i →  PtFunHomContr (comp K₁ i))))⁻¹)
-      {{Π-level (λ i → (Π-level (λ j → (Π-level (λ g →  equiv-preserves-level ((Σ-contr-red (FunHomContr {f = λ z → (fst (comTri K₁ g) z) ∙ idp}))⁻¹)
-      {{FunHomContr {f = λ a → ↯ (CCEq-Σ.ϕ (λ i → (comp K₁ i , (λ x → idp) , (λ a → idp))) i j g a)}}})))))}}
+    equiv-preserves-level ((Σ-contr-red (Π-level (λ i → PtFunHomContr (comp K₁ i))))⁻¹)
+      {{Π-level
+        (λ i → (Π-level (λ j →
+          (Π-level (λ g →
+            equiv-preserves-level ((Σ-contr-red (FunHomContr {f = λ z → (fst (comTri K₁ g) z) ∙ idp}))⁻¹)
+            {{FunHomContr {f = λ a → ↯ (CCEq-Σ.ϕ (λ i → (comp K₁ i , (λ x → idp) , (λ a → idp))) i j g a)}}})))))}}
 
   CosCocEq-eq : CosCocEq-tot ≃ Σ (CosCocone A F T) (λ K₂ → CosCocEq K₂)
   CosCocEq-eq =
-    equiv (λ x → ((λ i → fst (fst x i)) & (λ {j} {i} g → (fst (fst (snd x i j g))) , (fst (snd (snd x i j g))))) ,
-      CocEq (λ i x₁ → fst (snd (fst x i)) x₁)
-      (λ i a → snd (snd (fst x i)) a) (λ {i} {j} g → (λ x₁ → snd (fst (snd x i j g)) x₁ ) , λ a → =ₛ-in (snd (snd (snd x i j g)) a)))
-      (λ ((r & K) , e) → (λ i → r i , (CosCocEq.W e i) , (CosCocEq.u e i)) , λ i j g → (fst (K g) , fst (CosCocEq.Λ e g)) , (snd (K g)) ,
-        (λ a → =ₛ-out (snd (CosCocEq.Λ e g) a)))
-      (λ b → idp) λ a → idp
+    equiv
+      (λ x →
+        ((λ i → fst (fst x i)) & (λ {j} {i} g → (fst (fst (snd x i j g))) , (fst (snd (snd x i j g))))) ,
+        CocEq (λ i x₁ → fst (snd (fst x i)) x₁) (λ i a → snd (snd (fst x i)) a)
+          (λ {i} {j} g → (λ x₁ → snd (fst (snd x i j g)) x₁ ) , λ a → =ₛ-in (snd (snd (snd x i j g)) a)))
+      (λ ((r & K) , e) →
+        (λ i → r i , (CosCocEq.W e i) , (CosCocEq.u e i)) ,
+        λ i j g → (fst (K g) , fst (CosCocEq.Λ e g)) , (snd (K g)) , (λ a → =ₛ-out (snd (CosCocEq.Λ e g) a)))
+      (λ b → idp)
+      λ a → idp
 
   CosCocEq-IDsys : ID-sys (CosCocone A F T) (λ K → CosCocEq K) K₁ center-CCEq
   CosCocEq-IDsys p = contr-has-all-paths {{(equiv-preserves-level CosCocEq-eq {{CosCocEq-tot-contr}}) }} (K₁ , center-CCEq) p 

--- a/Colimit-code/Aux/FTID.agda
+++ b/Colimit-code/Aux/FTID.agda
@@ -29,9 +29,10 @@ module _ {i j} (A : Type i) (B : A → Type j) (a : A) (b : B a) where
       fib-pr-eq x y = transport (λ (x , y) → P x y) (s (x , y)) 
 
       ID-sys-ind : has-sec {f = depEval}
-      ID-sys-ind = sect (λ z → (λ x → λ y →  fib-pr-eq x y z)) const-dp
+      ID-sys-ind = sect (λ z → (λ x → λ y → fib-pr-eq x y z)) const-dp
 
-ID-ind : ∀ {i j k} {A : Type i} {B : A → Type j} {a : A} {b : B a} {P : (x : A) → (B x → Type k)} (s : ID-sys A B a b)
+ID-ind : ∀ {i j k} {A : Type i} {B : A → Type j}
+  {a : A} {b : B a} {P : (x : A) → (B x → Type k)} (s : ID-sys A B a b)
   → has-sec {f = depEval A B a b P}
 ID-ind {A = A} {B = B} {a = a} {b = b} {P = P} s = ID-sys-ind A B a b P s
 
@@ -65,17 +66,23 @@ module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄ ℓ₅} {A : Type ℓ₁} {B : Type ℓ₂
   {h : C → A} {v : C → D} {u : D → B} {f : B → E} where
 
   cmp-helper : {x y : C} (p : x == y) (s : h x == h y) (r : (z : C) →  u (v z) == τ (h z)) {k : A → E} (fₚ : f ∘ τ ∼ k)
-    → ! (ap (f ∘ u) (ap v p)) ∙
+    →
+    ! (ap (f ∘ u) (ap v p)) ∙
     (ap (f ∘ u) (ap v p) ∙ (ap f (r y) ∙ fₚ (h y)) ∙ ! (ap k s)) ∙
     ap k s ∙ ! (ap f (r y) ∙ fₚ (h y))
-    ==
+      ==
     ! (ap (f ∘ u) (ap v p)) ∙
     (ap f (r x) ∙ fₚ (h x)) ∙
     ap k s ∙ ! (ap f (! (ap u (ap v p)) ∙ r x ∙ ap τ s) ∙ fₚ (h y)) 
-  cmp-helper {x = x} {y = y} p s r {k = k} fₚ = IndFunHom
-    {P = λ m F → ! (ap (f ∘ u) (ap v p)) ∙ (ap (f ∘ u) (ap v p) ∙ (ap f (r y) ∙ F (h y)) ∙ ! (ap m s)) ∙ ap m s ∙ ! (ap f (r y) ∙ F (h y))
-      == ! (ap (f ∘ u) (ap v p)) ∙ (ap f (r x) ∙ F (h x)) ∙ ap m s ∙ ! (ap f (! (ap u (ap v p)) ∙ r x ∙ ap τ s) ∙ F (h y))}
-        (coher1 s p (r y) ∙ coher2 s p (r x)) k fₚ
+  cmp-helper {x = x} {y = y} p s r {k = k} fₚ =
+    IndFunHom
+      {P =
+        λ m F →
+          ! (ap (f ∘ u) (ap v p)) ∙ (ap (f ∘ u) (ap v p) ∙ (ap f (r y) ∙ F (h y)) ∙ ! (ap m s)) ∙ ap m s ∙ ! (ap f (r y) ∙ F (h y))
+            ==
+          ! (ap (f ∘ u) (ap v p)) ∙ (ap f (r x) ∙ F (h x)) ∙ ap m s ∙ ! (ap f (! (ap u (ap v p)) ∙ r x ∙ ap τ s) ∙ F (h y))}
+      (coher1 s p (r y) ∙ coher2 s p (r x))
+      k fₚ
     module CMPH where
       coher1 : {a b : A} (σ : a == b) {c d : C} (P : c == d) (R : u (v d) == τ b)
         → ! (ap (f ∘ u) (ap v P)) ∙ (ap (f ∘ u) (ap v P) ∙ (ap f R ∙ idp) ∙ ! (ap (f ∘ τ) σ)) ∙ ap (f ∘ τ) σ ∙ ! (ap f R ∙ idp) == idp
@@ -85,35 +92,51 @@ module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄ ℓ₅} {A : Type ℓ₁} {B : Type ℓ₂
         → idp == ! (ap (f ∘ u) (ap v P)) ∙ (ap f R ∙ idp) ∙ ap (f ∘ τ) σ ∙ ! (ap f (! (ap u (ap v P)) ∙ R ∙ ap τ σ) ∙ idp)
       coher2 idp idp R = fun-rid-inv2 R
 
-  ap-pth-unitr : (x : C) (r : (z : C) →  u (v z) == τ (h z))
-    → ! (ap (λ q → q ∙ ! (ap f (r x) ∙ idp)) (! (∙-unit-r (ap f (r x) ∙ idp)))) ∙
-      ! (ap (λ q → (ap f (r x) ∙ idp) ∙ q) (ap ! (ap (λ q → q ∙ idp) (ap (ap f) (∙-unit-r (r x)))))) ==
-      CMPH.coher1 {x = x} idp idp r (λ x₁ → idp) idp idp (r x) ∙ CMPH.coher2 {x = x} idp idp r (λ x₁ → idp) idp idp (r x)
+  ap-pth-unitr : (x : C) (r : (z : C) → u (v z) == τ (h z))
+    →
+    ! (ap (λ q → q ∙ ! (ap f (r x) ∙ idp)) (! (∙-unit-r (ap f (r x) ∙ idp)))) ∙
+    ! (ap (λ q → (ap f (r x) ∙ idp) ∙ q) (ap ! (ap (λ q → q ∙ idp) (ap (ap f) (∙-unit-r (r x))))))
+      ==
+    CMPH.coher1 {x = x} idp idp r (λ x₁ → idp) idp idp (r x) ∙ CMPH.coher2 {x = x} idp idp r (λ x₁ → idp) idp idp (r x)
   ap-pth-unitr x r = lemma (r x)
     where
       lemma : {b : B} (R : b == τ (h x))
-        → ! (ap (λ q → q ∙ ! (ap f R ∙ idp)) (! (∙-unit-r (ap f R ∙ idp)))) ∙
-          ! (ap (_∙_ (ap f R ∙ idp)) (ap ! (ap (λ q → q ∙ idp) (ap (ap f) (∙-unit-r R)))))
-        == fun-rid-inv1 R ∙ fun-rid-inv2 R
+        →
+        ! (ap (λ q → q ∙ ! (ap f R ∙ idp)) (! (∙-unit-r (ap f R ∙ idp)))) ∙
+        ! (ap (_∙_ (ap f R ∙ idp)) (ap ! (ap (λ q → q ∙ idp) (ap (ap f) (∙-unit-r R)))))
+          ==
+        fun-rid-inv1 R ∙ fun-rid-inv2 R
       lemma idp = idp
 
 module _ {i j k} {A : Type j} {X : Coslice i j A} {Y : Coslice k j A} (f : < A >  X *→ Y) where
 
-  PtFunHomContr-aux : is-contr (Σ (Σ (ty X → ty Y) (λ g → fst f ∼ g)) (λ (h , K) →
-    Σ ((a : A) → h (fun X a) == fun Y a) (λ p → ((a : A) → ! (K (fun X a)) ∙ (snd f a) == p a))))
-  PtFunHomContr-aux = equiv-preserves-level
-    ((Σ-contr-red {P = (λ (h , K) → Σ ((a : A) → h (fun X a) == fun Y a) (λ p → ((a : A) → ! (K (fun X a)) ∙ (snd f a) == p a)))}
-      (FunHomContr {f = fst f}))⁻¹) {{ equiv-preserves-level ((Σ-emap-r (λ q → app=-equiv))) {{pathfrom-is-contr (snd f)}} }} 
+  PtFunHomContr-aux :
+    is-contr
+      (Σ (Σ (ty X → ty Y) (λ g → fst f ∼ g))
+        (λ (h , K) → Σ ((a : A) → h (fun X a) == fun Y a) (λ p → ((a : A) → ! (K (fun X a)) ∙ (snd f a) == p a))))
+  PtFunHomContr-aux =
+    equiv-preserves-level
+      ((Σ-contr-red
+        {P = (λ (h , K) → Σ ((a : A) → h (fun X a) == fun Y a) (λ p → ((a : A) → ! (K (fun X a)) ∙ (snd f a) == p a)))}
+        (FunHomContr {f = fst f}))⁻¹)
+      {{equiv-preserves-level ((Σ-emap-r (λ q → app=-equiv))) {{pathfrom-is-contr (snd f)}}}} 
 
   open MapsCos A
 
   PtFunHomContr :  is-contr (Σ (X *→ Y) (λ g → < X > f ∼ g))
   PtFunHomContr = equiv-preserves-level lemma {{PtFunHomContr-aux }}
     where
-      lemma : Σ (Σ (ty X → ty Y) (λ g → fst f ∼ g)) (λ (h , K) → Σ ((a : A) → h (fun X a) == fun Y a) (λ p → ((a : A) →
-        ! (K (fun X a)) ∙ (snd f a) == p a))) ≃ Σ (X *→ Y) (λ g → < X > f ∼ g)
-      lemma = equiv (λ ((g , K) , (p , H)) → (g , (λ a → p a)) , ((λ x → K x) , (λ a → H a)) ) (λ ((h , p) , (H , K)) → (h , H) , (p , K))
-        (λ ((h , p) , (H , K)) → idp) λ ((g , K) , (p , H)) → idp 
+      lemma :
+        Σ (Σ (ty X → ty Y) (λ g → fst f ∼ g))
+          (λ (h , K) → Σ ((a : A) → h (fun X a) == fun Y a) (λ p → ((a : A) → ! (K (fun X a)) ∙ (snd f a) == p a)))
+          ≃
+        Σ (X *→ Y) (λ g → < X > f ∼ g)
+      lemma =
+        equiv
+          (λ ((g , K) , (p , H)) → (g , (λ a → p a)) , ((λ x → K x) , (λ a → H a)))
+          (λ ((h , p) , (H , K)) → (h , H) , (p , K))
+          (λ ((h , p) , (H , K)) → idp)
+          λ ((g , K) , (p , H)) → idp 
 
   PtFunEq : {g : X *→ Y} → (< X > f ∼ g) → f == g
   PtFunEq {g} h = ind (ID-ind {P = λ g s → f == g} λ r → contr-path PtFunHomContr r) idp g h

--- a/Colimit-code/Aux/Helper-paths.agda
+++ b/Colimit-code/Aux/Helper-paths.agda
@@ -4,7 +4,7 @@ open import lib.Basics
 
 module Helper-paths where
 
-module _ {ℓ₁} {A : Type ℓ₁} where
+module _ {ℓ} {A : Type ℓ} where
 
   ap-idf-rid : {x y : A} (p : x == y) → p == ap (λ z → z) p ∙ idp
   ap-idf-rid idp = idp
@@ -36,8 +36,8 @@ module _ {ℓ₁ ℓ₂} {A : Type ℓ₁} {B : Type ℓ₂} (f : A → B) where
 
 module _ {ℓ₁ ℓ₂} {A : Type ℓ₁} {B : Type ℓ₂} {f g : A → B} where
 
-  hmtpy-nat-rev : (H : f ∼ g) {x y : A} (p : x == y) {z : B} (q : f y == z) →
-    ! (H x) == ap g p ∙ ((! (H y) ∙ q) ∙ ! q) ∙ ! (ap f p)
+  hmtpy-nat-rev : (H : f ∼ g) {x y : A} (p : x == y) {z : B} (q : f y == z)
+    → ! (H x) == ap g p ∙ ((! (H y) ∙ q) ∙ ! q) ∙ ! (ap f p)
   hmtpy-nat-rev H {x = x} idp q = !-∙-!-!-rid q (H x)
 
 module _ {ℓ₁ ℓ₂ ℓ₃} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type ℓ₃} (f : A → B) (g : B → C) where
@@ -50,22 +50,28 @@ module _ {ℓ₁ ℓ₂ ℓ₃} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type �
 
 module _ {ℓ₁ ℓ₂ ℓ₃} {B : Type ℓ₁} {C : Type ℓ₂} {E : Type ℓ₃} (g : B → C) where
 
-  ap-cmp-inv-loop : (k : E → B) {x : E} {y : B} (q : y == k x) (Q : x == x) → ap g (q ∙ ap k Q ∙ ap k Q) ∙ idp == (ap g q ∙ ap (g ∘ k) Q) ∙ ap (g ∘ k) Q
+  ap-cmp-inv-loop : (k : E → B) {x : E} {y : B} (q : y == k x) (Q : x == x)
+    → ap g (q ∙ ap k Q ∙ ap k Q) ∙ idp == (ap g q ∙ ap (g ∘ k) Q) ∙ ap (g ∘ k) Q
   ap-cmp-inv-loop k idp Q = ap-inv-cmp-rid2 k g Q Q
 
-module _ {ℓ₁ ℓ₂ ℓ₃} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type ℓ₃} (f : A → B) (g : B → C) where
+module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄ ℓ₅} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type ℓ₃} {D : Type ℓ₄} {E : Type ℓ₅} (f : A → B) (g : B → C) where
 
-  long-path-red2 : ∀ {ℓ₄ ℓ₅} {D : Type ℓ₄} {E : Type ℓ₅} (h : D → A) (k : E → B) {x y : D} (s : x == y) {a : A} (t : h x == a)
-    {z : E} (q : k z == f (h y)) (Q : z == z) →
-    ap g (! (ap f (! (ap h s) ∙ t)) ∙ ! q ∙ ap k Q ∙ ap k Q) ∙ idp == (! (ap (g ∘ f) t) ∙ ap (g ∘ f ∘ h) s ∙ (ap g (! q) ∙ ap (g ∘ k) Q)) ∙ ap (g ∘ k) Q
+  long-path-red2 : (h : D → A) (k : E → B) {x y : D} (s : x == y) {a : A} (t : h x == a)
+    {z : E} (q : k z == f (h y)) (Q : z == z)
+    →
+    ap g (! (ap f (! (ap h s) ∙ t)) ∙ ! q ∙ ap k Q ∙ ap k Q) ∙ idp
+      ==
+    (! (ap (g ∘ f) t) ∙ ap (g ∘ f ∘ h) s ∙ (ap g (! q) ∙ ap (g ∘ k) Q)) ∙ ap (g ∘ k) Q
   long-path-red2 h k idp idp q Q = ap-cmp-inv-loop g k (! q) Q 
 
 module _ {ℓ₁ ℓ₂} {A : Type ℓ₁} {B : Type ℓ₂} (f g : A → B) where
 
-  transp-inv-comm : {x y : A} (p : x == y) (q : f x == g x) → transport (λ z → g z == f z) p (! q) == ! (transport (λ z → f z == g z) p q)
+  transp-inv-comm : {x y : A} (p : x == y) (q : f x == g x)
+    → transport (λ z → g z == f z) p (! q) == ! (transport (λ z → f z == g z) p q)
   transp-inv-comm idp q = idp
 
-  apd-tr-inv-fn : (q : (z : A) → f z == g z) {x y : A} (p : x == y) → apd-tr (λ z → ! (q z)) p ◃∎ =ₛ transp-inv-comm p (q x) ◃∙ ap ! (apd-tr q p) ◃∎
+  apd-tr-inv-fn : (q : (z : A) → f z == g z) {x y : A} (p : x == y)
+    → apd-tr (λ z → ! (q z)) p ◃∎ =ₛ transp-inv-comm p (q x) ◃∙ ap ! (apd-tr q p) ◃∎
   apd-tr-inv-fn q idp = =ₛ-in idp
 
 module _ {ℓ₁ ℓ₂} {A : Type ℓ₁} {B : A → Type ℓ₂} where

--- a/Colimit-code/L-R-L/CC-Equiv-LRL-0.agda
+++ b/Colimit-code/L-R-L/CC-Equiv-LRL-0.agda
@@ -22,15 +22,18 @@ module Constr {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type ℓ} (F
   RLfun f* = recCosCoc (PostComp ColCoC f*) 
 
   RfunEq : (f* : < A > Cos P left *→ T) → fst f* ∘ right ∼ fst (RLfun f*) ∘ right
-  RfunEq (f , fₚ) = colimE (λ i x → idp)
-    (λ i → λ j → λ g → λ x → from-transp-g (λ z → (f ∘ right) z == (fst (RLfun (f , fₚ)) ∘ right) z) (cglue g x) (↯ (V i j g x)))
-      module _ where
-        V : (i j : Obj Γ) (g : Hom Γ i j) (x : ty (F # i)) →
-          transport (λ z → (f ∘ right) z == (fst (RLfun (f , fₚ)) ∘ right) z) (cglue g x) idp =-= idp
-        V i j g x =    transport (λ z → (f ∘ right) z == (fst (RLfun (f , fₚ)) ∘ right) z) (cglue g x) idp
-                         =⟪ transp-pth {f = f ∘ right} {g = fst (RLfun (f , fₚ)) ∘ right} (cglue g x)  idp ⟫
-                       ! (ap (f ∘ right) (cglue g x)) ∙ ap (reccForg (PostComp ColCoC (f , fₚ))) (cglue g x)
-                         =⟪ ap (λ p → ! (ap (f ∘ right) (cglue g x)) ∙ p) (recc-βr (PostComp ColCoC (f , fₚ)) g x) ⟫
-                       ! (ap (f ∘ right) (cglue g x)) ∙ (ap f (ap right (cglue g x)))
-                         =⟪ cmp-inv-l (cglue g x) ⟫ 
-                       idp ∎∎
+  RfunEq (f , fₚ) =
+    colimE
+      (λ i x → idp)
+      (λ i → λ j → λ g → λ x → from-transp-g (λ z → (f ∘ right) z == (fst (RLfun (f , fₚ)) ∘ right) z) (cglue g x) (↯ (V i j g x)))
+    module _ where
+      V : (i j : Obj Γ) (g : Hom Γ i j) (x : ty (F # i)) →
+        transport (λ z → (f ∘ right) z == (fst (RLfun (f , fₚ)) ∘ right) z) (cglue g x) idp =-= idp
+      V i j g x =
+        transport (λ z → (f ∘ right) z == (fst (RLfun (f , fₚ)) ∘ right) z) (cglue g x) idp
+          =⟪ transp-pth {f = f ∘ right} {g = fst (RLfun (f , fₚ)) ∘ right} (cglue g x)  idp ⟫
+        ! (ap (f ∘ right) (cglue g x)) ∙ ap (reccForg (PostComp ColCoC (f , fₚ))) (cglue g x)
+          =⟪ ap (λ p → ! (ap (f ∘ right) (cglue g x)) ∙ p) (recc-βr (PostComp ColCoC (f , fₚ)) g x) ⟫
+        ! (ap (f ∘ right) (cglue g x)) ∙ (ap f (ap right (cglue g x)))
+          =⟪ cmp-inv-l (cglue g x) ⟫ 
+        idp ∎∎

--- a/Colimit-code/L-R-L/CC-Equiv-LRL-1.agda
+++ b/Colimit-code/L-R-L/CC-Equiv-LRL-1.agda
@@ -25,281 +25,318 @@ module Constr2 {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type ℓ} (
     K = κ F g a T f fₚ
     
     abstract
-
       γ-β : apd-tr (RfunEq (f , fₚ)) (cglue g (fun (F # i) a)) == ↯ (V f fₚ i j g (fun (F # i) a))
       γ-β =
         apd-to-tr (λ x → f (right x) == H (right x)) (RfunEq (f , fₚ)) (cglue g (fun (F # i) a))
-          (↯ (V f fₚ i j g (fun (F # i) a))) (cglue-β (λ i x → idp)
-            (λ i → λ j → λ g → λ x → from-transp-g (λ z → (f ∘ right) z == (fst (RLfun (f , fₚ)) ∘ right) z)
-              (cglue g x) (↯ (V f fₚ i j g x))) g (fun (F # i) a))
+          (↯ (V f fₚ i j g (fun (F # i) a)))
+          (cglue-β (λ i x → idp)
+            (λ i → λ j → λ g → λ x → from-transp-g (λ z → (f ∘ right) z == (fst (RLfun (f , fₚ)) ∘ right) z) (cglue g x) (↯ (V f fₚ i j g x)))
+            g (fun (F # i) a))
 
-    module _ where   
+    abstract
+      apdRW2 :
+        apd-tr (λ x → RfunEq (f , fₚ) (ψ x)) (cglue g a) ◃∎
+          =ₛ
+        apd-comp-ap {γ = RfunEq (f , fₚ)} (cglue g a) ◃∙
+        ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ◃∙
+        apd-helper {F = λ x → f (right x) == H (right x)} {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ◃∙
+        ↯ (V f fₚ i j g (fun (F # i) a)) ◃∎
+      apdRW2 =
+        apd-tr (λ x → RfunEq (f , fₚ) (ψ x)) (cglue g a) ◃∎
+          =ₛ⟨ apd-comp-s (cglue g a) ⟩
+        apd-comp-ap (cglue g a) ◃∙ apd-tr (RfunEq (f , fₚ)) (ap ψ (cglue g a)) ◃∎
+          =ₛ⟨ 1 & 1 & apd-comp-eq-s (cglue g a) (ψ-βr g a) ⟩
+        apd-comp-ap (cglue g a) ◃∙
+        ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ◃∙
+        apd-tr (RfunEq (f , fₚ)) (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a)) ◃∎
+          =ₛ⟨ 2 & 1 & apd-concat-arg (! (ap (cin j) (snd (F <#> g) a))) (cglue g (fun (F # i) a)) ⟩
+        apd-comp-ap (cglue g a) ◃∙
+        ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ◃∙
+        apd-helper {F = λ x → f (right x) == H (right x)} {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ◃∙
+        apd-tr (RfunEq (f , fₚ)) (cglue g (fun (F # i) a)) ◃∎
+          =ₛ⟨ 3 & 1 & =ₛ-in γ-β ⟩
+        apd-comp-ap (cglue g a) ◃∙
+        ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ◃∙
+        apd-helper {F = λ x → f (right x) == H (right x)} {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ◃∙
+        ↯ (V f fₚ i j g (fun (F # i) a)) ◃∎ ∎ₛ
 
-      abstract
+    transpEq-s : (s : f (right (ψ (cin j a))) == H (right (ψ (cin j a))))
+      →
+      transport (λ x → f (right (ψ x)) == H (right (ψ x))) (cglue g a) s
+        =-=
+      transport (λ x →  f (right (ψ x)) == f (right (ψ x))) (cglue g a) s
+    transpEq-s s =
+      transport (λ x → f (right (ψ x)) == H (right (ψ x))) (cglue g a) s
+        =⟪ O₁ s (cglue g a) (ψ-βr g a) ⟫
+      (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ s ∙ ap (reccForg K) (! (ap (cin j) (snd (F <#> g) a)) ∙ (cglue g (fun (F # i) a)))
+        =⟪ O₂ {p = (! (ap (f ∘ right) (ap ψ (cglue g a))))} (snd (F <#> g) a) (ap f (! (glue (cin j a))) ∙ fₚ a) (cglue g (fun (F # i) a))
+             (recc-βr K g (fun (F # i) a)) ⟫  
+      (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ s ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙
+      ! (! (ap f (ap right (cglue g (fun (F # i) a)))) ∙ ap (f ∘ right ∘ cin j) (snd (F <#> g) a) ∙ ap f (! (glue (cin j a))) ∙ fₚ a)
+        =⟪ ap (λ p → (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ s ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ p) (ap ! (snd (comTri K g) a)) ⟫
+      ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ s ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a)
+        =⟪ ap (λ p → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ s ∙ p ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a) )
+             (O₄ (λ x → ap f (! (glue x)) ∙ fₚ ([id] x)) (cglue g a) (id-βr g a)) ⟫
+      ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ s ∙ (ap (f ∘ right) (ap ψ (cglue g a)) ∙ (ap f (! (glue (cin i a))) ∙ fₚ a) ∙ idp) ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a)
+        =⟪ O₅ s (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a) ⟫
+      transport (λ x →  f (right (ψ x)) == f (right (ψ x))) (cglue g a) s ∎∎
 
-        apdRW2 : apd-tr (λ x → RfunEq (f , fₚ) (ψ x)) (cglue g a) ◃∎ =ₛ apd-comp-ap {γ = RfunEq (f , fₚ)} (cglue g a) ◃∙
-          ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ◃∙
-          apd-helper {F = λ x → f (right x) == H (right x)} {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ◃∙ ↯ (V f fₚ i j g (fun (F # i) a)) ◃∎
-        apdRW2 = apd-tr (λ x → RfunEq (f , fₚ) (ψ x)) (cglue g a) ◃∎
-                   =ₛ⟨ apd-comp-s (cglue g a) ⟩
-                 apd-comp-ap (cglue g a) ◃∙ apd-tr (RfunEq (f , fₚ)) (ap ψ (cglue g a)) ◃∎
-                   =ₛ⟨ 1 & 1 & apd-comp-eq-s (cglue g a) (ψ-βr g a)  ⟩
-                 apd-comp-ap (cglue g a) ◃∙ ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ◃∙ apd-tr (RfunEq (f , fₚ))
-                 (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a)) ◃∎
-                   =ₛ⟨ 2 & 1 & apd-concat-arg (! (ap (cin j) (snd (F <#> g) a))) (cglue g (fun (F # i) a)) ⟩
-                 apd-comp-ap (cglue g a) ◃∙ ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ◃∙
-                 apd-helper {F = λ x → f (right x) == H (right x)} {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ◃∙
-                 apd-tr (RfunEq (f , fₚ)) (cglue g (fun (F # i) a)) ◃∎
-                   =ₛ⟨ 3 & 1 & =ₛ-in γ-β ⟩
-                 apd-comp-ap (cglue g a) ◃∙ ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ◃∙
-                 apd-helper {F = λ x → f (right x) == H (right x)} {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ◃∙ (↯ (V f fₚ i j g (fun (F # i) a))) ◃∎ ∎ₛ
+    MidRW :
+      ap (λ s → transport (λ x → f (right (ψ x)) == H (right (ψ x))) (cglue g a) s)
+        (ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∎                                                                                                                              
+        =ₛ
+      ↯ (transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a))) ◃∙
+      ap (λ s → transport (λ x → f (right (ψ x)) == f (right (ψ x))) (cglue g a) s)
+        (ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
+      ! (↯ (transpEq-s idp)) ◃∎
+    MidRW = =ₛ-in (apeq-rev (λ s → ↯ (transpEq-s s)) (ap-inv-canc f (glue (cin j a)) (fₚ a)))
 
-      transpEq-s : (s : f (right (ψ (cin j a))) == H (right (ψ (cin j a))))
-        → transport (λ x → f (right (ψ x)) == H (right (ψ x))) (cglue g a) s
-          =-= transport (λ x →  f (right (ψ x)) == f (right (ψ x))) (cglue g a) s
-      transpEq-s s =
-              transport (λ x → f (right (ψ x)) == H (right (ψ x))) (cglue g a) s
-                =⟪ O₁ s (cglue g a) (ψ-βr g a) ⟫
-              (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ s ∙ ap (reccForg K) (! (ap (cin j) (snd (F <#> g) a)) ∙ (cglue g (fun (F # i) a)))
-                =⟪ O₂ {p = (! (ap (f ∘ right) (ap ψ (cglue g a))))} (snd (F <#> g) a) (ap f (! (glue (cin j a))) ∙ fₚ a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a)) ⟫  
-              (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ s ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ ! (! (ap f (ap right (cglue g (fun (F # i) a)))) ∙
-              ap (f ∘ right ∘ cin j) (snd (F <#> g) a) ∙ ap f (! (glue (cin j a))) ∙ fₚ a)
-                =⟪ ap (λ p → (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ s ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ p) (ap ! (snd (comTri K g) a)) ⟫
-              ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ s ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a)
-                =⟪ ap (λ p → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ s ∙ p ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a) ) (O₄ (λ x → ap f (! (glue x)) ∙ fₚ ([id] x))
-                  (cglue g a) (id-βr g a)) ⟫
-              ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ s ∙ (ap (f ∘ right) (ap ψ (cglue g a)) ∙ (ap f (! (glue (cin i a))) ∙ fₚ a) ∙ idp) ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a)
-                =⟪ O₅ s (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a) ⟫
-              transport (λ x →  f (right (ψ x)) == f (right (ψ x))) (cglue g a) s ∎∎
-              
-      MidRW : ap (λ s → transport (λ x → f (right (ψ x)) == H (right (ψ x))) (cglue g a) s)                                                                                           
-                (ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∎                                                                                                                              
-                =ₛ
-              ↯ (transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a))) ◃∙
-                ap (λ s → transport (λ x → f (right (ψ x)) == f (right (ψ x))) (cglue g a) s)                                                                            
-              (ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
-              ! (↯ (transpEq-s idp)) ◃∎
-      MidRW = =ₛ-in (apeq-rev (λ s → ↯ (transpEq-s s)) (ap-inv-canc f (glue (cin j a)) (fₚ a))) 
+    abstract
+    
+      CoherLemma : {z : Colim (ConsDiag Γ A)} (Q : z == cin i a)
+        →
+        ! (O₅ idp Q (ap f (! (glue (cin i a))) ∙ idp)) ∙
+        (CMPH.coher1 {τ = left} {h = [id]} {v = ψ} {u = right} {f = f} (cglue g a) idp (λ x → ! (glue x)) (λ x₁ → idp) idp Q (! (glue (cin i a))) ∙
+        CMPH.coher2 {τ = left} {h = [id]} {v = ψ} {u = right} {f = f} (cglue g a) idp (λ x → ! (glue x)) (λ x₁ → idp) idp Q (! (glue z))) ∙
+        inv-canc-cmp f right (ap ψ Q) (! (glue z)) idp
+          ==
+        apd-tr-refl {f = f ∘ right} {h = ψ} Q
+      CoherLemma idp = lemma (! (glue (cin i a)))
+        where
+          lemma : {x : P} (R : right (ψ (cin i a)) == x)
+            →
+            ! (O₅ {f = f ∘ right} {h = ψ} {b = cin i a} idp idp (ap f R ∙ idp)) ∙
+            (fun-rid-inv1 {f = f} R ∙ fun-rid-inv2 {f = f} R) ∙
+            inv-canc-cmp f right idp R idp
+              ==
+            idp
+          lemma idp = idp
 
+      ζ₂ : {k : A → ty T} (κ : f ∘ left ∼ k)
+        →
+        ! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ κ a)) ◃∙
+        cmp-helper {f = f} (cglue g a) idp (λ x → ! (glue x)) κ ◃∙
+        inv-canc-cmp f right (ap ψ (cglue g a)) (! (glue (cin j a))) (κ a) ◃∎
+          =ₛ
+        apd-tr-refl {f = f ∘ right} {h = ψ} (cglue g a) ◃∎
+      ζ₂ {k} κ =
+        IndFunHom
+          {P = λ k₁ κ₁ →
+            ! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ κ₁ a)) ◃∙
+            cmp-helper {τ = left} {h = [id]} {v = ψ} {u = right} {f = f} (cglue g a) idp (λ x → ! (glue x)) κ₁ ◃∙
+            inv-canc-cmp f right (ap ψ (cglue g a)) (! (glue (cin j a))) (κ₁ a) ◃∎
+              =ₛ
+            apd-tr-refl {f = f ∘ right} {h = ψ} (cglue g a) ◃∎} lemma k κ
+        where
+          lemma :
+            ! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ idp)) ◃∙
+            cmp-helper {τ = left} {h = [id]} {v = ψ} {u = right} {f = f} (cglue g a) idp (λ x → ! (glue x)) (λ x → idp) ◃∙
+            inv-canc-cmp f right (ap ψ (cglue g a)) (! (glue (cin j a))) idp ◃∎
+              =ₛ
+            apd-tr-refl {f = f ∘ right} {h = ψ} (cglue g a) ◃∎
+          lemma =
+            ! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ idp)) ◃∙
+            cmp-helper {τ = left} {h = [id]} {v = ψ} {u = right} {f = f} (cglue g a) idp (λ x → ! (glue x)) (λ x → idp) ◃∙
+            inv-canc-cmp f right (ap ψ (cglue g a)) (! (glue (cin j a))) idp ◃∎
+              =ₛ₁⟨ 1 & 1 &
+                   IndFunHom-β
+                     {P = λ m F →
+                       ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap (f ∘ right) (ap ψ (cglue g a)) ∙ (ap f (! (glue (cin i a))) ∙ F a) ∙ idp) ∙ ! (ap f (! (glue (cin i a))) ∙ F a)
+                         ==
+                       ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ F a) ∙ ! (ap f (! (ap right (ap ψ (cglue g a))) ∙ ! (glue (cin j a)) ∙ idp) ∙ F a)}
+                   (CMPH.coher1 {τ = left} {h = [id]} {v = ψ} {u = right} (cglue g a) idp (λ x → ! (glue x)) (λ x₁ → idp) idp (cglue g a) (! (glue (cin i a))) ∙
+                   CMPH.coher2 {τ = left} {h = [id]} {v = ψ} {u = right} (cglue g a) idp (λ x → ! (glue x)) (λ x₁ → idp) idp (cglue g a) (! (glue (cin j a))) ) ⟩
+              ! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ idp)) ◃∙
+              (CMPH.coher1 {τ = left} {h = [id]} {v = ψ} {u = right} (cglue g a) idp (λ x → ! (glue x)) (λ x₁ → idp) idp (cglue g a) (! (glue (cin i a))) ∙
+              CMPH.coher2 {τ = left} {h = [id]} {v = ψ} {u = right} (cglue g a) idp (λ x → ! (glue x)) (λ x₁ → idp) idp (cglue g a) (! (glue (cin j a)))) ◃∙
+              inv-canc-cmp f right (ap ψ (cglue g a)) (! (glue (cin j a))) idp ◃∎
+                =ₛ₁⟨ CoherLemma (cglue g a) ⟩
+            apd-tr-refl {f = f ∘ right} {h = ψ} (cglue g a) ◃∎ ∎ₛ
 
-    module _ where 
+    abstract
 
-      abstract
-
-        CoherLemma : {z : Colim (ConsDiag Γ A)} (Q : z == cin i a)
-          → (! (O₅ idp Q (ap f (! (glue (cin i a))) ∙ idp)) ∙
-            (CMPH.coher1 {τ = left} {h = [id]} {v = ψ} {u = right} {f = f} (cglue g a) idp (λ x → ! (glue x)) (λ x₁ → idp) idp Q (! (glue (cin i a))) ∙
-            CMPH.coher2 {τ = left} {h = [id]} {v = ψ} {u = right} {f = f} (cglue g a) idp (λ x → ! (glue x)) (λ x₁ → idp) idp Q (! (glue z))) ∙
-              inv-canc-cmp f right (ap ψ Q) (! (glue z)) idp)
-            == apd-tr-refl {f = f ∘ right} {h = ψ} Q
-        CoherLemma idp = lemma (! (glue (cin i a)))
+      RightRW2a :
+        ! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a)) ◃∙
+        ! (ap (λ p → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ p ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a))
+          (O₄ {f = f ∘ right} {h = ψ} {u = fun T} (λ x → ap f (! (glue x)) ∙ fₚ ([id] x)) (cglue g a) (id-βr g a))) ◃∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+          (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₃-v2 {f = left} {v = ψ} {u = right} (λ x → ! (glue x)) (cglue g a) (id-βr g a)))))) ◃∙
+        inv-canc-cmp f right (ap ψ (cglue g a)) (! (glue (cin j (idf A a)))) (fₚ a) ◃∎                  
+          =ₛ
+        ! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a)) ◃∙
+        cmp-helper {f = f} (cglue g a) idp (λ x → ! (glue x)) fₚ ◃∙
+        inv-canc-cmp f right (ap ψ (cglue g a)) (! (glue (cin j a))) (fₚ a) ◃∎
+      RightRW2a =
+        ! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a)) ◃∙
+        ! (ap (λ p → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ p ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a))
+          (O₄ {f = f ∘ right} {h = ψ} {u = fun T} (λ x → ap f (! (glue x)) ∙ fₚ ([id] x)) (cglue g a) (id-βr g a))) ◃∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+          (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₃-v2 {f = left} {v = ψ} {u = right} (λ x → ! (glue x)) (cglue g a) (id-βr g a)))))) ◃∙
+        inv-canc-cmp f right (ap ψ (cglue g a)) (! (glue (cin j (idf A a)))) (fₚ a) ◃∎
+          =ₛ⟨ =ₛ-in
+                (assoc4
+                  (! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a)))
+                  (! (ap (λ p → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ p ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a))
+                    (O₄ {f = f ∘ right} {h = ψ} {u = fun T} (λ x → ap f (! (glue x)) ∙ fₚ ([id] x)) (cglue g a) (id-βr g a))))
+                  (! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+                       (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₃-v2 {f = left} {v = ψ} {u = right} (λ x → ! (glue x)) (cglue g a) (id-βr g a)))))))
+                  (inv-canc-cmp f right (ap ψ (cglue g a)) (! (glue (cin j (idf A a)))) (fₚ a)) ∙
+                ap (λ r →
+                     ! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a)) ∙
+                     r ∙
+                     inv-canc-cmp f right (ap ψ (cglue g a)) (! (glue (cin j (idf A a)))) (fₚ a))
+                   (𝕏 (cglue g a) (id-βr g a) (λ x → ! (glue x)) fₚ)) ⟩
+         ! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a)) ◃∙
+         cmp-helper {f = f} (cglue g a) idp (λ x → ! (glue x)) fₚ ◃∙
+         inv-canc-cmp f right (ap ψ (cglue g a)) (! (glue (cin j a))) (fₚ a) ◃∎ ∎ₛ
           where
-            lemma : {x : P} (R : right (ψ (cin i a))  == x)
-              → ! (O₅ {f = f ∘ right} {h = ψ} {b = cin i a} idp idp (ap f R ∙ idp)) ∙ (fun-rid-inv1 {f = f} R ∙ fun-rid-inv2 {f = f} R)
-                ∙ inv-canc-cmp f right idp R idp
-              == idp
-            lemma idp = idp
+            assoc4 : ∀ {lev : ULevel} {W : Type lev} {s w x y z : W} (p₁ : s == w) (p₂ : w == x) (p₃ : x == y) (p₄ : y == z)
+              → p₁ ∙ p₂ ∙ p₃ ∙ p₄ == p₁ ∙ (p₂ ∙ p₃) ∙ p₄
+            assoc4 idp idp idp p₄ = idp
 
-        ζ₂ : {k : A → ty T} (κ : f ∘ left ∼ k) → ! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ κ a)) ◃∙ cmp-helper {f = f} (cglue g a) idp (λ x → ! (glue x)) κ ◃∙
-               inv-canc-cmp f right (ap ψ (cglue g a)) (! (glue (cin j a))) (κ a) ◃∎
-             =ₛ apd-tr-refl {f = f ∘ right} {h = ψ} (cglue g a) ◃∎
-        ζ₂ {k} κ = IndFunHom {P = λ k₁ κ₁ → ! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ κ₁ a)) ◃∙ cmp-helper {τ = left} {h = [id]} {v = ψ} {u = right} {f = f} (cglue g a) idp
-          (λ x → ! (glue x)) κ₁ ◃∙ inv-canc-cmp f right (ap ψ (cglue g a)) (! (glue (cin j a))) (κ₁ a) ◃∎ =ₛ apd-tr-refl {f = f ∘ right} {h = ψ} (cglue g a) ◃∎} lemma k κ
-          where
-            lemma : (! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ idp)) ◃∙ cmp-helper {τ = left} {h = [id]} {v = ψ} {u = right} {f = f} (cglue g a) idp
-              (λ x → ! (glue x)) (λ x → idp) ◃∙ inv-canc-cmp f right (ap ψ (cglue g a)) (! (glue (cin j a))) idp ◃∎) =ₛ (apd-tr-refl {f = f ∘ right} {h = ψ} (cglue g a) ◃∎)
-            lemma = (! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ idp)) ◃∙ cmp-helper {τ = left} {h = [id]} {v = ψ} {u = right} {f = f} (cglue g a) idp
-                      (λ x → ! (glue x)) (λ x → idp) ◃∙ inv-canc-cmp f right (ap ψ (cglue g a)) (! (glue (cin j a))) idp ◃∎)
-                    =ₛ₁⟨ 1 & 1 & IndFunHom-β
-                      {P = λ m F → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap (f ∘ right) (ap ψ (cglue g a)) ∙ (ap f (! (glue (cin i a))) ∙ F a) ∙ idp) ∙
-                      ! (ap f (! (glue (cin i a))) ∙ F a)
-                         == ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ F a) ∙ ! (ap f (! (ap right (ap ψ (cglue g a))) ∙ ! (glue (cin j a)) ∙ idp) ∙ F a)}
-                       (CMPH.coher1 {τ = left} {h = [id]} {v = ψ} {u = right} (cglue g a) idp (λ x → ! (glue x)) (λ x₁ → idp) idp (cglue g a) (! (glue (cin i a))) ∙
-                       CMPH.coher2 {τ = left} {h = [id]} {v = ψ} {u = right} (cglue g a) idp (λ x → ! (glue x)) (λ x₁ → idp) idp (cglue g a) (! (glue (cin j a))) ) ⟩
-                    (! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ idp)) ◃∙
-                      (CMPH.coher1 {τ = left} {h = [id]} {v = ψ} {u = right} (cglue g a) idp (λ x → ! (glue x)) (λ x₁ → idp) idp (cglue g a) (! (glue (cin i a))) ∙
-                    CMPH.coher2 {τ = left} {h = [id]} {v = ψ} {u = right} (cglue g a) idp (λ x → ! (glue x)) (λ x₁ → idp) idp (cglue g a) (! (glue (cin j a)))) ◃∙
-                      inv-canc-cmp f right (ap ψ (cglue g a)) (! (glue (cin j a))) idp ◃∎)
-                    =ₛ₁⟨ CoherLemma (cglue g a) ⟩
-                  (apd-tr-refl {f = f ∘ right} {h = ψ} (cglue g a) ◃∎) ∎ₛ
+      RightRW₂ :
+        seq-! (transpEq-s idp) ∙∙ apd-comp-ap {γ = RfunEq (f , fₚ)} (cglue g a) ◃∙
+        ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ◃∙
+        apd-helper {F = λ x → f (right x) == H (right x)} {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ◃∙
+        ↯ (V f fₚ i j g (fun (F # i) a)) ◃∎
+          =ₛ
+        ! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a)) ◃∙
+        ! (ap (λ p → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ p ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a))
+            (O₄ (λ x → ap f (! (glue x)) ∙ fₚ ([id] x)) (cglue g a) (id-βr g a))) ◃∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+          (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₃-v2 (λ x → ! (glue x)) (cglue g a) (id-βr g a)))))) ◃∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₂-v2 (ψ-βr g a) (! (glue (cin j (idf A a))))))))) ◃∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₁-v2 (snd (F <#> g) a)))))) ◃∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap-cp-revR f (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))))) ◃∙
+        ! (O₂ {p = ! (ap (f ∘ right) (ap ψ (cglue g a)))} {g = cin j} {q = idp} (snd (F <#> g) a) (ap f (! (glue (cin j a))) ∙ fₚ a)
+          (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
+        ! (O₁ {g = H ∘ right} idp (cglue g a) (ψ-βr g a)) ◃∙
+        apd-comp-ap {γ = RfunEq (f , fₚ)} (cglue g a) ◃∙
+        ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ◃∙
+        apd-helper {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ◃∙
+        (transp-pth (cglue g (fun (F # i) a)) idp ∙
+        ap (_∙_ (! (ap (f ∘ right) (cglue g (fun (F # i) a))))) (recc-βr (PostComp ColCoC (f , fₚ)) g (fun (F # i) a)) ∙
+        cmp-inv-l {f = right} {g = f} (cglue g (fun (F # i) a))) ◃∎ 
+      RightRW₂ =
+        seq-! (transpEq-s idp) ∙∙ apd-comp-ap {γ = RfunEq (f , fₚ)} (cglue g a) ◃∙
+        ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ◃∙
+        apd-helper {F = λ x → f (right x) == H (right x)} {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ◃∙
+        ↯ (V f fₚ i j g (fun (F # i) a)) ◃∎
+          =ₛ⟨ 2 & 1 &  PathSeq2 F g a T f fₚ ⟩
+        ! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a)) ◃∙
+        ! (ap (λ p → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ p ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a))
+            (O₄ (λ x → ap f (! (glue x)) ∙ fₚ ([id] x)) (cglue g a) (id-βr g a))) ◃∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₃-v2 (λ x → ! (glue x)) (cglue g a) (id-βr g a)))))) ◃∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₂-v2 (ψ-βr g a) (! (glue (cin j (idf A a))))))))) ◃∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₁-v2 (snd (F <#> g) a)))))) ◃∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap-cp-revR f (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))))) ◃∙
+        ! (O₂ {p = ! (ap (f ∘ right) (ap ψ (cglue g a)))} {g = cin j} {q = idp} (snd (F <#> g) a) (ap f (! (glue (cin j a))) ∙ fₚ a)
+          (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
+        ! (O₁ {g = H ∘ right} idp (cglue g a) (ψ-βr g a)) ◃∙
+        apd-comp-ap {γ = RfunEq (f , fₚ)} (cglue g a) ◃∙
+        ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ◃∙
+        apd-helper {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ◃∙
+        (transp-pth (cglue g (fun (F # i) a)) idp ∙
+        ap (_∙_ (! (ap (f ∘ right) (cglue g (fun (F # i) a))))) (recc-βr (PostComp ColCoC (f , fₚ)) g (fun (F # i) a)) ∙
+        cmp-inv-l {f = right} {g = f} (cglue g (fun (F # i) a))) ◃∎ ∎ₛ
 
-    module _ where 
+    abstract
+      ζ₁ : {x : Colim (ConsDiag Γ A)} (Q : cin j a == x) {w : ty (F # j)} (u : w == fun (F # j) a)
+        (v : cin j w == ψ x) (T₁ : ap ψ Q == ! (ap (cin j) u) ∙ v)
+        {L : f (right (cin j w)) == reccForg K (ψ x)} (T₂ : ap (reccForg K) v == L)
+        {z : ty T} (σ : f (right (cin j (fun (F # j) a))) == z)
+        →
+        ! (O₂ {p = ! (ap (f ∘ right) (ap ψ Q))} {g = cin j} {q = idp} u σ v T₂) ∙
+        ! (O₁ {g = H ∘ right} idp Q T₁) ∙
+        apd-comp-ap {γ = RfunEq (f , fₚ)} Q ∙
+        ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) T₁ ∙
+        apd-helper {γ = RfunEq (f , fₚ)} (! (ap (cin j) u)) ∙
+        transp-pth v idp ∙
+        ap (λ p → ! (ap (f ∘ right) v) ∙ p) T₂
+          ==
+        Δ-red u L σ v (ap (λ p → ! (ap (f ∘ right) p)) T₁)
+      ζ₁ idp idp v T₁ idp idp = lemma T₁
+        where
+          lemma : {V : ψ (cin j a) == ψ (cin j a)} (T : idp == V)
+            → ! (O₂ {p = idp} {g = cin j} {q = idp} idp idp V idp) ∙
+              ! (O₁ {f = f ∘ right} {h = ψ} {b = cin j a} idp idp T) ∙
+              ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) T ∙
+              transp-pth V (RfunEq (f , fₚ) (cin j (fun (F # j) a))) ∙ idp
+                ==
+              Δ-red {g = cin j} idp (ap (reccForg K) V) idp V (ap (λ p → ! (ap (f ∘ right) p)) T)
+          lemma idp = idp
 
-      abstract
+    abstract
+      RightRW1a :
+        ! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a)) ◃∙
+        ! (ap (λ p → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ p ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a))
+            (O₄ (λ x → ap f (! (glue x)) ∙ fₚ ([id] x)) (cglue g a) (id-βr g a))) ◃∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+          (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₃-v2 (λ x → ! (glue x)) (cglue g a) (id-βr g a)))))) ◃∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₂-v2 (ψ-βr g a) (! (glue (cin j (idf A a))))))))) ◃∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₁-v2 (snd (F <#> g) a)))))) ◃∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap-cp-revR f (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))))) ◃∙
+        ! (O₂ {p = ! (ap (f ∘ right) (ap ψ (cglue g a)))} {g = cin j} {q = idp} (snd (F <#> g) a) (ap f (! (glue (cin j a))) ∙ fₚ a)
+          (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
+        ! (O₁ {g = H ∘ right} idp (cglue g a) (ψ-βr g a)) ◃∙
+        apd-comp-ap {γ = RfunEq (f , fₚ)} (cglue g a) ◃∙
+        ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ◃∙
+        apd-helper {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ◃∙
+        (transp-pth (cglue g (fun (F # i) a)) idp ∙
+        ap (_∙_ (! (ap (f ∘ right) (cglue g (fun (F # i) a))))) (recc-βr (PostComp ColCoC (f , fₚ)) g (fun (F # i) a)) ∙
+        cmp-inv-l {f = right} {g = f} (cglue g (fun (F # i) a))) ◃∎
+          =ₛ
+        (! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a)) ∙
+        ! (ap (λ p → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ p ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a))
+            (O₄ (λ x → ap f (! (glue x)) ∙ fₚ ([id] x)) (cglue g a) (id-βr g a)) ) ∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₃-v2 (λ x → ! (glue x)) (cglue g a) (id-βr g a)))))) ∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₂-v2 (ψ-βr g a) (! (glue (cin j (idf A a))))))))) ∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₁-v2 (snd (F <#> g) a)))))) ∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap-cp-revR f (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))))) ∙
+        ! (O₂ {p = ! (ap (f ∘ right) (ap ψ (cglue g a)))} {g = cin j} {q = idp} (snd (F <#> g) a) (ap f (! (glue (cin j a))) ∙ fₚ a)
+          (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ∙
+        ! (O₁ {g = H ∘ right} idp (cglue g a) (ψ-βr g a)) ∙
+        apd-comp-ap {γ = RfunEq (f , fₚ)} (cglue g a) ∙
+        ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ∙
+        apd-helper {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ∙
+        (transp-pth (cglue g (fun (F # i) a)) idp ∙
+        ap (_∙_ (! (ap (f ∘ right) (cglue g (fun (F # i) a))))) (recc-βr (PostComp ColCoC (f , fₚ)) g (fun (F # i) a)) ∙
+        cmp-inv-l {f = right} {g = f} (cglue g (fun (F # i) a)))) ◃∎
+      RightRW1a = =ₛ-in idp      
 
-        RightRW2a : ! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a)) ◃∙
-                      ! (ap (λ p → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ p ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a)) (O₄ {f = f ∘ right} {h = ψ} {u = fun T}
-                        (λ x → ap f (! (glue x)) ∙ fₚ ([id] x)) (cglue g a) (id-βr g a))) ◃∙
-                      ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f)
-                        (E₃-v2 {f = left} {v = ψ} {u = right} (λ x → ! (glue x)) (cglue g a) (id-βr g a)))))) ◃∙
-                      inv-canc-cmp f right (ap ψ (cglue g a)) (! (glue (cin j (idf A a)))) (fₚ a) ◃∎                  
-                        =ₛ
-                      ! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a)) ◃∙
-                      cmp-helper {f = f} (cglue g a) idp (λ x → ! (glue x)) fₚ ◃∙
-                      inv-canc-cmp f right (ap ψ (cglue g a)) (! (glue (cin j a))) (fₚ a) ◃∎
-        RightRW2a = ! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a)) ◃∙
-                      ! (ap (λ p → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ p ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a)) (O₄ {f = f ∘ right} {h = ψ} {u = fun T}
-                        (λ x → ap f (! (glue x)) ∙ fₚ ([id] x)) (cglue g a) (id-βr g a))) ◃∙
-                      ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f)
-                        (E₃-v2 {f = left} {v = ψ} {u = right} (λ x → ! (glue x)) (cglue g a) (id-βr g a)))))) ◃∙
-                      inv-canc-cmp f right (ap ψ (cglue g a)) (! (glue (cin j (idf A a)))) (fₚ a) ◃∎                  
-                        =ₛ⟨ =ₛ-in (assoc4 (! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a)))
-                            (! (ap (λ p → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ p ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a)) (O₄ {f = f ∘ right} {h = ψ} {u = fun T}
-                            (λ x → ap f (! (glue x)) ∙ fₚ ([id] x)) (cglue g a) (id-βr g a))))
-                            (! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f)
-                            (E₃-v2 {f = left} {v = ψ} {u = right} (λ x → ! (glue x)) (cglue g a) (id-βr g a)))))))
-                            (inv-canc-cmp f right (ap ψ (cglue g a)) (! (glue (cin j (idf A a)))) (fₚ a))
-                          ∙ ap (λ r →
-                            ! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a)) ∙ r ∙ inv-canc-cmp f right (ap ψ (cglue g a)) (! (glue (cin j (idf A a)))) (fₚ a))
-                            (𝕏 (cglue g a) (id-βr g a) (λ x → ! (glue x)) fₚ)) ⟩ 
-                      ! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a)) ◃∙
-                      cmp-helper {f = f} (cglue g a) idp (λ x → ! (glue x)) fₚ ◃∙
-                      inv-canc-cmp f right (ap ψ (cglue g a)) (! (glue (cin j a))) (fₚ a) ◃∎ ∎ₛ
-            where
-              assoc4 : ∀ {lev : ULevel} {W : Type lev} {s w x y z : W} (p₁ : s == w) (p₂ : w == x) (p₃ : x == y) (p₄ : y == z)
-                → p₁ ∙ p₂ ∙ p₃ ∙ p₄ == p₁ ∙ (p₂ ∙ p₃) ∙ p₄
-              assoc4 idp idp idp p₄ = idp
-
-        RightRW₂ :  seq-! (transpEq-s idp) ∙∙ apd-comp-ap {γ = RfunEq (f , fₚ)} (cglue g a) ◃∙
-                    ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ◃∙
-                    apd-helper {F = λ x → f (right x) == H (right x)} {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ◃∙
-                    ↯ (V f fₚ i j g (fun (F # i) a)) ◃∎
-                     =ₛ ! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a)) ◃∙
-                    ! (ap (λ p → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ p ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a)) (O₄ (λ x → ap f (! (glue x)) ∙ fₚ ([id] x))
-                      (cglue g a) (id-βr g a)) ) ◃∙
-                    ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f)
-                      (E₃-v2 (λ x → ! (glue x)) (cglue g a) (id-βr g a)))))) ◃∙
-                    ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
-                      (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₂-v2 (ψ-βr g a) (! (glue (cin j (idf A a))))))))) ◃∙
-                    ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙
-                      (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₁-v2 (snd (F <#> g) a)))))) ◃∙
-                    ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙
-                      (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap-cp-revR f (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))))) ◃∙
-                    ! (O₂ {p = ! (ap (f ∘ right) (ap ψ (cglue g a)))} {g = cin j} {q = idp} (snd (F <#> g) a) (ap f (! (glue (cin j a))) ∙ fₚ a) (cglue g (fun (F # i) a))
-                      (recc-βr K g (fun (F # i) a))) ◃∙
-                    ! (O₁ {g = H ∘ right} idp (cglue g a) (ψ-βr g a)) ◃∙
-                    apd-comp-ap {γ = RfunEq (f , fₚ)} (cglue g a) ◃∙
-                    ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ◃∙
-                    apd-helper {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ◃∙
-                    (transp-pth (cglue g (fun (F # i) a)) idp ∙
-                    ap (_∙_ (! (ap (f ∘ right) (cglue g (fun (F # i) a))))) (recc-βr (PostComp ColCoC (f , fₚ)) g (fun (F # i) a)) ∙
-                    cmp-inv-l {f = right} {g = f} (cglue g (fun (F # i) a))) ◃∎ 
-        RightRW₂ =  seq-! (transpEq-s idp) ∙∙ apd-comp-ap {γ = RfunEq (f , fₚ)} (cglue g a) ◃∙
-                    ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ◃∙
-                    apd-helper {F = λ x → f (right x) == H (right x)} {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ◃∙
-                    ↯ (V f fₚ i j g (fun (F # i) a)) ◃∎
-                      =ₛ⟨ 2 & 1 &  PathSeq2 F g a T f fₚ ⟩
-                    ! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a)) ◃∙
-                    ! (ap (λ p → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ p ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a)) (O₄ (λ x → ap f (! (glue x)) ∙ fₚ ([id] x))
-                      (cglue g a) (id-βr g a)) ) ◃∙
-                    ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f)
-                      (E₃-v2 (λ x → ! (glue x)) (cglue g a) (id-βr g a)))))) ◃∙
-                    ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
-                      (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₂-v2 (ψ-βr g a) (! (glue (cin j (idf A a))))))))) ◃∙
-                    ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙
-                      (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₁-v2 (snd (F <#> g) a)))))) ◃∙
-                    ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙
-                      (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap-cp-revR f (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))))) ◃∙
-                    ! (O₂ {p = ! (ap (f ∘ right) (ap ψ (cglue g a)))} {g = cin j} {q = idp} (snd (F <#> g) a) (ap f (! (glue (cin j a))) ∙ fₚ a) (cglue g (fun (F # i) a))
-                      (recc-βr K g (fun (F # i) a))) ◃∙
-                    ! (O₁ {g = H ∘ right} idp (cglue g a) (ψ-βr g a)) ◃∙
-                    apd-comp-ap {γ = RfunEq (f , fₚ)} (cglue g a) ◃∙
-                    ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ◃∙
-                    apd-helper {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ◃∙
-                    (transp-pth (cglue g (fun (F # i) a)) idp ∙
-                      ap (_∙_ (! (ap (f ∘ right) (cglue g (fun (F # i) a))))) (recc-βr (PostComp ColCoC (f , fₚ)) g (fun (F # i) a)) ∙
-                      cmp-inv-l {f = right} {g = f} (cglue g (fun (F # i) a))) ◃∎ ∎ₛ
-
-    module _ where
-
-      abstract
-
-        ζ₁ : {x : Colim (ConsDiag Γ A)} (Q : cin j a == x) {w : ty (F # j)} (u : w == fun (F # j) a) (v : cin j w == ψ x)
-          (T₁ : ap ψ Q == ! (ap (cin j) u) ∙ v) {L : f (right (cin j w)) == reccForg K (ψ x)} (T₂ : ap (reccForg K) v == L)
-          {z : ty T} (σ : f (right (cin j (fun (F # j) a))) == z)
-          → (! (O₂ {p = ! (ap (f ∘ right) (ap ψ Q))} {g = cin j} {q = idp} u σ v T₂)) ∙ (! (O₁ {g = H ∘ right} idp Q T₁)) ∙ 
-            apd-comp-ap {γ = RfunEq (f , fₚ)} Q ∙
-            ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) T₁ ∙
-            apd-helper {γ = RfunEq (f , fₚ)} (! (ap (cin j) u)) ∙
-            transp-pth v idp ∙
-            ap (λ p → ! (ap (f ∘ right) v) ∙ p) T₂
-          == Δ-red u L σ v (ap (λ p → ! (ap (f ∘ right) p)) T₁)
-        ζ₁ idp idp v T₁ idp idp = lemma T₁
-          where lemma : {V : ψ (cin j a) == ψ (cin j a)} (T : idp == V) 
-                  → ! (O₂ {p = idp} {g = cin j} {q = idp} idp idp V idp) ∙ ! (O₁ {f = f ∘ right} {h = ψ} {b = cin j a} idp idp T) ∙
-                    ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) T ∙
-                    transp-pth V (RfunEq (f , fₚ) (cin j (fun (F # j) a))) ∙ idp
-                  ==
-                    Δ-red {g = cin j} idp (ap (reccForg K) V) idp V (ap (λ p → ! (ap (f ∘ right) p)) T)
-                lemma idp = idp
-
-    module _ where 
-
-      abstract
-
-        RightRW1a : ! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a)) ◃∙
-                  ! (ap (λ p → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ p ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a)) (O₄ (λ x → ap f (! (glue x)) ∙ fₚ ([id] x))
-                    (cglue g a) (id-βr g a)) ) ◃∙
-                  ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f)
-                    (E₃-v2 (λ x → ! (glue x)) (cglue g a) (id-βr g a)))))) ◃∙
-                  ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
-                    (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₂-v2 (ψ-βr g a) (! (glue (cin j (idf A a))))))))) ◃∙
-                  ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙
-                    (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₁-v2 (snd (F <#> g) a)))))) ◃∙
-                  ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙
-                    (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap-cp-revR f (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))))) ◃∙
-                  ! (O₂ {p = ! (ap (f ∘ right) (ap ψ (cglue g a)))} {g = cin j} {q = idp} (snd (F <#> g) a) (ap f (! (glue (cin j a))) ∙ fₚ a) (cglue g (fun (F # i) a))
-                    (recc-βr K g (fun (F # i) a))) ◃∙
-                  ! (O₁ {g = H ∘ right} idp (cglue g a) (ψ-βr g a)) ◃∙
-                  apd-comp-ap {γ = RfunEq (f , fₚ)} (cglue g a) ◃∙
-                  ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ◃∙
-                  apd-helper {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ◃∙
-                  (transp-pth (cglue g (fun (F # i) a)) idp ∙
-                  ap (_∙_ (! (ap (f ∘ right) (cglue g (fun (F # i) a))))) (recc-βr (PostComp ColCoC (f , fₚ)) g (fun (F # i) a)) ∙
-                  cmp-inv-l {f = right} {g = f} (cglue g (fun (F # i) a))) ◃∎
-            =ₛ   (! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a)) ∙
-                  ! (ap (λ p → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ p ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a)) (O₄ (λ x → ap f (! (glue x)) ∙ fₚ ([id] x))
-                    (cglue g a) (id-βr g a)) ) ∙
-                  ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f)
-                    (E₃-v2 (λ x → ! (glue x)) (cglue g a) (id-βr g a)))))) ∙
-                  ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
-                    (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₂-v2 (ψ-βr g a) (! (glue (cin j (idf A a))))))))) ∙
-                  ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙
-                    (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₁-v2 (snd (F <#> g) a)))))) ∙
-                  ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙
-                    (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap-cp-revR f (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))))) ∙
-                  ! (O₂ {p = ! (ap (f ∘ right) (ap ψ (cglue g a)))} {g = cin j} {q = idp} (snd (F <#> g) a) (ap f (! (glue (cin j a))) ∙ fₚ a) (cglue g (fun (F # i) a))
-                    (recc-βr K g (fun (F # i) a))) ∙
-                  ! (O₁ {g = H ∘ right} idp (cglue g a) (ψ-βr g a)) ∙
-                  apd-comp-ap {γ = RfunEq (f , fₚ)} (cglue g a) ∙
-                  ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ∙
-                  apd-helper {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ∙
-                  (transp-pth (cglue g (fun (F # i) a)) idp ∙
-                  ap (_∙_ (! (ap (f ∘ right) (cglue g (fun (F # i) a))))) (recc-βr (PostComp ColCoC (f , fₚ)) g (fun (F # i) a)) ∙
-                  cmp-inv-l {f = right} {g = f} (cglue g (fun (F # i) a)))) ◃∎
-        RightRW1a = =ₛ-in idp      
-
-      module _ where
-
-        abstract
-
-          RightRW₁ :
-            ! (↯ (transpEq-s idp)) ◃∙ apd-tr (λ x → RfunEq (f , fₚ) (ψ x)) (cglue g a) ◃∎
-            =ₛ
-            seq-! (transpEq-s idp) ∙∙ apd-comp-ap {γ = RfunEq (f , fₚ)} (cglue g a) ◃∙
-            ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ◃∙
-            apd-helper {F = λ x → f (right x) == H (right x)} {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ◃∙
-            ↯ (V f fₚ i j g (fun (F # i) a)) ◃∎ 
-          RightRW₁ =
-            ! (↯ (transpEq-s idp)) ◃∙ apd-tr (λ x → RfunEq (f , fₚ) (ψ x)) (cglue g a) ◃∎
-              =ₛ⟨ 1 & 1 & apdRW2 ⟩
-            ! (↯ (transpEq-s idp)) ◃∙
-            apd-comp-ap {γ = RfunEq (f , fₚ)} (cglue g a) ◃∙
-            ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ◃∙
-            apd-helper {F = λ x → f (right x) == H (right x)} {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ◃∙
-            ↯ (V f fₚ i j g (fun (F # i) a)) ◃∎
-              =ₛ⟨ 0 & 1 & !-∙-seq (transpEq-s idp) ⟩
-            seq-! (transpEq-s idp) ∙∙ apd-comp-ap {γ = RfunEq (f , fₚ)} (cglue g a) ◃∙
-            ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ◃∙
-            apd-helper {F = λ x → f (right x) == H (right x)} {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ◃∙
-            ↯ (V f fₚ i j g (fun (F # i) a)) ◃∎ ∎ₛ
+    abstract
+      RightRW₁ :
+        ! (↯ (transpEq-s idp)) ◃∙ apd-tr (λ x → RfunEq (f , fₚ) (ψ x)) (cglue g a) ◃∎
+          =ₛ
+        seq-! (transpEq-s idp) ∙∙ apd-comp-ap {γ = RfunEq (f , fₚ)} (cglue g a) ◃∙
+        ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ◃∙
+        apd-helper {F = λ x → f (right x) == H (right x)} {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ◃∙
+        ↯ (V f fₚ i j g (fun (F # i) a)) ◃∎ 
+      RightRW₁ =
+        ! (↯ (transpEq-s idp)) ◃∙
+        apd-tr (λ x → RfunEq (f , fₚ) (ψ x)) (cglue g a) ◃∎
+          =ₛ⟨ 1 & 1 & apdRW2 ⟩
+        ! (↯ (transpEq-s idp)) ◃∙
+        apd-comp-ap {γ = RfunEq (f , fₚ)} (cglue g a) ◃∙
+        ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ◃∙
+        apd-helper {F = λ x → f (right x) == H (right x)} {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ◃∙
+        ↯ (V f fₚ i j g (fun (F # i) a)) ◃∎
+          =ₛ⟨ 0 & 1 & !-∙-seq (transpEq-s idp) ⟩
+        seq-! (transpEq-s idp) ∙∙ apd-comp-ap {γ = RfunEq (f , fₚ)} (cglue g a) ◃∙
+        ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ◃∙
+        apd-helper {F = λ x → f (right x) == H (right x)} {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ◃∙
+        ↯ (V f fₚ i j g (fun (F # i) a)) ◃∎ ∎ₛ

--- a/Colimit-code/L-R-L/CC-Equiv-LRL-2.agda
+++ b/Colimit-code/L-R-L/CC-Equiv-LRL-2.agda
@@ -22,93 +22,97 @@ module Constr3 {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type ℓ} (
     open Constr2.DiagCoher2 F T i j f fₚ g a public
 
     abstract
-
-      SliceRW :   ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
-                    (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₂-v2 (ψ-βr g a) (! (glue (cin j (idf A a))))))))) ◃∙
-                  ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙
-                    (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₁-v2 (snd (F <#> g) a)))))) ◃∙
-                  ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙
-                    (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap-cp-revR f (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))))) ◃∙
-                  ! (O₂ {p = ! (ap (f ∘ right) (ap ψ (cglue g a)))} {g = cin j} {q = idp} (snd (F <#> g) a) (ap f (! (glue (cin j a))) ∙ fₚ a) (cglue g (fun (F # i) a))
-                    (recc-βr K g (fun (F # i) a))) ◃∙
-                  ! (O₁ {g = H ∘ right} idp (cglue g a) (ψ-βr g a)) ◃∙
-                  apd-comp-ap {γ = RfunEq (f , fₚ)} (cglue g a) ◃∙
-                  ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ◃∙
-                  apd-helper {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ◃∙
-                  transp-pth (cglue g (fun (F # i) a)) idp ◃∙
-                  ap (_∙_ (! (ap (f ∘ right) (cglue g (fun (F # i) a))))) (recc-βr (PostComp ColCoC (f , fₚ)) g (fun (F # i) a)) ◃∙
-                  cmp-inv-l {f = right} {g = f} (cglue g (fun (F # i) a)) ◃∎
-                    =ₛ
-                  inv-canc-cmp f right (ap ψ (cglue g a)) (! (glue (cin j (idf A a)))) (fₚ a) ◃∎
-      SliceRW =   ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
-                    (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₂-v2 (ψ-βr g a) (! (glue (cin j (idf A a))))))))) ◃∙
-                  ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙
-                    (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₁-v2 (snd (F <#> g) a)))))) ◃∙
-                  ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙
-                    (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap-cp-revR f (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))))) ◃∙
-                  ! (O₂ {p = ! (ap (f ∘ right) (ap ψ (cglue g a)))} {g = cin j} {q = idp} (snd (F <#> g) a) (ap f (! (glue (cin j a))) ∙ fₚ a) (cglue g (fun (F # i) a))
-                    (recc-βr K g (fun (F # i) a))) ◃∙
-                  ! (O₁ {g = H ∘ right} idp (cglue g a) (ψ-βr g a)) ◃∙
-                  apd-comp-ap {γ = RfunEq (f , fₚ)} (cglue g a) ◃∙
-                  ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ◃∙
-                  apd-helper {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ◃∙
-                  transp-pth (cglue g (fun (F # i) a)) idp ◃∙
-                  ap (_∙_ (! (ap (f ∘ right) (cglue g (fun (F # i) a))))) (recc-βr (PostComp ColCoC (f , fₚ)) g (fun (F # i) a)) ◃∙
-                  cmp-inv-l {f = right} {g = f} (cglue g (fun (F # i) a)) ◃∎
-                    =ₛ₁⟨ 3 & 7 & ζ₁ (cglue g a) (snd (F <#> g) a) (cglue g (fun (F # i) a)) (ψ-βr g a) (recc-βr K g (fun (F # i) a)) (ap f (! (glue (cin j a))) ∙ fₚ a) ⟩
-                  ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
-                    (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₂-v2 (ψ-βr g a) (! (glue (cin j (idf A a))))))))) ◃∙
-                  ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙
-                    (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₁-v2 (snd (F <#> g) a)))))) ◃∙
-                  ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙
-                    (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap-cp-revR f (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))))) ◃∙
-                  Δ-red (snd (F <#> g) a) (ap f (ap right (cglue g (fun (F # i) a)))) (ap f (! (glue (cin j a))) ∙ fₚ a) (cglue g (fun (F # i) a))
-                    (ap (λ p → ! (ap (f ∘ right) p)) (ψ-βr g a)) ◃∙
-                  cmp-inv-l {f = right} {g = f} (cglue g (fun (F # i) a)) ◃∎
-                    =ₛ₁⟨ 𝕐 (snd (F <#> g) a) (cglue g (fun (F # i) a)) (! (glue (cin j a))) (ψ-βr g a) (fₚ a) ⟩
-                  inv-canc-cmp f right (ap ψ (cglue g a)) (! (glue (cin j (idf A a)))) (fₚ a) ◃∎ ∎ₛ
+      SliceRW :
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+          (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₂-v2 (ψ-βr g a) (! (glue (cin j (idf A a))))))))) ◃∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₁-v2 (snd (F <#> g) a)))))) ◃∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap-cp-revR f (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))))) ◃∙
+        ! (O₂ {p = ! (ap (f ∘ right) (ap ψ (cglue g a)))} {g = cin j} {q = idp} (snd (F <#> g) a) (ap f (! (glue (cin j a))) ∙ fₚ a)
+          (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
+        ! (O₁ {g = H ∘ right} idp (cglue g a) (ψ-βr g a)) ◃∙
+        apd-comp-ap {γ = RfunEq (f , fₚ)} (cglue g a) ◃∙
+        ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ◃∙
+        apd-helper {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ◃∙
+        transp-pth (cglue g (fun (F # i) a)) idp ◃∙
+        ap (_∙_ (! (ap (f ∘ right) (cglue g (fun (F # i) a))))) (recc-βr (PostComp ColCoC (f , fₚ)) g (fun (F # i) a)) ◃∙
+        cmp-inv-l {f = right} {g = f} (cglue g (fun (F # i) a)) ◃∎
+          =ₛ
+        inv-canc-cmp f right (ap ψ (cglue g a)) (! (glue (cin j (idf A a)))) (fₚ a) ◃∎
+      SliceRW =
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₂-v2 (ψ-βr g a) (! (glue (cin j (idf A a))))))))) ◃∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₁-v2 (snd (F <#> g) a)))))) ◃∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap-cp-revR f (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))))) ◃∙
+        ! (O₂ {p = ! (ap (f ∘ right) (ap ψ (cglue g a)))} {g = cin j} {q = idp} (snd (F <#> g) a)
+            (ap f (! (glue (cin j a))) ∙ fₚ a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
+        ! (O₁ {g = H ∘ right} idp (cglue g a) (ψ-βr g a)) ◃∙
+        apd-comp-ap {γ = RfunEq (f , fₚ)} (cglue g a) ◃∙
+        ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ◃∙
+        apd-helper {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ◃∙
+        transp-pth (cglue g (fun (F # i) a)) idp ◃∙
+        ap (_∙_ (! (ap (f ∘ right) (cglue g (fun (F # i) a))))) (recc-βr (PostComp ColCoC (f , fₚ)) g (fun (F # i) a)) ◃∙
+        cmp-inv-l {f = right} {g = f} (cglue g (fun (F # i) a)) ◃∎
+          =ₛ₁⟨ 3 & 7 & ζ₁ (cglue g a) (snd (F <#> g) a) (cglue g (fun (F # i) a)) (ψ-βr g a) (recc-βr K g (fun (F # i) a)) (ap f (! (glue (cin j a))) ∙ fₚ a) ⟩
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₂-v2 (ψ-βr g a) (! (glue (cin j (idf A a))))))))) ◃∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₁-v2 (snd (F <#> g) a)))))) ◃∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap-cp-revR f (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))))) ◃∙
+        Δ-red (snd (F <#> g) a) (ap f (ap right (cglue g (fun (F # i) a)))) (ap f (! (glue (cin j a))) ∙ fₚ a)
+          (cglue g (fun (F # i) a)) (ap (λ p → ! (ap (f ∘ right) p)) (ψ-βr g a)) ◃∙
+        cmp-inv-l {f = right} {g = f} (cglue g (fun (F # i) a)) ◃∎
+          =ₛ₁⟨ 𝕐 (snd (F <#> g) a) (cglue g (fun (F # i) a)) (! (glue (cin j a))) (ψ-βr g a) (fₚ a) ⟩
+        inv-canc-cmp f right (ap ψ (cglue g a)) (! (glue (cin j (idf A a)))) (fₚ a) ◃∎ ∎ₛ
 
     abstract  
+      RightRW1 :
+        (! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a)) ∙
+        ! (ap (λ p → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ p ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a))
+            (O₄ (λ x → ap f (! (glue x)) ∙ fₚ ([id] x)) (cglue g a) (id-βr g a))) ∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₃-v2 (λ x → ! (glue x)) (cglue g a) (id-βr g a)))))) ∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₂-v2 (ψ-βr g a) (! (glue (cin j (idf A a))))))))) ∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₁-v2 (snd (F <#> g) a)))))) ∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap-cp-revR f (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))))) ∙
+       ! (O₂ {p = ! (ap (f ∘ right) (ap ψ (cglue g a)))} {g = cin j} {q = idp} (snd (F <#> g) a) (ap f (! (glue (cin j a))) ∙ fₚ a)
+           (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ∙
+       ! (O₁ {g = H ∘ right} idp (cglue g a) (ψ-βr g a)) ∙
+       apd-comp-ap {γ = RfunEq (f , fₚ)} (cglue g a) ∙
+       ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ∙
+       apd-helper {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ∙
+       (transp-pth (cglue g (fun (F # i) a)) idp ∙
+       ap (_∙_ (! (ap (f ∘ right) (cglue g (fun (F # i) a))))) (recc-βr (PostComp ColCoC (f , fₚ)) g (fun (F # i) a)) ∙
+       cmp-inv-l {f = right} {g = f} (cglue g (fun (F # i) a)))) ◃∎
+         =ₛ
+       ! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a)) ◃∙
+       ! (ap (λ p → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ p ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a))
+           (O₄ {f = f ∘ right} {h = ψ} {u = fun T} (λ x → ap f (! (glue x)) ∙ fₚ ([id] x)) (cglue g a) (id-βr g a))) ◃∙
+       ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+         (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₃-v2 {f = left} {v = ψ} {u = right} (λ x → ! (glue x)) (cglue g a) (id-βr g a)))))) ◃∙
+       inv-canc-cmp f right (ap ψ (cglue g a)) (! (glue (cin j (idf A a)))) (fₚ a) ◃∎
+      RightRW1 =
+        =ₛ-in
+          (ap
+            (λ r →
+              ! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a)) ∙
+              ! (ap (λ p → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ p ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a))
+                  (O₄ (λ x → ap f (! (glue x)) ∙ fₚ ([id] x)) (cglue g a) (id-βr g a))) ∙
+              ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+                  (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₃-v2 (λ x → ! (glue x)) (cglue g a) (id-βr g a)))))) ∙ r)
+            (=ₛ-out SliceRW)) 
 
-      RightRW1 :  (! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a)) ∙
-                  ! (ap (λ p → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ p ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a)) (O₄ (λ x → ap f (! (glue x)) ∙ fₚ ([id] x))
-                    (cglue g a) (id-βr g a)) ) ∙
-                  ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f)
-                    (E₃-v2 (λ x → ! (glue x)) (cglue g a) (id-βr g a)))))) ∙
-                  ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
-                    (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₂-v2 (ψ-βr g a) (! (glue (cin j (idf A a))))))))) ∙
-                  ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙
-                    (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₁-v2 (snd (F <#> g) a)))))) ∙
-                  ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙
-                    (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap-cp-revR f (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))))) ∙
-                  ! (O₂ {p = ! (ap (f ∘ right) (ap ψ (cglue g a)))} {g = cin j} {q = idp} (snd (F <#> g) a) (ap f (! (glue (cin j a))) ∙ fₚ a) (cglue g (fun (F # i) a))
-                    (recc-βr K g (fun (F # i) a))) ∙
-                  ! (O₁ {g = H ∘ right} idp (cglue g a) (ψ-βr g a)) ∙
-                  apd-comp-ap {γ = RfunEq (f , fₚ)} (cglue g a) ∙
-                  ap (λ p → transport (λ x → f (right x) == H (right x)) p idp) (ψ-βr g a) ∙
-                  apd-helper {γ = RfunEq (f , fₚ)} (! (ap (cin j) (snd (F <#> g) a))) ∙
-                  (transp-pth (cglue g (fun (F # i) a)) idp ∙
-                  ap (_∙_ (! (ap (f ∘ right) (cglue g (fun (F # i) a))))) (recc-βr (PostComp ColCoC (f , fₚ)) g (fun (F # i) a)) ∙
-                  cmp-inv-l {f = right} {g = f} (cglue g (fun (F # i) a)))) ◃∎
-                     =ₛ
-                  ! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a)) ◃∙
-                  ! (ap (λ p → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ p ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a)) (O₄ {f = f ∘ right} {h = ψ} {u = fun T}
-                    (λ x → ap f (! (glue x)) ∙ fₚ ([id] x)) (cglue g a) (id-βr g a))) ◃∙
-                  ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f)
-                    (E₃-v2 {f = left} {v = ψ} {u = right} (λ x → ! (glue x)) (cglue g a) (id-βr g a)))))) ◃∙
-                  inv-canc-cmp f right (ap ψ (cglue g a)) (! (glue (cin j (idf A a)))) (fₚ a) ◃∎ -- apd-tr-refl {f = f ∘ right} {h = ψ} (cglue g a) ◃∎  
-      RightRW1 = =ₛ-in
-                     (ap (λ r → ! (O₅ idp (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a)) ∙
-                       ! (ap (λ p → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙
-                       p ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a)) (O₄ (λ x → ap f (! (glue x)) ∙
-                       fₚ ([id] x)) (cglue g a) (id-βr g a))) ∙ ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙
-                       (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f)
-                       (E₃-v2 (λ x → ! (glue x)) (cglue g a) (id-βr g a)))))) ∙ r)
-                       (=ₛ-out SliceRW)) 
-
-    module _ where
-
-      abstract   
-
-        RightRW : ! (↯ (transpEq-s idp)) ◃∙ apd-tr (λ x → RfunEq (f , fₚ) (ψ x)) (cglue g a) ◃∎ =ₛ apd-tr-refl {f = f ∘ right} {h = ψ} (cglue g a) ◃∎
-        RightRW = RightRW₁ ∙ₛ (RightRW₂ ∙ₛ (RightRW1a ∙ₛ (RightRW1 ∙ₛ (RightRW2a ∙ₛ (ζ₂ fₚ)))))
+    abstract   
+      RightRW :
+        ! (↯ (transpEq-s idp)) ◃∙
+        apd-tr (λ x → RfunEq (f , fₚ) (ψ x)) (cglue g a) ◃∎
+          =ₛ
+        apd-tr-refl {f = f ∘ right} {h = ψ} (cglue g a) ◃∎
+      RightRW = RightRW₁ ∙ₛ (RightRW₂ ∙ₛ (RightRW1a ∙ₛ (RightRW1 ∙ₛ (RightRW2a ∙ₛ (ζ₂ fₚ)))))

--- a/Colimit-code/L-R-L/CC-Equiv-LRL-3.agda
+++ b/Colimit-code/L-R-L/CC-Equiv-LRL-3.agda
@@ -28,10 +28,15 @@ module Constr4 {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type ℓ} (
 
     open Constr3.DiagCoher3 F T i j f fₚ g a public
 
-    ω : transport (λ x → (fun T) ([id] x) == reccForg K (ψ x)) (cglue g a) (! (ap f (! (glue (cin j a))) ∙ fₚ a)) =-= ! (ap f (! (glue (cin i a))) ∙ fₚ a)
+    ω :
+      transport (λ x → (fun T) ([id] x) == reccForg K (ψ x)) (cglue g a) (! (ap f (! (glue (cin j a))) ∙ fₚ a))
+        =-=
+      ! (ap f (! (glue (cin i a))) ∙ fₚ a)
     ω = η (comp K) (comTri K) i j g a
 
-    ω-ap-inv : (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a) =-=
+    ω-ap-inv :
+      (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a)
+        =-=
       (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ transport (λ x → (fun T) ([id] x) == reccForg K (ψ x)) (cglue g a) (! (ap f (! (glue (cin j a))) ∙ fₚ a))
     ω-ap-inv = seq-! (ap-seq (λ p → (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ p) ω)
 
@@ -43,167 +48,210 @@ module Constr4 {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type ℓ} (
     ω=ω-switch = κ=κ-switch K g a
 
     abstract
-
       ω=ω-switch-ap-inv : ω-ap-inv-switch =ₛ ω-ap-inv
       ω=ω-switch-ap-inv = !-=ₛ (ap-seq-=ₛ (λ p → (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ p) ω=ω-switch) 
 
-
     PathSeq1 :
-      (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a) =-=
+      (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin i a))) ∙ fₚ a)
+        =-=
       transport (λ x → f (right (ψ x)) == f (right (ψ x))) (cglue g a) ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a))
     PathSeq1 =
-      ω-ap-inv ∙∙ (! (apd-concat-pres {F = λ x → ! (ap f (glue x)) ∙ fₚ ([id] x)} {G = σ (comp K) (comTri K)} (cglue g a)) ◃∙
+      ω-ap-inv ∙∙
+      (! (apd-concat-pres {F = λ x → ! (ap f (glue x)) ∙ fₚ ([id] x)} {G = σ (comp K) (comTri K)} (cglue g a)) ◃∙
       transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)))
 
     abstract
 
       Reduce1 : {x : Colim (ConsDiag Γ A)} (p : cin j a == x) {Q : ψ (cin j a) == ψ x}
-          → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ ! (ap (fun T) (ap [id] p)) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a) ∙
-            ap (reccForg K) Q ==
-            ! (ap (f ∘ right) (ap ψ p)) ∙ ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)) ∙
-              ap (reccForg K) Q
+        →
+        (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ ! (ap (fun T) (ap [id] p)) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ ap (reccForg K) Q
+          ==
+        ! (ap (f ∘ right) (ap ψ p)) ∙ ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)) ∙ ap (reccForg K) Q
       Reduce1 idp {Q = Q} = ! (∙-assoc (! (ap f (glue (cin j a))) ∙ fₚ a) (! (ap f (! (glue (cin j a))) ∙ fₚ a)) (ap (reccForg K) Q))
     
       CommSq1 : {x : Colim (ConsDiag Γ A)} (p : cin j a == x) {Q : ψ (cin j a) == ψ x} (R : ap ψ p == Q)
-          → ! (ap (λ p → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ p) (H₁ p (! (ap f (! (glue (cin j a))) ∙ fₚ a)) R)) ◃∙
-            ! (apd-concat-pres {F = λ x → ! (ap f (glue x)) ∙ fₚ ([id] x)} {G = σ (comp K) (comTri K)} p)  ◃∙
-              O₁ (((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a))) p R ◃∎
-          =ₛ Reduce1 p {Q = Q} ◃∎
-      CommSq1 idp idp = =ₛ-in ( lemma (glue (cin j a)) (fₚ a) )
+        →
+        ! (ap (λ p → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ p) (H₁ p (! (ap f (! (glue (cin j a))) ∙ fₚ a)) R)) ◃∙
+        ! (apd-concat-pres {F = λ x → ! (ap f (glue x)) ∙ fₚ ([id] x)} {G = σ (comp K) (comTri K)} p)  ◃∙
+        O₁ (((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a))) p R ◃∎
+          =ₛ
+        Reduce1 p {Q = Q} ◃∎
+      CommSq1 idp idp = =ₛ-in (lemma (glue (cin j a)) (fₚ a))
           where
             lemma : {x : P} (r : left a == x) {y : ty T} (s : f (left a) == y) 
-              → ! (ap (_∙_ (! (ap f r) ∙ s)) (! (∙-unit-r (! (ap f (! r) ∙ s)))))
-                ∙ ! (∙-unit-r ((! (ap f r) ∙ s) ∙ ! (ap f (! r) ∙ s)))
-              == ! (∙-assoc (! (ap f r) ∙ s) (! (ap f (! r) ∙ s)) idp)
+              →
+              ! (ap (_∙_ (! (ap f r) ∙ s)) (! (∙-unit-r (! (ap f (! r) ∙ s))))) ∙ ! (∙-unit-r ((! (ap f r) ∙ s) ∙ ! (ap f (! r) ∙ s)))
+                ==
+              ! (∙-assoc (! (ap f r) ∙ s) (! (ap f (! r) ∙ s)) idp)
             lemma idp idp = idp 
 
       Reduce2 : {x : Colim (ConsDiag Γ A)} (p : cin j a == x) {R : (reccForg K) (cin j (fst (F <#> g) (fun (F # i) a))) == (reccForg K) (ψ x)}
-            → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ ! (ap (fun T) (ap [id] p)) ∙
-                ! (! R ∙ ap (f ∘ right ∘ cin j) (snd (F <#> g) a) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a)) ==
-              ! (ap (f ∘ right) (ap ψ p)) ∙ ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)) ∙
-                (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ ! (! R ∙ ap (f ∘ right ∘ cin j) (snd (F <#> g) a) ∙ ap f (! (glue (cin j a))) ∙ fₚ a)
-      Reduce2 idp {R = R} = R2lemma (ap f (! (glue (cin j a))) ∙ fₚ a) (! (ap f (glue (cin j a))) ∙ fₚ a) (! (! R ∙ ap (f ∘ right ∘ cin j) (snd (F <#> g) a) ∙
-        ap f (! (glue (cin j a))) ∙ fₚ a))
-          module _ where R2lemma : ∀ {x z w y : ty T} (q : x == z) (u : w == z) (r : z == y) → u ∙ r == (u ∙ ! q) ∙ q ∙ r
-                         R2lemma idp u r = ap (λ p → p ∙ r) (! (∙-unit-r u))
+        →
+        (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙
+        ! (ap (fun T) (ap [id] p)) ∙
+        ! (! R ∙ ap (f ∘ right ∘ cin j) (snd (F <#> g) a) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a))
+          ==
+       ! (ap (f ∘ right) (ap ψ p)) ∙
+       ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)) ∙
+       (ap f (! (glue (cin j a))) ∙ fₚ a) ∙
+       ! (! R ∙ ap (f ∘ right ∘ cin j) (snd (F <#> g) a) ∙ ap f (! (glue (cin j a))) ∙ fₚ a)
+      Reduce2 idp {R = R} =
+        R2lemma
+          (ap f (! (glue (cin j a))) ∙ fₚ a)
+          (! (ap f (glue (cin j a))) ∙ fₚ a)
+          (! (! R ∙ ap (f ∘ right ∘ cin j) (snd (F <#> g) a) ∙ ap f (! (glue (cin j a))) ∙ fₚ a))
+          module _ where
+            R2lemma : {x z w y : ty T} (q : x == z) (u : w == z) (r : z == y) → u ∙ r == (u ∙ ! q) ∙ q ∙ r
+            R2lemma idp u r = ap (λ p → p ∙ r) (! (∙-unit-r u))
 
       CommSq2 : {x : Colim (ConsDiag Γ A)} (p : cin j a == x) {s : cin j (fst (F <#> g) (fun (F # i) a))  == ψ x}
-          {R : (reccForg K) (cin j (fst (F <#> g) (fun (F # i) a))) == (reccForg K) (ψ x)} (V : ap (reccForg K) s == R)
-          → ! (ap (λ q → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ q) (H₂ (snd (F <#> g) a) (ap f (! (glue (cin j a))) ∙ fₚ a) {p = ! (ap (fun T) (ap [id] p))} s V)) ◃∙
-            Reduce1 p ◃∙ O₂ {p = ! (ap (f ∘ right) (ap ψ p))} {g = cin j} {q = ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a))}
-            (snd (F <#> g) a) (ap f (! (glue (cin j a))) ∙ fₚ a) s V ◃∎
-          =ₛ Reduce2 p {R = R} ◃∎
+        {R : (reccForg K) (cin j (fst (F <#> g) (fun (F # i) a))) == (reccForg K) (ψ x)} (V : ap (reccForg K) s == R)
+        →
+        ! (ap (λ q → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ q) (H₂ (snd (F <#> g) a) (ap f (! (glue (cin j a))) ∙ fₚ a) {p = ! (ap (fun T) (ap [id] p))} s V)) ◃∙
+        Reduce1 p ◃∙ O₂ {p = ! (ap (f ∘ right) (ap ψ p))} {g = cin j} {q = ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a))}
+          (snd (F <#> g) a) (ap f (! (glue (cin j a))) ∙ fₚ a) s V ◃∎
+          =ₛ
+        Reduce2 p {R = R} ◃∎
       CommSq2 idp {s = s} {R = R} idp = lemma (fₚ a) (snd (F <#> g) a) (glue (cin j a)) 
           where
             lemma : {y : ty T} (w : f (left a) == y) {z : ty (F # j)} (t : fst (F <#> g) (fun (F # i) a) == z) (r : left a == right (cin j z))
-              → (! (ap (_∙_ (! (ap f r) ∙ w)) (H₂ {u = reccForg K} {g = cin j} t (ap f (! r) ∙ w) {p = idp} s idp)) ◃∙ ! (∙-assoc (! (ap f r) ∙ w) (! (ap f (! r) ∙ w))
-              (ap (reccForg K) (! (ap (cin j) t) ∙ s))) ◃∙ O₂ {p = idp} {g = cin j} t (ap f (! r) ∙ w) s idp ◃∎)
-              =ₛ R2lemma {R = ap (reccForg K) s} (ap f (! r) ∙ w) (! (ap f r) ∙ w) (! (! R ∙ ap (f ∘ right ∘ cin j) t ∙ ap f (! r) ∙ w)) ◃∎
+              →
+              ! (ap (_∙_ (! (ap f r) ∙ w)) (H₂ {u = reccForg K} {g = cin j} t (ap f (! r) ∙ w) {p = idp} s idp)) ◃∙
+              ! (∙-assoc (! (ap f r) ∙ w) (! (ap f (! r) ∙ w)) (ap (reccForg K) (! (ap (cin j) t) ∙ s))) ◃∙
+              O₂ {p = idp} {g = cin j} t (ap f (! r) ∙ w) s idp ◃∎
+                =ₛ
+              R2lemma {R = ap (reccForg K) s} (ap f (! r) ∙ w) (! (ap f r) ∙ w) (! (! R ∙ ap (f ∘ right ∘ cin j) t ∙ ap f (! r) ∙ w)) ◃∎
             lemma idp idp r = lemma2 r
               where
                 lemma2 : {x : P} (e : x == right (cin j (fst (F <#> g) (fun (F # i) a))))
-                  → ! (ap (_∙_ (! (ap f e) ∙ idp)) (H₂ {u = reccForg K} {g = cin j} idp (ap f (! e) ∙ idp) s idp)) ◃∙ ! (∙-assoc (! (ap f e) ∙ idp) (! (ap f (! e) ∙ idp))
-                    (ap (reccForg K) s)) ◃∙ O₂ {p = idp} {g = cin j} {q = ((! (ap f e) ∙ idp) ∙ ! (ap f (! e) ∙ idp))} idp (ap f (! e) ∙ idp) s idp ◃∎
-                  =ₛ R2lemma {R = ap (reccForg K) s} (ap f (! e) ∙ idp) (! (ap f e) ∙ idp) (! (! (ap (reccForg K) s) ∙ ap f (! e) ∙ idp)) ◃∎
+                  →
+                  ! (ap (_∙_ (! (ap f e) ∙ idp)) (H₂ {u = reccForg K} {g = cin j} idp (ap f (! e) ∙ idp) s idp)) ◃∙
+                  ! (∙-assoc (! (ap f e) ∙ idp) (! (ap f (! e) ∙ idp)) (ap (reccForg K) s)) ◃∙
+                  O₂ {p = idp} {g = cin j} {q = ((! (ap f e) ∙ idp) ∙ ! (ap f (! e) ∙ idp))} idp (ap f (! e) ∙ idp) s idp ◃∎
+                    =ₛ
+                  R2lemma {R = ap (reccForg K) s} (ap f (! e) ∙ idp) (! (ap f e) ∙ idp) (! (! (ap (reccForg K) s) ∙ ap f (! e) ∙ idp)) ◃∎
                 lemma2 idp = lemma3 s
                   where
                     lemma3 : {c : Colim (DiagForg A Γ F)} (S : cin j (fst (F <#> g) (fun (F # i) a)) == c)
-                      → (! (ap (λ q → q) (H₂ {g = cin j} idp idp S idp)) ◃∙ idp ◃∙ O₂ {p = idp} {g = cin j} {q = idp} idp idp S idp ◃∎) =ₛ
-                        R2lemma {R = ap (reccForg K) s} idp idp (! (! (ap (reccForg K) S) ∙ idp)) ◃∎
+                      →
+                      ! (ap (λ q → q) (H₂ {g = cin j} idp idp S idp)) ◃∙ idp ◃∙ O₂ {p = idp} {g = cin j} {q = idp} idp idp S idp ◃∎
+                        =ₛ
+                      R2lemma {R = ap (reccForg K) s} idp idp (! (! (ap (reccForg K) S) ∙ idp)) ◃∎
                     lemma3 idp = =ₛ-in idp
 
-      Reduce3 : {x : Colim (ConsDiag Γ A)} (p : cin j a == x) {t : ty T} (V : fun T a == t) 
-            → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ ! (ap (fun T) (ap [id] p)) ∙ V ==
-              ! (ap (f ∘ right) (ap ψ p)) ∙ ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)) ∙
-                (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ V
+      Reduce3 : {x : Colim (ConsDiag Γ A)} (p : cin j a == x) {t : ty T} (V : fun T a == t)
+        →
+        (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ ! (ap (fun T) (ap [id] p)) ∙ V
+          ==
+        ! (ap (f ∘ right) (ap ψ p)) ∙ ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ V
       Reduce3 idp V = R3lemma (glue (cin j a)) (fₚ a) V 
           module _ where
             R3lemma : {x : P} (r : left a == x) {y : ty T} (s : f (left a) == y) {z : ty T} (w : y == z)
-              → (! (ap f r) ∙ s) ∙ w
-              == ((! (ap f r) ∙ s) ∙ ! ((ap f (! r)) ∙ s)) ∙ (ap f (! r) ∙ s) ∙ w
+              → (! (ap f r) ∙ s) ∙ w == ((! (ap f r) ∙ s) ∙ ! ((ap f (! r)) ∙ s)) ∙ (ap f (! r) ∙ s) ∙ w
             R3lemma idp idp w = idp
 
       CommSq3 : {x : Colim (ConsDiag Γ A)} (p : cin j a == x) {R : (reccForg K) (cin j (fst (F <#> g) (fun (F # i) a))) == (reccForg K) (ψ x)}
-          {S : fun T a  == (reccForg K) (ψ x)} (E : ! (! R ∙ ap (f ∘ right ∘ cin j) (snd (F <#> g) a) ∙ ap f (! (glue (cin j a))) ∙ fₚ a) == S)
-          → ! (ap (λ q →  (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ q) (ap (λ q → ! (ap (fun T) (ap [id] p)) ∙ q) E)) ◃∙ Reduce2 p {R = R} ◃∙
-            ap (λ q → ! (ap (f ∘ right) (ap ψ p)) ∙ ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)) ∙
-              (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) E ◃∎
-          =ₛ Reduce3 p S ◃∎
+        {S : fun T a  == (reccForg K) (ψ x)} (E : ! (! R ∙ ap (f ∘ right ∘ cin j) (snd (F <#> g) a) ∙ ap f (! (glue (cin j a))) ∙ fₚ a) == S)
+        →
+        ! (ap (λ q →  (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ q) (ap (λ q → ! (ap (fun T) (ap [id] p)) ∙ q) E)) ◃∙
+        Reduce2 p {R = R} ◃∙
+        ap (λ q → ! (ap (f ∘ right) (ap ψ p)) ∙ ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) E ◃∎
+          =ₛ
+        Reduce3 p S ◃∎
       CommSq3 idp {R = R} idp = lemma (glue (cin j a)) (fₚ a) (! (! R ∙ ap (f ∘ right ∘ cin j) (snd (F <#> g) a) ∙ ap f (! (glue (cin j a))) ∙ fₚ a))
-          where
-            lemma : {x : P} (r : left a == x) {y : ty T} (s : f (left a) == y) {z : ty T} (w : y == z)
-              → idp ◃∙ R2lemma {R = R} (ap f (! r) ∙ s) (! (ap f r) ∙ s) w ◃∙ idp ◃∎ =ₛ R3lemma (! (! R ∙ ap (f ∘ right ∘ cin j) (snd (F <#> g) a) ∙
-                ap f (! (glue (cin j a))) ∙ fₚ a)) r s w ◃∎
-            lemma idp idp w = =ₛ-in idp
+        where
+          lemma : {x : P} (r : left a == x) {y : ty T} (s : f (left a) == y) {z : ty T} (w : y == z)
+            →
+            idp ◃∙ R2lemma {R = R} (ap f (! r) ∙ s) (! (ap f r) ∙ s) w ◃∙ idp ◃∎
+              =ₛ
+            R3lemma (! (! R ∙ ap (f ∘ right ∘ cin j) (snd (F <#> g) a) ∙ ap f (! (glue (cin j a))) ∙ fₚ a)) r s w ◃∎
+          lemma idp idp w = =ₛ-in idp
 
-      Reduce4 : {x : Colim (ConsDiag Γ A)} (p : cin j a == x) {z : A} (e : z == [id] x) {w : ty T} (u : w == fun T z) →
+      Reduce4 : {x : Colim (ConsDiag Γ A)} (p : cin j a == x) {z : A} (e : z == [id] x) {w : ty T} (u : w == fun T z)
+        →
         (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ ! (ap (fun T) e) ∙ ! u
-         == ! (ap (f ∘ right) (ap ψ p)) ∙ ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)) ∙
-            (ap (f ∘ right) (ap ψ p) ∙ (ap f (! (glue x)) ∙ fₚ ([id] x)) ∙ ! (ap (fun T) e)) ∙ ! u
+          ==
+        ! (ap (f ∘ right) (ap ψ p)) ∙ ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)) ∙
+        (ap (f ∘ right) (ap ψ p) ∙ (ap f (! (glue x)) ∙ fₚ ([id] x)) ∙ ! (ap (fun T) e)) ∙ ! u
       Reduce4 idp {z = z} e u = R4lemma (glue (cin j a)) (fₚ a) (! (ap (fun T) e)) (! u)
-          module _ where
-            R4lemma : {x n : P} (r : n == x) {y d c : ty T} (s : f n == y) (q : y == d) (U : d == c)
-              → (! (ap f r) ∙ s) ∙ q ∙ U == ((! (ap f r) ∙ s) ∙
-              ! (ap f (! r) ∙ s)) ∙ ((ap f (! r) ∙ s) ∙ q) ∙ U
-            R4lemma idp idp q U = idp
+        module _ where
+          R4lemma : {x n : P} (r : n == x) {y d c : ty T} (s : f n == y) (q : y == d) (U : d == c)
+            → (! (ap f r) ∙ s) ∙ q ∙ U == ((! (ap f r) ∙ s) ∙ ! (ap f (! r) ∙ s)) ∙ ((ap f (! r) ∙ s) ∙ q) ∙ U
+          R4lemma idp idp q U = idp
 
       CommSq4 : {x : Colim (ConsDiag Γ A)} (p : cin j a == x) {e : a == [id] x} (K : ap [id] p == e) (u : f (right (ψ x)) == fun T a)
-          → ! (ap (λ q →  (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ q) (ap (λ q → q ∙ ! u) (ap (λ q → ! (ap (fun T) q)) K))) ◃∙ (Reduce3 p (! u) ◃∙
-            (ap (λ q → ! (ap (f ∘ right) (ap ψ p)) ∙ ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)) ∙ q ∙ ! u)
-              (O₄ {u = fun T} (λ x → ap f (! (glue x)) ∙ fₚ ([id] x)) p K) ◃∎))
-          =ₛ Reduce4 p e u ◃∎
+        →
+        ! (ap (λ q →  (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ q) (ap (λ q → q ∙ ! u) (ap (λ q → ! (ap (fun T) q)) K))) ◃∙
+        (Reduce3 p (! u) ◃∙
+        (ap (λ q → ! (ap (f ∘ right) (ap ψ p)) ∙ ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)) ∙ q ∙ ! u)
+          (O₄ {u = fun T} (λ x → ap f (! (glue x)) ∙ fₚ ([id] x)) p K) ◃∎))
+          =ₛ
+        Reduce4 p e u ◃∎
       CommSq4 idp idp u = lemma (glue (cin j a)) (fₚ a)
-          where
-            lemma : {x : P} (r : left a == x) (s : f (left a) == fun T a) 
-              → (idp ◃∙ R3lemma (! u) r s (! u) ◃∙ ap (λ q →  ((! (ap f r) ∙ s) ∙ ! (ap f (! r) ∙ s)) ∙ q ∙ ! u)
-                (! (∙-unit-r (ap f (! r) ∙ s))) ◃∎)
-              =ₛ R4lemma idp u r s idp (! u) ◃∎
-            lemma idp s = subLemma s (! u)
-              where subLemma : {z : ty T} (S : f (left a) == z) (U : z == f (right (ψ (cin j a))))
-                      → idp ◃∙ R3lemma (! u) idp S U ◃∙ ap (λ q → (S ∙ ! S) ∙ q ∙ U) (! (∙-unit-r S)) ◃∎ =ₛ R4lemma idp u idp S idp U ◃∎
-                    subLemma idp U = =ₛ-in idp
+        where
+          lemma : {x : P} (r : left a == x) (s : f (left a) == fun T a)
+            →
+            (idp ◃∙ R3lemma (! u) r s (! u) ◃∙ ap (λ q →  ((! (ap f r) ∙ s) ∙ ! (ap f (! r) ∙ s)) ∙ q ∙ ! u) (! (∙-unit-r (ap f (! r) ∙ s))) ◃∎)
+              =ₛ
+            R4lemma idp u r s idp (! u) ◃∎
+          lemma idp s = subLemma s (! u)
+            where
+              subLemma : {z : ty T} (S : f (left a) == z) (U : z == f (right (ψ (cin j a))))
+                → idp ◃∙ R3lemma (! u) idp S U ◃∙ ap (λ q → (S ∙ ! S) ∙ q ∙ U) (! (∙-unit-r S)) ◃∎ =ₛ R4lemma idp u idp S idp U ◃∎
+              subLemma idp U = =ₛ-in idp
 
       CommSq5 : {x : Colim (ConsDiag Γ A)} (p : cin j a == x)
-          → Reduce4 p idp (ap f (! (glue x)) ∙ fₚ ([id] x)) ◃∙ O₅ {f = f ∘ right} ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙
-            ! (ap f (! (glue (cin j a))) ∙ fₚ a)) p (ap f (! (glue x)) ∙ fₚ ([id] x)) ◃∎
-          =ₛ ! (apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ ! (ap f (! (glue x)) ∙ fₚ ([id] x))) p) ◃∎
-      CommSq5 idp =  lemma (glue (cin j a)) (fₚ a)
-          where
-            lemma : {n : P} (r : n == right (ψ (cin j a))) {t : ty T} (s : f n == t)
-              → (R4lemma idp (ap f (! (glue (cin j a))) ∙ fₚ a) r s idp (! (ap f (! r) ∙ s))
-                ◃∙ O₅ {f = f ∘ right} {h = ψ} {b = cin j a} ((! (ap f r) ∙ s) ∙ ! (ap f (! r) ∙ s)) idp (ap f (! r) ∙ s) ◃∎)
-              =ₛ (idp ◃∎)
-            lemma idp idp = =ₛ-in idp
+        →
+        Reduce4 p idp (ap f (! (glue x)) ∙ fₚ ([id] x)) ◃∙
+        O₅ {f = f ∘ right} ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)) p (ap f (! (glue x)) ∙ fₚ ([id] x)) ◃∎
+          =ₛ
+        ! (apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ ! (ap f (! (glue x)) ∙ fₚ ([id] x))) p) ◃∎
+      CommSq5 idp = lemma (glue (cin j a)) (fₚ a)
+        where
+          lemma : {n : P} (r : n == right (ψ (cin j a))) {t : ty T} (s : f n == t)
+            →
+            R4lemma idp (ap f (! (glue (cin j a))) ∙ fₚ a) r s idp (! (ap f (! r) ∙ s)) ◃∙
+            O₅ {f = f ∘ right} {h = ψ} {b = cin j a} ((! (ap f r) ∙ s) ∙ ! (ap f (! r) ∙ s)) idp (ap f (! r) ∙ s) ◃∎
+              =ₛ
+            idp ◃∎
+          lemma idp idp = =ₛ-in idp
 
       BigReduct1 : PathSeq1 =ₛ ! (apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ ! (ap f (! (glue x)) ∙ fₚ ([id] x))) (cglue g a)) ◃∎
-      BigReduct1 = PathSeq1
-                     =ₛ⟨ 0 & 4 & !ₛ ω=ω-switch-ap-inv ⟩
-                   ω-ap-inv-switch ∙∙ (! (apd-concat-pres {F = λ x → ! (ap f (glue x)) ∙ fₚ ([id] x)} {G = σ (comp K) (comTri K)} (cglue g a)) ◃∙
-                     transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)))
-                     =ₛ⟨ 3 & 3 &  CommSq1 (cglue g a) (ψ-βr g a) ⟩
-                   (range 0 3 ω-ap-inv-switch) ∙∙ (Reduce1 (cglue g a) ◃∙ (range 1 4 (transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙
-                     ! (ap f (! (glue (cin j a))) ∙ fₚ a)))))
-                     =ₛ⟨ 2 & 3 & CommSq2 (cglue g a) (recc-βr K g (fun (F # i) a))  ⟩ 
-                   (range 0 2 ω-ap-inv-switch) ∙∙ (Reduce2 (cglue g a) {R = ap f (ap right (cglue g (fun (F # i) a)))} ◃∙
-                   (range 2 3 (transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)))))
-                     =ₛ⟨ 1 & 3 & CommSq3 (cglue g a) (ap ! (snd (comTri K g) a)) ⟩ 
-                   (range 0 1 ω-ap-inv-switch) ∙∙ (Reduce3 (cglue g a) (! (ap f (! (glue (cin i a))) ∙ fₚ a)) ◃∙
-                   (range 3 2 (transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)))))
-                     =ₛ⟨ 0  & 3  & CommSq4 (cglue g a) (id-βr g a) (ap f (! (glue (cin i a))) ∙ fₚ a) ⟩ 
-                   Reduce4 (cglue g a) idp (ap f (! (glue (cin i a))) ∙ fₚ a) ◃∙ O₅ ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a))
-                   (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a) ◃∎
-                     =ₛ⟨ CommSq5 (cglue g a) ⟩ 
-                   ! (apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ ! (ap f (! (glue x)) ∙ fₚ ([id] x))) (cglue g a)) ◃∎ ∎ₛ
+      BigReduct1 =
+        PathSeq1
+          =ₛ⟨ 0 & 4 & !ₛ ω=ω-switch-ap-inv ⟩
+        ω-ap-inv-switch ∙∙
+        (! (apd-concat-pres {F = λ x → ! (ap f (glue x)) ∙ fₚ ([id] x)} {G = σ (comp K) (comTri K)} (cglue g a)) ◃∙
+        transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)))
+          =ₛ⟨ 3 & 3 &  CommSq1 (cglue g a) (ψ-βr g a) ⟩
+        (range 0 3 ω-ap-inv-switch) ∙∙
+        (Reduce1 (cglue g a) ◃∙
+        (range 1 4 (transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)))))
+          =ₛ⟨ 2 & 3 & CommSq2 (cglue g a) (recc-βr K g (fun (F # i) a)) ⟩
+        (range 0 2 ω-ap-inv-switch) ∙∙
+        (Reduce2 (cglue g a) {R = ap f (ap right (cglue g (fun (F # i) a)))} ◃∙
+        (range 2 3 (transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)))))
+          =ₛ⟨ 1 & 3 & CommSq3 (cglue g a) (ap ! (snd (comTri K g) a)) ⟩ 
+        (range 0 1 ω-ap-inv-switch) ∙∙
+        (Reduce3 (cglue g a) (! (ap f (! (glue (cin i a))) ∙ fₚ a)) ◃∙
+        (range 3 2 (transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)))))
+          =ₛ⟨ 0  & 3  & CommSq4 (cglue g a) (id-βr g a) (ap f (! (glue (cin i a))) ∙ fₚ a) ⟩ 
+        Reduce4 (cglue g a) idp (ap f (! (glue (cin i a))) ∙ fₚ a) ◃∙
+        O₅ ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)) (cglue g a) (ap f (! (glue (cin i a))) ∙ fₚ a) ◃∎
+          =ₛ⟨ CommSq5 (cglue g a) ⟩ 
+        ! (apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ ! (ap f (! (glue x)) ∙ fₚ ([id] x))) (cglue g a)) ◃∎ ∎ₛ
 
       abstract
-
         apdRW1 :
-          apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ σ (comp K) (comTri K) x) (cglue g a) ◃∎ =ₛ
+          apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ σ (comp K) (comTri K) x) (cglue g a) ◃∎
+            =ₛ
           apd-concat-pres {F = λ x → ! (ap f (glue x)) ∙ fₚ ([id] x)} {G = σ (comp K) (comTri K)} (cglue g a) ◃∙
           ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ p) (↯ ω) ◃∎
-        apdRW1 = apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ σ (comp K) (comTri K) x) (cglue g a) ◃∎
-                   =ₛ⟨ apd-concat-fun-s (cglue g a) ⟩
-                 apd-concat-pres (cglue g a) ◃∙ ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ p)
-                 (apd-tr (σ (comp K) (comTri K)) (cglue g a)) ◃∎
-                   =ₛ⟨ 1 & 1 & =ₛ-in (ap (ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ p)) (σ-β K g a)) ⟩
-                 apd-concat-pres (cglue g a) ◃∙ ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ p) (↯ ω) ◃∎ ∎ₛ
+        apdRW1 =
+          apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ σ (comp K) (comTri K) x) (cglue g a) ◃∎
+            =ₛ⟨ apd-concat-fun-s (cglue g a) ⟩
+          apd-concat-pres (cglue g a) ◃∙
+          ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ p) (apd-tr (σ (comp K) (comTri K)) (cglue g a)) ◃∎
+            =ₛ⟨ 1 & 1 & =ₛ-in (ap (ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ p)) (σ-β K g a)) ⟩
+          apd-concat-pres (cglue g a) ◃∙
+          ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ p) (↯ ω) ◃∎ ∎ₛ

--- a/Colimit-code/L-R-L/CC-Equiv-LRL-4.agda
+++ b/Colimit-code/L-R-L/CC-Equiv-LRL-4.agda
@@ -21,56 +21,58 @@ module Constr5 {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type ℓ} (
     abstract
 
       LeftRW₁ :
-        (! (ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ p) (↯ ω))) ◃∙
+        ! (ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ p) (↯ ω)) ◃∙
         ! (apd-concat-pres {F = λ x → ! (ap f (glue x)) ∙ fₚ ([id] x)} {G = σ (comp K) (comTri K)} (cglue g a)) ◃∙
-          transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a))
+        transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a))
           =ₛ
-        (! (↯ (ap-seq (λ p → (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ p) ω))) ◃∙
+        ! (↯ (ap-seq (λ p → (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ p) ω)) ◃∙
         ! (apd-concat-pres {F = λ x → ! (ap f (glue x)) ∙ fₚ ([id] x)} {G = σ (comp K) (comTri K)} (cglue g a)) ◃∙
         transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a))
       LeftRW₁ =
-        (! (ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ p) (↯ ω))) ◃∙
+        ! (ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ p) (↯ ω)) ◃∙
         ! (apd-concat-pres {F = λ x → ! (ap f (glue x)) ∙ fₚ ([id] x)} {G = σ (comp K) (comTri K)} (cglue g a)) ◃∙
         transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a))
-          =ₛ⟨ =ₛ-in (ap (λ r → r ∙ ! (apd-concat-pres {F = λ x → ! (ap f (glue x)) ∙ fₚ ([id] x)} {G = σ (comp K) (comTri K)} (cglue g a)) ∙
+          =ₛ⟨
+            =ₛ-in
+              (ap (λ r →
+                r ∙ ! (apd-concat-pres {F = λ x → ! (ap f (glue x)) ∙ fₚ ([id] x)} {G = σ (comp K) (comTri K)} (cglue g a)) ∙
                 ↯ (transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a))))
-                (ap ! (=ₛ-out (ap-seq-∙ (λ p → (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ p) ω)))) ⟩
-        (! (↯ (ap-seq (λ p → (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ p) ω))) ◃∙
+              (ap ! (=ₛ-out (ap-seq-∙ (λ p → (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ p) ω)))) ⟩
+        ! (↯ (ap-seq (λ p → (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ p) ω)) ◃∙
         ! (apd-concat-pres {F = λ x → ! (ap f (glue x)) ∙ fₚ ([id] x)} {G = σ (comp K) (comTri K)} (cglue g a)) ◃∙
         transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)) ∎ₛ
                     
       LeftRW₀ :
-        (! (apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ σ (comp K) (comTri K) x) (cglue g a))) ◃∙
+        ! (apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ σ (comp K) (comTri K) x) (cglue g a)) ◃∙
         transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a))
           =ₛ
-        (! (ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ p) (↯ ω))) ◃∙
+        ! (ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ p) (↯ ω)) ◃∙
         ! (apd-concat-pres {F = λ x → ! (ap f (glue x)) ∙ fₚ ([id] x)} {G = σ (comp K) (comTri K)} (cglue g a)) ◃∙
         transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a))
       LeftRW₀ =
-        (! (apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ σ (comp K) (comTri K) x) (cglue g a))) ◃∙
+        ! (apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ σ (comp K) (comTri K) x) (cglue g a)) ◃∙
         transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a))
           =ₛ⟨ 0 & 1 & !-=ₛ apdRW1 ⟩
-        (! (ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ p) (↯ ω))) ◃∙
+        ! (ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ p) (↯ ω)) ◃∙
         ! (apd-concat-pres {F = λ x → ! (ap f (glue x)) ∙ fₚ ([id] x)} {G = σ (comp K) (comTri K)} (cglue g a)) ◃∙
         transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)) ∎ₛ
                 
       LeftRW₂ :
-        (! (↯ (ap-seq (λ p → (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ p) ω))) ◃∙
+        ! (↯ (ap-seq (λ p → (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ p) ω)) ◃∙
         ! (apd-concat-pres {F = λ x → ! (ap f (glue x)) ∙ fₚ ([id] x)} {G = σ (comp K) (comTri K)} (cglue g a)) ◃∙
-          transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a))
+        transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a))
           =ₛ
         PathSeq1 
       LeftRW₂ =
-        (! (↯ (ap-seq (λ p → (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ p) ω))) ◃∙
+        ! (↯ (ap-seq (λ p → (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ p) ω)) ◃∙
         ! (apd-concat-pres {F = λ x → ! (ap f (glue x)) ∙ fₚ ([id] x)} {G = σ (comp K) (comTri K)} (cglue g a)) ◃∙
         transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a))
           =ₛ⟨ 0 & 1 & !-∙-seq (ap-seq (λ p → (! (ap f (glue (cin i a))) ∙ fₚ a) ∙ p) ω) ⟩
         PathSeq1 ∎ₛ
 
     abstract
-
       LeftRW :
-        (! (apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ σ (comp K) (comTri K) x) (cglue g a))) ◃∙
+        ! (apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ σ (comp K) (comTri K) x) (cglue g a)) ◃∙
         transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a))
           =ₛ
         ! (apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ ! (ap f (! (glue x)) ∙ fₚ ([id] x))) (cglue g a)) ◃∎

--- a/Colimit-code/L-R-L/CC-Equiv-LRL-5.agda
+++ b/Colimit-code/L-R-L/CC-Equiv-LRL-5.agda
@@ -34,79 +34,94 @@ module Constr6 {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type ℓ} (
     open DiagCoher5 i j f fₚ g a public
 
     abstract
-
+    
       RL-transfer : {x : Colim (ConsDiag Γ A)} (p : cin j a == x)
-          → ! (apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ ! (ap f (! (glue x)) ∙ fₚ ([id] x))) p)  ◃∙
-            ap (transport (λ z → f (right (ψ z)) == f (right (ψ z))) p) (ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
-            apd-tr-refl {f = f ∘ right} {h = ψ} p ◃∎
-          =ₛ ap-inv-canc f (glue x) (fₚ ([id] x)) ◃∎
+        →
+        ! (apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ ! (ap f (! (glue x)) ∙ fₚ ([id] x))) p)  ◃∙
+        ap (transport (λ z → f (right (ψ z)) == f (right (ψ z))) p) (ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
+        apd-tr-refl {f = f ∘ right} {h = ψ} p ◃∎
+          =ₛ
+        ap-inv-canc f (glue x) (fₚ ([id] x)) ◃∎
       RL-transfer idp = =ₛ-in (lemma (ap-inv-canc f (glue (cin j a)) (fₚ a)))
-          where lemma : {u v : f (right (ψ (cin j a))) == f (right (ψ (cin j a)))} (q : u == v) → ap (λ z → z) q ∙ idp == q
-                lemma idp = idp
+        where
+          lemma : {u v : f (right (ψ (cin j a))) == f (right (ψ (cin j a)))} (q : u == v) → ap (λ z → z) q ∙ idp == q
+          lemma idp = idp
 
-    RLfunHtpy1 :
-      transport (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ ap (fst (RLfun (f , fₚ))) (glue z) == RfunEq (f , fₚ) (ψ z)) (cglue g a) 𝕣₂ ◃∎ =ₛ
-      ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
-      ! (apd-tr (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (cglue g a)) ◃∙
-      ! (ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))
-        (ap (λ p → (! (ap f (glue (cin j (idf A a)))) ∙ fₚ ([id] (cin j (idf A a)))) ∙ p) (FPrecc-βr K (cin j (idf A a))))) ◃∙
-      ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))
-        (ap (λ p → (! (ap f (glue (cin j a))) ∙ fₚ a) ∙ p) (FPrecc-βr K (cin j a))) ◃∙
-      ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))(ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
-      apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎
-    RLfunHtpy1 = transport (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ ap (fst (RLfun (f , fₚ))) (glue z) == RfunEq (f , fₚ) (ψ z)) (cglue g a) 𝕣₂ ◃∎
-                    =ₛ⟨ transp-id-concat (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ ap (fst (RLfun (f , fₚ))) (glue z)) (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a)
-                        (ap (λ p → (! (ap f (glue (cin j a))) ∙ fₚ a) ∙ p) (FPrecc-βr K (cin j a))) (ap-inv-canc f (glue (cin j a)) (fₚ a))
-                        (dtransp-nat (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ ap (fst (RLfun (f , fₚ))) (glue z))
-                        (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (λ z → ap (λ p → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ p)
-                        (FPrecc-βr K z)) (cglue g a)) ⟩
-                  (ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ∙
-                    ! (apd-tr (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (cglue g a)) ∙
-                    ! (ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))
-                      (ap (λ p → (! (ap f (glue (cin j (idf A a)))) ∙ fₚ ([id] (cin j (idf A a)))) ∙ p) (FPrecc-βr K (cin j (idf A a)))))) ◃∙
-                  ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))
-                    (ap (λ p → (! (ap f (glue (cin j a))) ∙ fₚ a) ∙ p) (FPrecc-βr K (cin j a))) ◃∙
-                  ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))(ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
-                  apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎
-                    =ₑ⟨ 0 & 1 & ( ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
-                  ! (apd-tr (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (cglue g a)) ◃∙
-                  ! (ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))
-                    (ap (λ p → (! (ap f (glue (cin j (idf A a)))) ∙ fₚ ([id] (cin j (idf A a)))) ∙ p) (FPrecc-βr K (cin j (idf A a))))) ◃∎)  % =ₛ-in idp   ⟩
-                  ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
-                  ! (apd-tr (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (cglue g a)) ◃∙
-                  ! (ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))
-                    (ap (λ p → (! (ap f (glue (cin j (idf A a)))) ∙ fₚ ([id] (cin j (idf A a)))) ∙ p) (FPrecc-βr K (cin j (idf A a))))) ◃∙
-                  ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))
-                    (ap (λ p → (! (ap f (glue (cin j a))) ∙ fₚ a) ∙ p) (FPrecc-βr K (cin j a))) ◃∙
-                  ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))(ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
-                  apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎ ∎ₛ
+      RLfunHtpy1 :
+        transport (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ ap (fst (RLfun (f , fₚ))) (glue z) == RfunEq (f , fₚ) (ψ z)) (cglue g a) 𝕣₂ ◃∎
+          =ₛ
+        ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
+        ! (apd-tr (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (cglue g a)) ◃∙
+        ! (ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))
+            (ap (λ p → (! (ap f (glue (cin j (idf A a)))) ∙ fₚ ([id] (cin j (idf A a)))) ∙ p) (FPrecc-βr K (cin j (idf A a))))) ◃∙
+        ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))
+          (ap (λ p → (! (ap f (glue (cin j a))) ∙ fₚ a) ∙ p) (FPrecc-βr K (cin j a))) ◃∙
+        ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))(ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
+        apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎
+      RLfunHtpy1 =
+        transport (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ ap (fst (RLfun (f , fₚ))) (glue z) == RfunEq (f , fₚ) (ψ z)) (cglue g a) 𝕣₂ ◃∎
+          =ₛ⟨ transp-id-concat (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ ap (fst (RLfun (f , fₚ))) (glue z))
+                (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a)
+                (ap (λ p → (! (ap f (glue (cin j a))) ∙ fₚ a) ∙ p) (FPrecc-βr K (cin j a)))
+                (ap-inv-canc f (glue (cin j a)) (fₚ a))
+                (dtransp-nat (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ ap (fst (RLfun (f , fₚ))) (glue z))
+                  (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z)
+                  (λ z → ap (λ p → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ p) (FPrecc-βr K z))
+                  (cglue g a)) ⟩
+        (ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ∙
+        ! (apd-tr (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (cglue g a)) ∙
+        ! (ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))
+            (ap (λ p → (! (ap f (glue (cin j (idf A a)))) ∙ fₚ ([id] (cin j (idf A a)))) ∙ p) (FPrecc-βr K (cin j (idf A a)))))) ◃∙
+        ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))
+          (ap (λ p → (! (ap f (glue (cin j a))) ∙ fₚ a) ∙ p) (FPrecc-βr K (cin j a))) ◃∙
+        ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))(ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
+        apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎
+          =ₑ⟨ 0 & 1 &
+            (ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
+            ! (apd-tr (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (cglue g a)) ◃∙
+            ! (ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))
+                (ap (λ p → (! (ap f (glue (cin j (idf A a)))) ∙ fₚ ([id] (cin j (idf A a)))) ∙ p) (FPrecc-βr K (cin j (idf A a))))) ◃∎)
+            % =ₛ-in idp ⟩
+        ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
+        ! (apd-tr (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (cglue g a)) ◃∙
+        ! (ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))
+            (ap (λ p → (! (ap f (glue (cin j (idf A a)))) ∙ fₚ ([id] (cin j (idf A a)))) ∙ p) (FPrecc-βr K (cin j (idf A a))))) ◃∙
+        ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))
+          (ap (λ p → (! (ap f (glue (cin j a))) ∙ fₚ a) ∙ p) (FPrecc-βr K (cin j a))) ◃∙
+        ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))(ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
+        apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎ ∎ₛ
 
-    RLfunHtpy2 :  ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
-                  ! (apd-tr (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (cglue g a)) ◃∙
-                  ! (ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))
-                    (ap (λ p → (! (ap f (glue (cin j (idf A a)))) ∙ fₚ ([id] (cin j (idf A a)))) ∙ p) (FPrecc-βr K (cin j (idf A a))))) ◃∙
-                  ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))
-                    (ap (λ p → (! (ap f (glue (cin j a))) ∙ fₚ a) ∙ p) (FPrecc-βr K (cin j a))) ◃∙
-                  ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))(ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
-                  apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎
-                    =ₛ ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
-                  ! (apd-tr (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (cglue g a)) ◃∙
-                  idp ◃∙
-                  ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))(ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
-                  apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎
-    RLfunHtpy2 =
-                  ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
-                  ! (apd-tr (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (cglue g a)) ◃∙
-                  ! (ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))
-                    (ap (λ p → (! (ap f (glue (cin j (idf A a)))) ∙ fₚ ([id] (cin j (idf A a)))) ∙ p) (FPrecc-βr K (cin j (idf A a))))) ◃∙
-                  ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))
-                    (ap (λ p → (! (ap f (glue (cin j a))) ∙ fₚ a) ∙ p) (FPrecc-βr K (cin j a))) ◃∙
-                  ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))(ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
-                  apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎
-                    =ₑ⟨ 2 & 2 & (idp ◃∎)  % =ₛ-in (!-inv-l (ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))
-                      (ap (λ p → (! (ap f (glue (cin j a))) ∙ fₚ a) ∙ p) (FPrecc-βr K (cin j a))))) ⟩
-                  ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
-                  ! (apd-tr (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (cglue g a)) ◃∙
-                  idp ◃∙
-                  ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))(ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
-                  apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎ ∎ₛ
+      RLfunHtpy2 :
+        ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
+        ! (apd-tr (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (cglue g a)) ◃∙
+        ! (ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))
+            (ap (λ p → (! (ap f (glue (cin j (idf A a)))) ∙ fₚ ([id] (cin j (idf A a)))) ∙ p) (FPrecc-βr K (cin j (idf A a))))) ◃∙
+        ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))
+          (ap (λ p → (! (ap f (glue (cin j a))) ∙ fₚ a) ∙ p) (FPrecc-βr K (cin j a))) ◃∙
+        ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))(ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
+        apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎
+          =ₛ
+        ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
+        ! (apd-tr (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (cglue g a)) ◃∙
+        idp ◃∙
+        ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))(ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
+        apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎
+      RLfunHtpy2 =
+        ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
+        ! (apd-tr (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (cglue g a)) ◃∙
+        ! (ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))
+            (ap (λ p → (! (ap f (glue (cin j (idf A a)))) ∙ fₚ ([id] (cin j (idf A a)))) ∙ p) (FPrecc-βr K (cin j (idf A a))))) ◃∙
+        ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))
+          (ap (λ p → (! (ap f (glue (cin j a))) ∙ fₚ a) ∙ p) (FPrecc-βr K (cin j a))) ◃∙
+        ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))(ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
+        apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎
+          =ₑ⟨ 2 & 2 & (idp ◃∎)
+            % =ₛ-in
+              (!-inv-l
+                (ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))
+                  (ap (λ p → (! (ap f (glue (cin j a))) ∙ fₚ a) ∙ p) (FPrecc-βr K (cin j a))))) ⟩
+        ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
+        ! (apd-tr (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (cglue g a)) ◃∙
+        idp ◃∙
+        ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))(ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
+        apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎ ∎ₛ

--- a/Colimit-code/L-R-L/CC-Equiv-LRL-6.agda
+++ b/Colimit-code/L-R-L/CC-Equiv-LRL-6.agda
@@ -19,80 +19,90 @@ module Constr7 {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type ℓ} (
 
     open Constr6.DiagCoher6 F T i j f fₚ g a
 
-    RLfunHtpy3 :  ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
-                  ! (apd-tr (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (cglue g a)) ◃∙
-                  idp ◃∙
-                  ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))(ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
-                  apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎
-                    =ₛ ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
-                  ! (apd-tr (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (cglue g a)) ◃∙
-                  ↯ (transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)))  ◃∙
-                  ap (transport (λ z → f (right (ψ z)) == f (right (ψ z))) (cglue g a))(ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
-                  ! (↯ (transpEq-s idp))  ◃∙
-                  apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎
-    RLfunHtpy3 =
-                  ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
-                  ! (apd-tr (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (cglue g a)) ◃∙
-                  idp ◃∙
-                  ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))(ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
-                  apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎
-                    =ₑ⟨ 2 & 2 & (↯ (transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)))  ◃∙
-                  ap (transport (λ z → f (right (ψ z)) == f (right (ψ z))) (cglue g a))(ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
-                  ! (↯ (transpEq-s idp)) ◃∎)  % =ₛ-in (=ₛ-out MidRW) ⟩
-                  ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
-                  ! (apd-tr (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (cglue g a)) ◃∙
-                  ↯ (transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)))  ◃∙
-                  ap (transport (λ z → f (right (ψ z)) == f (right (ψ z))) (cglue g a))(ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
-                  ! (↯ (transpEq-s idp))  ◃∙
-                  apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎ ∎ₛ
-                  
-    RLfunHtpy4 :  ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
-                  ! (apd-tr (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (cglue g a)) ◃∙
-                  ↯ (transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)))  ◃∙
-                  ap (transport (λ z → f (right (ψ z)) == f (right (ψ z))) (cglue g a))(ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
-                  ! (↯ (transpEq-s idp))  ◃∙
-                  apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎
-                    =ₛ ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
-                  ! (apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ ! (ap f (! (glue x)) ∙ fₚ ([id] x))) (cglue g a))  ◃∙
-                  ap (transport (λ z → f (right (ψ z)) == f (right (ψ z))) (cglue g a)) (ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
-                  ! (↯ (transpEq-s idp))  ◃∙
-                  apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎
-    RLfunHtpy4 =
-                  ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
-                  ! (apd-tr (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (cglue g a)) ◃∙
-                  ↯ (transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)))  ◃∙
-                  ap (transport (λ z → f (right (ψ z)) == f (right (ψ z))) (cglue g a))(ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
-                  ! (↯ (transpEq-s idp))  ◃∙
-                  apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎
-                   =ₑ⟨ 1 & 2 & (! (apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ ! (ap f (! (glue x)) ∙ fₚ ([id] x))) (cglue g a)) ◃∎)  % =ₛ-in (=ₛ-out (LeftRW)) ⟩
-                  ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
-                  ! (apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ ! (ap f (! (glue x)) ∙ fₚ ([id] x))) (cglue g a))  ◃∙
-                  ap (transport (λ z → f (right (ψ z)) == f (right (ψ z))) (cglue g a)) (ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
-                  ! (↯ (transpEq-s idp))  ◃∙
-                  apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎ ∎ₛ
-
-    RLfunHtpy5 :  ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
-                  ! (apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ ! (ap f (! (glue x)) ∙ fₚ ([id] x))) (cglue g a))  ◃∙
-                  ap (transport (λ z → f (right (ψ z)) == f (right (ψ z))) (cglue g a)) (ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
-                  ! (↯ (transpEq-s idp))  ◃∙
-                  apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎
-                    =ₛ 𝕣₁
-    RLfunHtpy5 =
-                  ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
-                  ! (apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ ! (ap f (! (glue x)) ∙ fₚ ([id] x))) (cglue g a))  ◃∙
-                  ap (transport (λ z → f (right (ψ z)) == f (right (ψ z))) (cglue g a)) (ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
-                  ! (↯ (transpEq-s idp))  ◃∙
-                  apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎
-                    =ₑ⟨ 3 & 2 & (apd-tr-refl {f = f ∘ right} {h = ψ} (cglue g a) ◃∎) % RightRW  ⟩
-                  ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p)
-                    (FPrecc-βr K (cin i a)) ◃∙
-                  ! (apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ ! (ap f (! (glue x)) ∙ fₚ ([id] x))) (cglue g a)) ◃∙
-                  ap (transport (λ z → f (right (ψ z)) == f (right (ψ z))) (cglue g a)) (ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
-                  apd-tr-refl {f = f ∘ right} {h = ψ} (cglue g a) ◃∎
-                    =ₑ⟨ 1 & 3 & (ap-inv-canc f (glue (cin i a)) (fₚ a) ◃∎) % RL-transfer (cglue g a) ⟩
-                  𝕣₁ ∎ₛ 
-
     abstract
 
-      RLfunHtpy : transport (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ ap (fst (RLfun (f , fₚ))) (glue z) == RfunEq (f , fₚ) (ψ z)) (cglue g a) 𝕣₂ ◃∎ =ₛ 𝕣₁
+      RLfunHtpy3 :
+        ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
+        ! (apd-tr (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (cglue g a)) ◃∙
+        idp ◃∙
+        ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))(ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
+        apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎
+          =ₛ
+        ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
+        ! (apd-tr (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (cglue g a)) ◃∙
+        ↯ (transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a))) ◃∙
+        ap (transport (λ z → f (right (ψ z)) == f (right (ψ z))) (cglue g a))(ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
+        ! (↯ (transpEq-s idp)) ◃∙
+        apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎
+      RLfunHtpy3 =
+        ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
+        ! (apd-tr (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (cglue g a)) ◃∙
+        idp ◃∙
+        ap (transport (λ z → f (right (ψ z)) == fst (RLfun (f , fₚ)) (right (ψ z))) (cglue g a))(ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
+        apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎
+          =ₑ⟨ 2 & 2 &
+            (↯ (transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a))) ◃∙
+            ap (transport (λ z → f (right (ψ z)) == f (right (ψ z))) (cglue g a))(ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
+            ! (↯ (transpEq-s idp)) ◃∎)
+            % =ₛ-in (=ₛ-out MidRW) ⟩
+        ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
+        ! (apd-tr (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (cglue g a)) ◃∙
+        ↯ (transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a))) ◃∙
+        ap (transport (λ z → f (right (ψ z)) == f (right (ψ z))) (cglue g a))(ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
+        ! (↯ (transpEq-s idp))  ◃∙
+        apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎ ∎ₛ
+
+      RLfunHtpy4 :
+        ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
+        ! (apd-tr (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (cglue g a)) ◃∙
+        ↯ (transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a))) ◃∙
+        ap (transport (λ z → f (right (ψ z)) == f (right (ψ z))) (cglue g a))(ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
+        ! (↯ (transpEq-s idp)) ◃∙
+        apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎
+          =ₛ ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
+        ! (apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ ! (ap f (! (glue x)) ∙ fₚ ([id] x))) (cglue g a)) ◃∙
+        ap (transport (λ z → f (right (ψ z)) == f (right (ψ z))) (cglue g a)) (ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
+        ! (↯ (transpEq-s idp)) ◃∙
+        apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎
+      RLfunHtpy4 =
+        ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
+        ! (apd-tr (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ σ (comp K) (comTri K) z) (cglue g a)) ◃∙
+        ↯ (transpEq-s ((! (ap f (glue (cin j a))) ∙ fₚ a) ∙ ! (ap f (! (glue (cin j a))) ∙ fₚ a)))  ◃∙
+        ap (transport (λ z → f (right (ψ z)) == f (right (ψ z))) (cglue g a))(ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
+        ! (↯ (transpEq-s idp))  ◃∙
+        apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎
+         =ₑ⟨ 1 & 2 & (! (apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ ! (ap f (! (glue x)) ∙ fₚ ([id] x))) (cglue g a)) ◃∎)  % =ₛ-in (=ₛ-out (LeftRW)) ⟩
+        ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
+        ! (apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ ! (ap f (! (glue x)) ∙ fₚ ([id] x))) (cglue g a))  ◃∙
+        ap (transport (λ z → f (right (ψ z)) == f (right (ψ z))) (cglue g a)) (ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
+        ! (↯ (transpEq-s idp))  ◃∙
+        apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎ ∎ₛ
+
+      RLfunHtpy5 :
+        ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
+        ! (apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ ! (ap f (! (glue x)) ∙ fₚ ([id] x))) (cglue g a))  ◃∙
+        ap (transport (λ z → f (right (ψ z)) == f (right (ψ z))) (cglue g a)) (ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
+        ! (↯ (transpEq-s idp))  ◃∙
+        apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎
+          =ₛ
+        𝕣₁
+      RLfunHtpy5 =
+        ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
+        ! (apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ ! (ap f (! (glue x)) ∙ fₚ ([id] x))) (cglue g a))  ◃∙
+        ap (transport (λ z → f (right (ψ z)) == f (right (ψ z))) (cglue g a)) (ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
+        ! (↯ (transpEq-s idp))  ◃∙
+        apd-tr (λ z → RfunEq (f , fₚ) (ψ z)) (cglue g a) ◃∎
+          =ₑ⟨ 3 & 2 & (apd-tr-refl {f = f ∘ right} {h = ψ} (cglue g a) ◃∎) % RightRW ⟩
+        ap (λ p → (! (ap f (glue (cin i a))) ∙ fₚ ([id] (cin i a))) ∙ p) (FPrecc-βr K (cin i a)) ◃∙
+        ! (apd-tr (λ x → (! (ap f (glue x)) ∙ fₚ ([id] x)) ∙ ! (ap f (! (glue x)) ∙ fₚ ([id] x))) (cglue g a)) ◃∙
+        ap (transport (λ z → f (right (ψ z)) == f (right (ψ z))) (cglue g a)) (ap-inv-canc f (glue (cin j a)) (fₚ a)) ◃∙
+        apd-tr-refl {f = f ∘ right} {h = ψ} (cglue g a) ◃∎
+          =ₑ⟨ 1 & 3 & (ap-inv-canc f (glue (cin i a)) (fₚ a) ◃∎) % RL-transfer (cglue g a) ⟩
+        𝕣₁ ∎ₛ 
+
+    abstract
+      RLfunHtpy :
+        transport (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ ap (fst (RLfun (f , fₚ))) (glue z) == RfunEq (f , fₚ) (ψ z)) (cglue g a) 𝕣₂ ◃∎
+          =ₛ
+        𝕣₁
       RLfunHtpy = RLfunHtpy1 ∙ₛ (RLfunHtpy2 ∙ₛ (RLfunHtpy3 ∙ₛ (RLfunHtpy4 ∙ₛ RLfunHtpy5))) 

--- a/Colimit-code/L-R-L/CC-Equiv-LRL-7.agda
+++ b/Colimit-code/L-R-L/CC-Equiv-LRL-7.agda
@@ -17,15 +17,16 @@ module _ {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type ℓ} (F : Co
 
   open Constr F T
 
-  module _ (f : P → ty T) (fₚ : (a : A) → f (left a)  == fun T a) where
+  module _ (f : P → ty T) (fₚ : (a : A) → f (left a) == fun T a) where
 
     RLfunEqFun : f ∼ fst (RLfun (f , fₚ))
     RLfunEqFun =
       PushoutMapEq f (fst (RLfun (f , fₚ))) fₚ (RfunEq (f , fₚ))
       (colimE (λ i a → ↯ (Constr6.𝕣 F T (f , fₚ) i a))
-        (λ i j g a → from-transp-g (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙
-        ap (fst (RLfun (f , fₚ))) (glue z) == RfunEq (f , fₚ) (ψ z)) (cglue g a)
-        (=ₛ-out (Constr7.DiagCoher7.RLfunHtpy F T i j f fₚ g a))))
+        (λ i j g a →
+          from-transp-g (λ z → (! (ap f (glue z)) ∙ fₚ ([id] z)) ∙ ap (fst (RLfun (f , fₚ))) (glue z)
+            ==
+          RfunEq (f , fₚ) (ψ z)) (cglue g a) (=ₛ-out (Constr7.DiagCoher7.RLfunHtpy F T i j f fₚ g a))))
 
     RLfunEqBP : (a : A) → ! (RLfunEqFun (left a)) ∙ fₚ a == idp
     RLfunEqBP a = !-inv-l (fₚ a)

--- a/Colimit-code/L-R-L/CC-v2-rewrite.agda
+++ b/Colimit-code/L-R-L/CC-v2-rewrite.agda
@@ -21,54 +21,74 @@ module _ {ℓv ℓe ℓ ℓd} {Γ : Graph ℓv ℓe} {A : Type ℓ} (F : CosDiag
     κ = PostComp ColCoC (f , fₚ)
 
     Ω : ! (fst (comTri κ g) (fun (F # i) a)) ∙ snd (< A > comp κ j ∘ F <#> g) a =-= snd (comp κ i) a
-    Ω = (ap-cp-revR f (right ∘ cin j ) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))) ◃∙ (ap (λ q → q ∙ fₚ a)
-      (ap (ap f) (E₁-v2 {g = cin j} {R = cglue g (fun (F # i) a)}
-        (snd (F <#> g) a)))) ◃∙ (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₂-v2 {p = ap ψ (cglue g a)} (ψ-βr g a) (! (glue (cin j a)))))) ◃∙
+    Ω =
+      ap-cp-revR f (right ∘ cin j ) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a))) ◃∙
+      ap (λ q → q ∙ fₚ a) (ap (ap f) (E₁-v2 {g = cin j} {R = cglue g (fun (F # i) a)} (snd (F <#> g) a))) ◃∙
+      ap (λ q → q ∙ fₚ a) (ap (ap f) (E₂-v2 {p = ap ψ (cglue g a)} (ψ-βr g a) (! (glue (cin j a))))) ◃∙
       (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₃-v2 {f = left} {v = ψ} {u = right} (λ x → ! (glue x)) (cglue g a) (id-βr g a)))) ◃∎
-          
-    Ω-pth4 : ! (↯ (ap-seq (λ q → (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap-seq ! Ω))) ◃∎ =ₛ
-         ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap (λ q → q ∙ fₚ a)
-           (ap (ap f) (E₃-v2 {f = left} {v = ψ} {u = right} (λ x → ! (glue x)) (cglue g a) (id-βr g a)))))) ◃∙
-         ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap (λ q → q ∙ fₚ a)
-           (ap (ap f) (E₂-v2 {p = ap ψ (cglue g a)} (ψ-βr g a) (! (glue (cin j a)))))))) ◃∙
-         ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap (λ q → q ∙ fₚ a)
-           (ap (ap f) (E₁-v2 {g = cin j} {R = cglue g (fun (F # i) a)} (snd (F <#> g) a)))))) ◃∙
-         ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap-cp-revR f (right ∘ cin j)
-           (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))))) ◃∎
-    Ω-pth4 = !-∙-seq (ap-seq (λ q → (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap-seq ! Ω))                                                    
-                                                                                                      
-    Ω-pth0 : snd (comTri κ g) a ◃∎ =ₛ Ω
-    Ω-pth0 = snd (comTri κ g) a ◃∎
-               =ₛ⟨ =ₛ-in idp ⟩
-             (ap-cp-revR f (right ∘ cin j ) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))) ◃∙ (ap (λ q → q ∙ fₚ a) (ap (ap f) (↯ (ϵ g g a)))) ◃∎
-               =ₛ₁⟨ 1 & 1 & ap (λ p → (ap (λ q → q ∙ fₚ a) (ap (ap f) p))) (=ₛ-out ϵ-Eq)  ⟩
-             (ap-cp-revR f (right ∘ cin j ) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))) ◃∙ (ap (λ q → q ∙ fₚ a) (ap (ap f) (↯ ϵ-v2))) ◃∎
-               =ₛ⟨ 1 & 1 & =ₛ-in (ap (λ p → ap (λ q → q ∙ fₚ a) p) (=ₛ-out (ap-seq-∙ (ap f) ϵ-v2))) ⟩
-             (ap-cp-revR f (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))) ◃∙ (ap (λ q → q ∙ fₚ a) (↯ (ap-seq (ap f) ϵ-v2))) ◃∎                               
-               =ₛ⟨ 1 & 1 & ap-seq-∙ (λ q → q ∙ fₚ a) (ap-seq (ap f) ϵ-v2) ⟩                                                                                                          
-             Ω ∎ₛ
-
-    Ω-pth2 : ! (ap (λ q → (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (↯ Ω))) ◃∎ =ₛ
-      ! (ap (λ q → (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (↯ (ap-seq ! Ω))) ◃∎
-    Ω-pth2 = =ₛ-in (ap (λ p → ! (ap (λ q → (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) p)) (=ₛ-out (ap-seq-∙ ! Ω)))
-    
-    Ω-pth3 : ! (ap (λ q → (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (↯ (ap-seq ! Ω))) ◃∎ =ₛ
-      ! (↯ (ap-seq (λ q → (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap-seq ! Ω))) ◃∎
-    Ω-pth3 = =ₛ-in (ap ! (=ₛ-out (ap-seq-∙ (λ q → (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap-seq ! Ω))))
-    
-    Ω-pth1 : ! (ap (λ q → (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (snd (comTri κ g) a))) ◃∎ =ₛ
-      ! (ap (λ q → (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (↯ Ω))) ◃∎
-    Ω-pth1 = =ₛ-in (ap (λ p → ! (ap (λ q → (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! p))) (=ₛ-out Ω-pth0))
 
     abstract
+      Ω-pth0 : snd (comTri κ g) a ◃∎ =ₛ Ω
+      Ω-pth0 =
+        snd (comTri κ g) a ◃∎
+          =ₛ⟨ =ₛ-in idp ⟩
+        ap-cp-revR f (right ∘ cin j ) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a))) ◃∙
+        ap (λ q → q ∙ fₚ a) (ap (ap f) (↯ (ϵ g g a))) ◃∎
+          =ₛ₁⟨ 1 & 1 & ap (λ p → (ap (λ q → q ∙ fₚ a) (ap (ap f) p))) (=ₛ-out ϵ-Eq) ⟩
+        ap-cp-revR f (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a))) ◃∙
+        ap (λ q → q ∙ fₚ a) (ap (ap f) (↯ ϵ-v2)) ◃∎
+          =ₛ⟨ 1 & 1 & =ₛ-in (ap (λ p → ap (λ q → q ∙ fₚ a) p) (=ₛ-out (ap-seq-∙ (ap f) ϵ-v2))) ⟩
+        ap-cp-revR f (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a))) ◃∙
+        ap (λ q → q ∙ fₚ a) (↯ (ap-seq (ap f) ϵ-v2)) ◃∎  
+          =ₛ⟨ 1 & 1 & ap-seq-∙ (λ q → q ∙ fₚ a) (ap-seq (ap f) ϵ-v2) ⟩                                                                                                          
+        Ω ∎ₛ
 
-      PathSeq2 : ! (ap (λ q → (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (snd (comTri κ g) a))) ◃∎ =ₛ
-            ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap (λ q → q ∙ fₚ a)
-              (ap (ap f) (E₃-v2 {f = left} {v = ψ} {u = right} (λ x → ! (glue x)) (cglue g a) (id-βr g a)))))) ◃∙
-            ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap (λ q → q ∙ fₚ a)
-              (ap (ap f) (E₂-v2 {p = ap ψ (cglue g a)} (ψ-βr g a) (! (glue (cin j a)))))))) ◃∙
-            ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₁-v2 {g = cin j}
-              {R = cglue g (fun (F # i) a)} (snd (F <#> g) a)))))) ◃∙
-            ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (ap-cp-revR f (right ∘ cin j ) (snd (F <#> g) a)
-              (ap right (cglue g (fun (F # i) a)))))) ◃∎
+    abstract
+    
+      Ω-pth1 :
+        ! (ap (λ q → (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (snd (comTri κ g) a))) ◃∎
+          =ₛ
+        ! (ap (λ q → (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (↯ Ω))) ◃∎
+      Ω-pth1 =
+        =ₛ-in (ap (λ p → ! (ap (λ q → (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! p))) (=ₛ-out Ω-pth0))
+
+      Ω-pth2 : !
+        (ap (λ q → (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (↯ Ω))) ◃∎
+          =ₛ
+        ! (ap (λ q → (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (↯ (ap-seq ! Ω))) ◃∎
+      Ω-pth2 =
+        =ₛ-in (ap (λ p → ! (ap (λ q → (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) p)) (=ₛ-out (ap-seq-∙ ! Ω)))
+
+      Ω-pth3 :
+        ! (ap (λ q → (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (↯ (ap-seq ! Ω))) ◃∎
+          =ₛ
+        ! (↯ (ap-seq (λ q → (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap-seq ! Ω))) ◃∎
+      Ω-pth3 =
+        =ₛ-in (ap ! (=ₛ-out (ap-seq-∙ (λ q → (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap-seq ! Ω))))
+
+      Ω-pth4 :
+        ! (↯ (ap-seq (λ q → (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap-seq ! Ω))) ◃∎
+          =ₛ
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+          (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₃-v2 {f = left} {v = ψ} {u = right} (λ x → ! (glue x)) (cglue g a) (id-βr g a)))))) ◃∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₂-v2 {p = ap ψ (cglue g a)} (ψ-βr g a) (! (glue (cin j a)))))))) ◃∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₁-v2 {g = cin j} {R = cglue g (fun (F # i) a)} (snd (F <#> g) a)))))) ◃∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+          (ap ! (ap-cp-revR f (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))))) ◃∎
+      Ω-pth4 = !-∙-seq (ap-seq (λ q → (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap-seq ! Ω))
+
+    abstract
+      PathSeq2 :
+        ! (ap (λ q → (! (ap (f ∘ right) (ap ψ (cglue g a)))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q) (ap ! (snd (comTri κ g) a))) ◃∎
+          =ₛ
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₃-v2 {f = left} {v = ψ} {u = right} (λ x → ! (glue x)) (cglue g a) (id-βr g a)))))) ◃∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₂-v2 {p = ap ψ (cglue g a)} (ψ-βr g a) (! (glue (cin j a)))))))) ◃∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap (λ q → q ∙ fₚ a) (ap (ap f) (E₁-v2 {g = cin j} {R = cglue g (fun (F # i) a)} (snd (F <#> g) a)))))) ◃∙
+        ! (ap (λ q → ! (ap (f ∘ right) (ap ψ (cglue g a))) ∙ (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ q)
+            (ap ! (ap-cp-revR f (right ∘ cin j ) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))))) ◃∎
       PathSeq2 = Ω-pth1 ∙ₛ (Ω-pth2 ∙ₛ (Ω-pth3 ∙ₛ Ω-pth4))

--- a/Colimit-code/Main-Theorem/CosColim-Adjunction.agda
+++ b/Colimit-code/Main-Theorem/CosColim-Adjunction.agda
@@ -1,8 +1,6 @@
 {-# OPTIONS --without-K --rewriting  #-}
 
 open import lib.Basics
-open import lib.types.Pushout
-open import lib.types.Span
 open import Coslice
 open import Diagram
 open import Cocone
@@ -35,8 +33,8 @@ module _ {ℓv ℓe ℓ} {Γ : Graph ℓv ℓe} {A : Type ℓ} where
 -- The first naturality square, arising from post-composition with the coslice map
 
   Iso-Nat-PostCmp : ∀ {ℓd ℓc₁ ℓc₂} (F : CosDiag ℓd ℓ A Γ) {T : Coslice ℓc₁ ℓ A} {U : Coslice ℓc₂ ℓ A}
-    (φ : T *→ U) (f* : (Cos (P F) left) *→ T) →
-    Map-to-Lim-map F φ (PostComp (ColCoC F) f*) == PostComp (ColCoC F) (φ ∘* f*)
+    (φ : T *→ U) (f* : (Cos (P F) left) *→ T)
+    → Map-to-Lim-map F φ (PostComp (ColCoC F) f*) == PostComp (ColCoC F) (φ ∘* f*)
   Iso-Nat-PostCmp F φ (f , fₚ) = CosColim-NatSq1-eq F φ f fₚ 
 
 -- The second naturality square, arising from pre-composition with the diagram map

--- a/Colimit-code/Main-Theorem/CosColim-Adjunction.agda
+++ b/Colimit-code/Main-Theorem/CosColim-Adjunction.agda
@@ -1,6 +1,7 @@
 {-# OPTIONS --without-K --rewriting  #-}
 
 open import lib.Basics
+open import lib.types.Pushout
 open import Coslice
 open import Diagram
 open import Cocone

--- a/Colimit-code/Main-Theorem/CosColim-Iso.agda
+++ b/Colimit-code/Main-Theorem/CosColim-Iso.agda
@@ -1,9 +1,7 @@
 {-# OPTIONS --without-K --rewriting  #-}
 
 open import lib.Basics
-open import lib.Equivalence2
 open import lib.types.Pushout
-open import lib.types.Span
 open import Coslice
 open import Diagram
 open import Colim

--- a/Colimit-code/Map-Nat/CosColimitMap00.agda
+++ b/Colimit-code/Map-Nat/CosColimitMap00.agda
@@ -21,7 +21,8 @@ module _ {ℓ₁ ℓ₂ ℓ₃} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type �
   pre-cmp-!-∙ : {x y : C} (p : x == y) {a : A} (q : h x == a) → ! (ap (f ∘ h) p) ∙ ap f q == ap f (! (ap h p) ∙ q)
   pre-cmp-!-∙ idp idp = idp
 
-  !-!-ap-cmp-rid3 : {x y : C} (p : x == y) {a : A} (q : h y == a) → ! (ap f (! (ap h (! p ∙ idp)) ∙ q ∙ idp)) ∙ ap (f ∘ h) p ∙ idp == ! (ap f q) ∙ idp
+  !-!-ap-cmp-rid3 : {x y : C} (p : x == y) {a : A} (q : h y == a)
+    → ! (ap f (! (ap h (! p ∙ idp)) ∙ q ∙ idp)) ∙ ap (f ∘ h) p ∙ idp == ! (ap f q) ∙ idp
   !-!-ap-cmp-rid3 idp idp = idp
 
 module _ {ℓ₁ ℓ₂} {A : Type ℓ₁} {B : Type ℓ₂} (f : A → B) where
@@ -50,14 +51,16 @@ module _ {ℓ₁ ℓ₂ ℓ₃} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type �
 module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type ℓ₃} {D : Type ℓ₄} (f : A → B) (h : C → A) (k : C → B) (m : B → D) where
 
   !-!-!-∘-∘-∘-rid : {x y : C} (p₁ : x == y) {z : A} (p₂ : h y == z) {b : A} (p₃ : b == z) {e : D} (p₆ : m (f z) == e) (p₅ : f (h y) == k y)
-    → ! (ap m (! (ap f (ap h p₁ ∙ p₂ ∙ ! p₃ ∙ idp)) ∙ ap (f ∘ h) p₁ ∙ p₅ ∙ ! (ap k p₁))) ∙ ap (m ∘ f) p₃ ∙ p₆
-    == ap (m ∘ k) p₁ ∙ ! (ap m p₅) ∙ ap (m ∘ f) p₂ ∙ p₆
+    →
+    ! (ap m (! (ap f (ap h p₁ ∙ p₂ ∙ ! p₃ ∙ idp)) ∙ ap (f ∘ h) p₁ ∙ p₅ ∙ ! (ap k p₁))) ∙ ap (m ∘ f) p₃ ∙ p₆
+      ==
+    ap (m ∘ k) p₁ ∙ ! (ap m p₅) ∙ ap (m ∘ f) p₂ ∙ p₆
   !-!-!-∘-∘-∘-rid idp p₂ p₃ p₆ p₅ = !-!-!-∘-rid f m p₂ p₃ p₆ p₅ 
 
 module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type ℓ₃} {D : Type ℓ₄} (f : A → B) (g : D → A) (h : C → A) where
 
-  long-red-!-∙ : {c₁ c₂ : C} (p₁ : c₁ == c₂) {a : A} (p₂ : h c₂ == a) {d₁ d₂ : D} (p₄ : d₁ == d₂) (p₃ : g d₂ == a) {b₁ b₂ : B}
-    (p₅ : f (h c₁) == b₁) (p₆ : f (h c₂) == b₂)
+  long-red-!-∙ : {c₁ c₂ : C} (p₁ : c₁ == c₂) {a : A} (p₂ : h c₂ == a) {d₁ d₂ : D} (p₄ : d₁ == d₂) (p₃ : g d₂ == a)
+    {b₁ b₂ : B} (p₅ : f (h c₁) == b₁) (p₆ : f (h c₂) == b₂)
     → ! (! (ap f (ap h p₁ ∙ p₂ ∙ ! p₃  ∙ ! (ap g p₄))) ∙ p₅) ∙ ap (f ∘ g) p₄ ∙ ap f p₃ ∙ ! (ap f p₂) ∙ p₆ == ! p₅ ∙ ap (f ∘ h) p₁ ∙ p₆
   long-red-!-∙ p₁ p₂ idp p₃ p₅ p₆ = ap-∘-!-!-rid-rid h f p₁ p₃ p₂ p₅ p₆
 
@@ -104,58 +107,72 @@ module ConstrMap {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ}
   module _ {i j : Obj Γ} (g : Hom Γ i j) (a : A) where
 
     ζ : transport (λ z → δ₀ (ψ₁ z) == ψ₂ z) (cglue g a) (ap (cin j) (snd (nat δ j) a)) =-= ap (cin i) (snd (nat δ i) a)
-    ζ = transport (λ z → δ₀ (ψ₁ z) == ψ₂ z) (cglue g a) (ap (cin j) (snd (nat δ j) a))
-          =⟪ transp-pth-cmpL δ₀ ψ₁ ψ₂ (cglue g a) (ap (cin j) (snd (nat δ j) a))  ⟫
-        ! (ap δ₀ (ap ψ₁ (cglue g a))) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)
-          =⟪ ap (λ p → ! (ap δ₀ p) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (ψ₁-βr g a)  ⟫
-        ! (ap δ₀ (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)
-          =⟪ pre-cmp-!-!-∙ δ₀ (cin j) (snd (F <#> g) a) (cglue g (fun (F # i) a)) (ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a))  ⟫
-        ! (ap δ₀ (cglue g (fun (F # i) a))) ∙ ap (cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)
-          =⟪ ap (λ p → ! p ∙ ap (cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (δ₀-βr g (fun (F # i) a)) ⟫
-        ! (! (ap (cin j) (comSq δ g (fun (F # i) a))) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) ∙ ap (cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (cin j)
-          (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a) 
-          =⟪ ap (λ p → ! p ∙ ap (cin j ∘ fst (nat δ j))
-            (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i)
-            (fun (F # i) a))) (comSq-coher δ g a))  ⟫
-        ! (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙ snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙
-          ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) ∙ ap (cin j ∘ fst (nat δ j))
-          (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)
-          =⟪ ap (λ p → ! (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙ snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙
-            ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) ∙ ap (cin j ∘ fst (nat δ j))
-            (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ p) (ψ₂-βr g a) ⟫
-        ! (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙ snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙
-          ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) ∙ ap (cin j ∘ fst (nat δ j))
-          (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ ! (ap (cin j) (snd (G <#> g) a)) ∙ cglue g (fun (G # i) a)
-          =⟪ long-red-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g)) (snd (nat δ i) a) (snd (G <#> g) a) (snd (F <#> g) a) (snd (nat δ j) a)
-            (cglue g (fst (nat δ i) (fun (F # i) a))) (cglue g (fun (G # i) a))  ⟫
-        ! (cglue g (fst (nat δ i) (fun (F # i) a))) ∙ ap (cin j ∘ fst (G <#> g)) (snd (nat δ i) a) ∙ cglue g (fun (G # i) a)
-          =⟪ apCommSq (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a) ⟫
-        ap (cin i) (snd (nat δ i) a) ∎∎
+    ζ =
+      transport (λ z → δ₀ (ψ₁ z) == ψ₂ z) (cglue g a) (ap (cin j) (snd (nat δ j) a))
+        =⟪ transp-pth-cmpL δ₀ ψ₁ ψ₂ (cglue g a) (ap (cin j) (snd (nat δ j) a))  ⟫
+      ! (ap δ₀ (ap ψ₁ (cglue g a))) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)
+        =⟪ ap (λ p → ! (ap δ₀ p) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (ψ₁-βr g a) ⟫
+      ! (ap δ₀ (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)
+        =⟪ pre-cmp-!-!-∙ δ₀ (cin j) (snd (F <#> g) a) (cglue g (fun (F # i) a)) (ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) ⟫
+      ! (ap δ₀ (cglue g (fun (F # i) a))) ∙ ap (cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)
+        =⟪ ap (λ p → ! p ∙ ap (cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (δ₀-βr g (fun (F # i) a)) ⟫
+      ! (! (ap (cin j) (comSq δ g (fun (F # i) a))) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) ∙
+      ap (cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
+      ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a) 
+        =⟪ ap (λ p → ! p ∙ ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a))
+             (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a)) ⟫
+      ! (! (ap (cin j)
+             (ap (fst (G <#> g)) (snd (nat δ i) a) ∙ snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙
+         cglue g (fst (nat δ i) (fun (F # i) a))) ∙ ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)
+        =⟪ ap (λ p →
+             ! (! (ap (cin j)
+                    (ap (fst (G <#> g)) (snd (nat δ i) a) ∙ snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙
+                  cglue g (fst (nat δ i) (fun (F # i) a))) ∙
+             ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ p)
+             (ψ₂-βr g a) ⟫
+      ! (! (ap (cin j)
+               (ap (fst (G <#> g)) (snd (nat δ i) a) ∙ snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙
+             cglue g (fst (nat δ i) (fun (F # i) a))) ∙
+      ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙
+      ! (ap (cin j) (snd (G <#> g) a)) ∙ cglue g (fun (G # i) a)
+        =⟪ long-red-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g)) (snd (nat δ i) a) (snd (G <#> g) a) (snd (F <#> g) a) (snd (nat δ j) a)
+             (cglue g (fst (nat δ i) (fun (F # i) a))) (cglue g (fun (G # i) a))  ⟫
+      ! (cglue g (fst (nat δ i) (fun (F # i) a))) ∙ ap (cin j ∘ fst (G <#> g)) (snd (nat δ i) a) ∙ cglue g (fun (G # i) a)
+        =⟪ apCommSq (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a) ⟫
+      ap (cin i) (snd (nat δ i) a) ∎∎
 
     Θ : ! (ap (right {d = SpCos₂}) (! (ap (cin j) (comSq δ g (fun (F # i) a))) ∙ cglue g (fst (nat δ i) (fun (F # i) a)))) ∙
-          ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))
-        =-=
+        ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))
+          =-=
       ap (right ∘ cin i) (snd (nat δ i) a) ∙ ! (glue (cin i a))
-    Θ = ! (ap (right {d = SpCos₂}) (! (ap (cin j) (comSq δ g (fun (F # i) a))) ∙ cglue g (fst (nat δ i) (fun (F # i) a)))) ∙
-          ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))
-          =⟪ ap (λ p → ! (ap (right {d = SpCos₂}) p) ∙
-            ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
-              (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a)) ⟫
-        ! (ap (right {d = SpCos₂}) (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙ snd (G <#> g) a ∙
-          ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ cglue g (fst (nat δ i) (fun (F # i) a)))) ∙
-          ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))
-          =⟪ ap (λ p → ! (ap (right {d = SpCos₂}) (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙ snd (G <#> g) a ∙
-          ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙ ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-            ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))  ⟫
-        ! (ap right (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙ snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙
-          ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ ap (cin j ∘ fst (G <#> g)) (snd (nat δ i) a) ∙
-          cglue g (fun (G # i) a) ∙ ! (ap (cin i) (snd (nat δ i) a)))) ∙ ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-          ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))
-          =⟪ long-red-ap-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g)) (cin i) right (snd (nat δ i) a) (snd (G <#> g) a) (snd (F <#> g) a)
-            (snd (nat δ j) a) (cglue g (fun (G # i) a)) (! (glue (cin j a))) ⟫
-        ap (right ∘ cin i) (snd (nat δ i) a) ∙ ! (ap right (cglue g (fun (G # i) a))) ∙ ap (right ∘ cin j) (snd (G <#> g) a) ∙ ! (glue (cin j a))
-          =⟪ ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p) (↯ (ϵ G g g a)) ⟫
-        ap (right ∘ cin i) (snd (nat δ i) a) ∙ ! (glue (cin i a)) ∎∎
+    Θ =
+      ! (ap (right {d = SpCos₂}) (! (ap (cin j) (comSq δ g (fun (F # i) a))) ∙ cglue g (fst (nat δ i) (fun (F # i) a)))) ∙
+      ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))
+        =⟪ ap (λ p → ! (ap (right {d = SpCos₂}) p) ∙
+                ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+             (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a)) ⟫
+      ! (ap (right {d = SpCos₂})
+          (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙ snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙
+          cglue g (fst (nat δ i) (fun (F # i) a)))) ∙
+      ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))
+        =⟪ ap (λ p →
+                ! (ap (right {d = SpCos₂}) (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙ snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙
+                  ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
+                ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
+                ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+              (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))  ⟫
+      ! (ap right
+          (! (ap (cin j)
+               (ap (fst (G <#> g)) (snd (nat δ i) a) ∙ snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙
+          ap (cin j ∘ fst (G <#> g)) (snd (nat δ i) a) ∙
+          cglue g (fun (G # i) a) ∙ ! (ap (cin i) (snd (nat δ i) a)))) ∙
+      ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
+      ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))
+        =⟪ long-red-ap-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g)) (cin i) right (snd (nat δ i) a) (snd (G <#> g) a) (snd (F <#> g) a)
+             (snd (nat δ j) a) (cglue g (fun (G # i) a)) (! (glue (cin j a))) ⟫
+      ap (right ∘ cin i) (snd (nat δ i) a) ∙ ! (ap right (cglue g (fun (G # i) a))) ∙ ap (right ∘ cin j) (snd (G <#> g) a) ∙ ! (glue (cin j a))
+        =⟪ ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p) (↯ (ϵ G g g a)) ⟫
+      ap (right ∘ cin i) (snd (nat δ i) a) ∙ ! (glue (cin i a)) ∎∎
 
   K-diag : CosCocone A F (Cos P₂ left)
   fst (comp K-diag i) = right ∘ cin i ∘ (fst (nat δ i))
@@ -171,9 +188,9 @@ module ConstrMap {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ}
   ℂ-β {i} {j} g a = =ₛ-in (
     apd-to-tr (λ z → δ₀ (ψ₁ z) == ψ₂ z) ℂ (cglue g a)
     (↯ (ζ g a))
-    (cglue-β (λ i a → ap (cin i) (snd (nat δ i) a))
-    (λ i j g a →  from-transp-g (λ z → δ₀ (ψ₁ z) == ψ₂ z)
-    (cglue g a) (↯ (ζ g a))) g a) ) 
+    (cglue-β
+      (λ i a → ap (cin i) (snd (nat δ i) a))
+      (λ i j g a →  from-transp-g (λ z → δ₀ (ψ₁ z) == ψ₂ z) (cglue g a) (↯ (ζ g a))) g a) ) 
 
   span-map-forg : SpanMap-Rev SpCos₁ SpCos₂
   SpanMap-Rev.hA span-map-forg = idf A
@@ -192,6 +209,8 @@ module ConstrMap {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ}
   
   𝕕-βr = PM.glue-β
 
-  ForgMap = colimR (λ i → right {d = SpCos₂} ∘ cin i ∘ (fst (nat δ i))) (λ i j g x → ap right (! (ap (cin j) (comSq δ g x)) ∙ cglue g (fst (nat δ i) x)))
+  ForgMap =
+    colimR (λ i → right {d = SpCos₂} ∘ cin i ∘ (fst (nat δ i))) (λ i j g x → ap right (! (ap (cin j) (comSq δ g x)) ∙ cglue g (fst (nat δ i) x)))
 
-  FM-βr = cglue-βr (λ i₁ → right {d = SpCos₂} ∘ cin i₁ ∘ fst (nat δ i₁)) (λ i₁ j₁ g₁ x₁ → ap right (! (ap (cin j₁) (comSq δ g₁ x₁)) ∙ cglue g₁ (fst (nat δ i₁) x₁)))
+  FM-βr =
+    cglue-βr (λ i₁ → right {d = SpCos₂} ∘ cin i₁ ∘ fst (nat δ i₁)) (λ i₁ j₁ g₁ x₁ → ap right (! (ap (cin j₁) (comSq δ g₁ x₁)) ∙ cglue g₁ (fst (nat δ i₁) x₁)))

--- a/Colimit-code/Map-Nat/CosColimitMap01.agda
+++ b/Colimit-code/Map-Nat/CosColimitMap01.agda
@@ -2,7 +2,6 @@
 
 open import lib.Basics
 open import lib.types.Pushout
-open import lib.types.Span
 open import Coslice
 open import Diagram
 open import AuxPaths
@@ -25,9 +24,8 @@ module ConstrMap2 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
   module MapCoher {i j : Obj Γ} (g : Hom Γ i j) (a : A) where
 
     𝕤 = E₁ (snd (F <#> g) a) (! (glue {d = SpCos₁} (cin j a))) ◃∙
-        ! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙
-          cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p)
-          (ap (ap left) (id-βr g a))) ◃∙
+        ! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p)
+            (ap (ap left) (id-βr g a))) ◃∙
         E₃ (λ x → ! (glue x)) (cglue g a) (ψ-βr F g a) (λ x → idp) ◃∙
         ∙-unit-r (! (glue (cin i a))) ◃∎
 
@@ -39,19 +37,18 @@ module ConstrMap2 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
           ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
           ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
       ap (λ p → ! (p ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
+           ! (glue (cin j a)))
+         (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
       ap (λ p → ! ((ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
-        ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙
-        !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙
+           (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
+           ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙ !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙
       long-path-red (snd (F <#> g) a) (ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
         (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)
         (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) idp ◃∙
-      ap (λ q → q) (ap-cp-revR 𝕕₀ (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a))) ∙
-        ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (↯ 𝕤))) ◃∙
+      ap (λ q → q) (ap-cp-revR 𝕕₀ (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a))) ∙ ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (↯ 𝕤))) ◃∙
       ap-inv-rid 𝕕₀ (glue (cin i a)) ◃∙
       ap ! (𝕕-βr (cin i a)) ◃∙
       !-!-ap-∘ (cin i) right (snd (nat δ i) a) (glue (cin i a)) ◃∎
@@ -92,9 +89,10 @@ module ConstrMap2 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
       ap (λ q → q) (↯ (ap-seq (λ p → p ∙ idp) (ap-seq (ap 𝕕₀) 𝕤))) ◃∎
         =ₛ⟨ ap-seq-∙ (λ q → q) (ap-seq (λ p → p ∙ idp) (ap-seq (ap 𝕕₀) 𝕤)) ⟩
       ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₁ (snd (F <#> g) a) (! (glue (cin j a)))))) ◃∙
-      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (! (ap (λ p → ! (ap right (! (ap (cin j)
-        (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p)
-        (ap (ap left) (id-βr g a)))))) ◃∙
+      ap (λ q → q)
+        (ap (λ p → p ∙ idp)
+          (ap (ap 𝕕₀)
+            (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a)))))) ◃∙
       ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₃ (λ x → ! (glue x)) (cglue g a)
         (ψ-βr F g a) (λ x → idp)))) ◃∙
       ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (∙-unit-r (! (glue (cin i a)))))) ◃∎ ∎ₛ
@@ -106,15 +104,15 @@ module ConstrMap2 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
           ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
           ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
           ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
-      ap (λ p → ! (p ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
+      ap (λ p →
+           ! (p ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙ ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
+           ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
       ap (λ p → ! ((ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
-        ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙
-        !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙
+           (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
+           ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙ !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙
       long-path-red (snd (F <#> g) a) (ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
         (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)
         (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) idp ◃∙
@@ -130,27 +128,25 @@ module ConstrMap2 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
           ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
           ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
           ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
-      ap (λ p → ! (p ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
-      ap (λ p → ! ((ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
-        ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙
-        !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙
+      ap (λ p → ! (p ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙  ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
+           ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
+      ap (λ p → ! ((ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
+          ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
+          ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
+          ! (glue (cin j a)))
+        (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙ !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙
       long-path-red (snd (F <#> g) a) (ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
         (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)
         (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) idp ◃∙
       ap (λ q → q) (ap-cp-revR 𝕕₀ (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))) ◃∙
       ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₁ (snd (F <#> g) a) (! (glue (cin j a)))))) ◃∙
-      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (! (ap (λ p → ! (ap right (! (ap (cin j)
-        (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p)
-        (ap (ap left) (id-βr g a)))))) ◃∙
-      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₃ (λ x → ! (glue x)) (cglue g a)
-        (ψ-βr F g a) (λ x → idp)))) ◃∙
+      ap (λ q → q)
+        (ap (λ p → p ∙ idp)
+          (ap (ap 𝕕₀) (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a)))))) ◃∙
+      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₃ (λ x → ! (glue x)) (cglue g a) (ψ-βr F g a) (λ x → idp)))) ◃∙
       ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (∙-unit-r (! (glue (cin i a)))))) ◃∙
-      ap-inv-rid 𝕕₀ (glue (cin i a)) ◃∙ -- transfer
-      ap ! (𝕕-βr (cin i a)) ◃∙  -- transfer
+      ap-inv-rid 𝕕₀ (glue (cin i a)) ◃∙
+      ap ! (𝕕-βr (cin i a)) ◃∙
       !-!-ap-∘ (cin i) right (snd (nat δ i) a) (glue (cin i a)) ◃∎ ∎ₛ
       

--- a/Colimit-code/Map-Nat/CosColimitMap02.agda
+++ b/Colimit-code/Map-Nat/CosColimitMap02.agda
@@ -2,7 +2,6 @@
 
 open import lib.Basics
 open import lib.types.Pushout
-open import lib.types.Span
 open import Coslice
 open import Diagram
 open import AuxPaths
@@ -27,8 +26,8 @@ module ConstrMap3 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
 
     𝕕-recc-transf1 =
       ap-inv-rid 𝕕₀ (glue (cin i a)) ◃∙ ap ! (𝕕-βr (cin i a)) ◃∎
-        =ₛ⟨ =ₛ-in (apd-tr-coher (λ z → ap 𝕕₀ (! (glue z)) ∙ idp) (λ z → ! (glue z ∙ ap right (! (ℂ z))))
-          (cglue g a) (λ z →  ap-inv-rid 𝕕₀ (glue z) ∙ ap ! (𝕕-βr z))) ⟩
+        =ₛ⟨ =ₛ-in (apd-tr-coher (λ z → ap 𝕕₀ (! (glue z)) ∙ idp) (λ z → ! (glue z ∙ ap right (! (ℂ z)))) (cglue g a)
+              (λ z →  ap-inv-rid 𝕕₀ (glue z) ∙ ap ! (𝕕-βr z))) ⟩
       ! (apd-tr (λ z → ap 𝕕₀ (! (glue z)) ∙ idp) (cglue g a)) ◃∙
       ap (transport (λ z → right (δ₀ (ψ F z)) == left ([id] z)) (cglue g a))
         (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a))) ◃∙
@@ -37,23 +36,20 @@ module ConstrMap3 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
       ! (apd-tr (λ z → ap 𝕕₀ (! (glue z)) ∙ idp) (cglue g a)) ◃∙
       ap (transport (λ z → right (δ₀ (ψ F z)) == left ([id] z)) (cglue g a))
         (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a))) ◃∙
-      transp-inv-comm (left ∘ [id]) (right ∘ δ₀ ∘ ψ F) (cglue g a)
-        (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ◃∙
+      transp-inv-comm (left ∘ [id]) (right ∘ δ₀ ∘ ψ F) (cglue g a) (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ◃∙
       ap ! (apd-tr (λ z → glue z ∙ ap right (! (ℂ z))) (cglue g a)) ◃∎
         =ₛ⟨ 3 & 1 & ap-seq-=ₛ ! (apd-ap-∙-l-coher right {F = glue} {G = ℂ} (cglue g a)) ⟩
       ! (apd-tr (λ z → ap 𝕕₀ (! (glue z)) ∙ idp) (cglue g a)) ◃∙
       ap (transport (λ z → right (δ₀ (ψ F z)) == left ([id] z)) (cglue g a))
         (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a))) ◃∙
-      transp-inv-comm (left ∘ [id]) (right ∘ δ₀ ∘ ψ F) (cglue g a)
-        (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ◃∙
+      transp-inv-comm (left ∘ [id]) (right ∘ δ₀ ∘ ψ F) (cglue g a)(glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ◃∙
       ap ! (apd-ap-∙-l right {F = glue} {G = ℂ} (cglue g a)) ◃∙
       ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (apd-tr ℂ (cglue g a))) ◃∎
         =ₛ₁⟨ 4 & 1 & ap (λ z →  ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) z)) (=ₛ-out (ℂ-β g a)) ⟩
       ! (apd-tr (λ z → ap 𝕕₀ (! (glue z)) ∙ idp) (cglue g a)) ◃∙
       ap (transport (λ z → right (δ₀ (ψ F z)) == left ([id] z)) (cglue g a))
         (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a))) ◃∙
-      transp-inv-comm (left ∘ [id]) (right ∘ δ₀ ∘ ψ F) (cglue g a)
-        (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ◃∙
+      transp-inv-comm (left ∘ [id]) (right ∘ δ₀ ∘ ψ F) (cglue g a) (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ◃∙
       ap ! (apd-ap-∙-l right {F = glue} {G = ℂ} (cglue g a)) ◃∙
       ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (↯ (ζ g a))) ◃∎ ∎ₛ
 
@@ -61,24 +57,21 @@ module ConstrMap3 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
       ! (apd-tr (λ z → ap 𝕕₀ (! (glue z)) ∙ idp) (cglue g a)) ◃∙
       ap (transport (λ z → right (δ₀ (ψ F z)) == left ([id] z)) (cglue g a))
         (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a))) ◃∙
-      transp-inv-comm (left ∘ [id]) (right ∘ δ₀ ∘ ψ F) (cglue g a)
-        (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ◃∙
+      transp-inv-comm (left ∘ [id]) (right ∘ δ₀ ∘ ψ F) (cglue g a) (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ◃∙
       ap ! (apd-ap-∙-l right {F = glue} {G = ℂ} (cglue g a)) ◃∙
       ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (↯ (ζ g a))) ◃∎
         =ₛ⟨ 4 & 1 & =ₛ-in (ap (ap !) (=ₛ-out (ap-seq-∙ (λ p → glue (cin i a) ∙ ap right (! p)) (ζ g a)))) ⟩
       ! (apd-tr (λ z → ap 𝕕₀ (! (glue z)) ∙ idp) (cglue g a)) ◃∙
       ap (transport (λ z → right (δ₀ (ψ F z)) == left ([id] z)) (cglue g a))
         (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a))) ◃∙
-      transp-inv-comm (left ∘ [id]) (right ∘ δ₀ ∘ ψ F) (cglue g a)
-        (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ◃∙
+      transp-inv-comm (left ∘ [id]) (right ∘ δ₀ ∘ ψ F) (cglue g a) (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ◃∙
       ap ! (apd-ap-∙-l right {F = glue} {G = ℂ} (cglue g a)) ◃∙
       ap ! (↯ (ap-seq (λ p → glue (cin i a) ∙ ap right (! p)) (ζ g a))) ◃∎
         =ₛ⟨ 4 & 1 & ap-seq-∙ ! (ap-seq (λ p → glue (cin i a) ∙ ap right (! p)) (ζ g a)) ⟩
       ! (apd-tr (λ z → ap 𝕕₀ (! (glue z)) ∙ idp) (cglue g a)) ◃∙
       ap (transport (λ z → right (δ₀ (ψ F z)) == left ([id] z)) (cglue g a))
         (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a))) ◃∙
-      transp-inv-comm (left ∘ [id]) (right ∘ δ₀ ∘ ψ F) (cglue g a)
-        (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ◃∙
+      transp-inv-comm (left ∘ [id]) (right ∘ δ₀ ∘ ψ F) (cglue g a) (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ◃∙
       ap ! (apd-ap-∙-l right {F = glue} {G = ℂ} (cglue g a)) ◃∙
       ap-seq ! (ap-seq (λ p → glue (cin i a) ∙ ap right (! p)) (ζ g a)) ∎ₛ
 
@@ -91,25 +84,24 @@ module ConstrMap3 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
           ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
           ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
           ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
-      ap (λ p → ! (p ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
+      ap (λ p → ! (p ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp)∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
       ap (λ p → ! ((ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
-        ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙
-        !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙
+           (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
+           ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙ !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙
       long-path-red (snd (F <#> g) a) (ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
         (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)
         (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) idp ◃∙
       ap (λ q → q) (ap-cp-revR 𝕕₀ (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))) ◃∙
       ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₁ (snd (F <#> g) a) (! (glue (cin j a)))))) ◃∙
-      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (! (ap (λ p → ! (ap right (! (ap (cin j)
-        (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p)
-        (ap (ap left) (id-βr g a)))))) ◃∙
-      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₃ (λ x → ! (glue x)) (cglue g a)
-        (ψ-βr F g a) (λ x → idp)))) ◃∙
+      ap (λ q → q)
+        (ap (λ p → p ∙ idp)
+          (ap (ap 𝕕₀)
+            (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a)))))) ◃∙
+      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₃ (λ x → ! (glue x)) (cglue g a) (ψ-βr F g a) (λ x → idp)))) ◃∙
       ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (∙-unit-r (! (glue (cin i a)))))) ◃∙
       ap-inv-rid 𝕕₀ (glue (cin i a)) ◃∙
       ap ! (𝕕-βr (cin i a)) ◃∙
@@ -121,57 +113,56 @@ module ConstrMap3 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
           ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
           ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
           ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
-      ap (λ p → ! (p ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
-      ap (λ p → ! ((ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
-        ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙
-        !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙
+      ap (λ p → ! (p ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙ ap (right ∘ cin j ∘ (fst (nat δ j)))
+           (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
+      ap (λ p → ! ((ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
+           ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙ !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙
       long-path-red (snd (F <#> g) a) (ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
         (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)
         (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) idp ◃∙
       ap (λ q → q) (ap-cp-revR 𝕕₀ (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))) ◃∙
       ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₁ (snd (F <#> g) a) (! (glue (cin j a)))))) ◃∙
-      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (! (ap (λ p → ! (ap right (! (ap (cin j)
-        (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p)
-        (ap (ap left) (id-βr g a)))))) ◃∙
-      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₃ (λ x → ! (glue x)) (cglue g a)
-        (ψ-βr F g a) (λ x → idp)))) ◃∙
+      ap (λ q → q)
+        (ap (λ p → p ∙ idp)
+          (ap (ap 𝕕₀)
+            (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a)))))) ◃∙
+      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₃ (λ x → ! (glue x)) (cglue g a) (ψ-βr F g a) (λ x → idp)))) ◃∙
       ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (∙-unit-r (! (glue (cin i a)))))) ◃∙
       ! (apd-tr (λ z → ap 𝕕₀ (! (glue z)) ∙ idp) (cglue g a)) ◃∙
       ap (transport (λ z → right (δ₀ (ψ F z)) == left ([id] z)) (cglue g a))
         (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a))) ◃∙
-      transp-inv-comm (left ∘ [id]) (right ∘ δ₀ ∘ ψ F) (cglue g a)
-        (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ◃∙
+      transp-inv-comm (left ∘ [id]) (right ∘ δ₀ ∘ ψ F) (cglue g a) (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ◃∙
       ap ! (apd-ap-∙-l right {F = glue} {G = ℂ} (cglue g a)) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (transp-pth-cmpL δ₀ ψ₁ ψ₂ (cglue g a)
-        (ap (cin j) (snd (nat δ j) a)))) ◃∙
+      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (transp-pth-cmpL δ₀ ψ₁ ψ₂ (cglue g a) (ap (cin j) (snd (nat δ j) a)))) ◃∙
+      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! (ap δ₀ p) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (ψ₁-βr g a))) ◃∙
       ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
-        (ap (λ p → ! (ap δ₀ p) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (ψ₁-βr g a))) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (pre-cmp-!-!-∙ δ₀ (cin j) (snd (F <#> g) a)
-        (cglue g (fun (F # i) a)) (ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)))) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! p ∙
-        ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (δ₀-βr g (fun (F # i) a)))) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! p ∙ ap (cin j ∘ fst (nat δ j))
-        (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a))
-        (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a)))
-        (comSq-coher δ g a)))) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! (! (ap (cin j) (ap (fst (G <#> g))
-        (snd (nat δ i) a) ∙ snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j))
-        (snd (F <#> g) a)))) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) ∙
-        ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ p)
-        (ψ₂-βr g a))) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
-        (long-red-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g))
-        (snd (nat δ i) a) (snd (G <#> g) a) (snd (F <#> g) a)
-        (snd (nat δ j) a) (cglue g (fst (nat δ i) (fun (F # i) a)))
-        (cglue g (fun (G # i) a)))) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
-        (apCommSq (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))) ◃∙
+             (pre-cmp-!-!-∙ δ₀ (cin j) (snd (F <#> g) a)  (cglue g (fun (F # i) a)) (ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)))) ◃∙
+      ap !
+        (ap (λ p → glue (cin i a) ∙ ap right (! p))
+          (ap (λ p → ! p ∙  ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (δ₀-βr g (fun (F # i) a)))) ◃∙
+      ap !
+        (ap (λ p → glue (cin i a) ∙ ap right (! p))
+          (ap (λ p → ! p ∙ ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a))
+            (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a)))) ◃∙
+      ap !
+        (ap (λ p → glue (cin i a) ∙ ap right (! p))
+          (ap (λ p → ! (! (ap (cin j) (ap (fst (G <#> g))
+              (snd (nat δ i) a) ∙ snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j))
+              (snd (F <#> g) a)))) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) ∙ ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
+              ap (cin j) (snd (nat δ j) a) ∙ p)
+          (ψ₂-βr g a))) ◃∙
+      ap !
+        (ap (λ p → glue (cin i a) ∙ ap right (! p))
+          (long-red-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g))
+            (snd (nat δ i) a) (snd (G <#> g) a) (snd (F <#> g) a)
+            (snd (nat δ j) a) (cglue g (fst (nat δ i) (fun (F # i) a)))
+            (cglue g (fun (G # i) a)))) ◃∙
+      ap !
+        (ap (λ p → glue (cin i a) ∙ ap right (! p))
+          (apCommSq (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))) ◃∙
       !-!-ap-∘ (cin i) right (snd (nat δ i) a) (glue (cin i a)) ◃∎ ∎ₛ
 
     open ConstrMap2.MapCoher δ g a

--- a/Colimit-code/Map-Nat/CosColimitMap03.agda
+++ b/Colimit-code/Map-Nat/CosColimitMap03.agda
@@ -2,7 +2,6 @@
 
 open import lib.Basics
 open import lib.types.Pushout
-open import lib.types.Span
 open import Coslice
 open import Diagram
 open import Helper-paths
@@ -32,122 +31,116 @@ module ConstrMap4 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
 
     fib-coher3 =
       ! (ap (λ p → ! p ∙ ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (
-          ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
-          ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
-          ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
-          ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
+              ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+            (
+            ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
+            ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
+            ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
+            ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
       ap (λ p → ! (p ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
-      ap (λ p → ! ((ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
-        ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙
-        !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
+           ! (glue (cin j a))) (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
+      ap (λ p → ! ((ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
+           ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙ !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙
       long-path-red (snd (F <#> g) a) (ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
         (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)
         (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) idp ◃∙
-      ap (λ q → q) (ap-cp-revR 𝕕₀ (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a))) ∙
-        ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (↯ 𝕤))) ◃∙
+      ap (λ q → q) (ap-cp-revR 𝕕₀ (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a))) ∙ ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (↯ 𝕤))) ◃∙
       ap-inv-rid 𝕕₀ (glue (cin i a)) ◃∙
       ap ! (𝕕-βr (cin i a)) ◃∙
-      !-!-ap-∘ (cin i) right (snd (nat δ i) a) (glue (cin i a))  ◃∙    
+      !-!-ap-∘ (cin i) right (snd (nat δ i) a) (glue (cin i a)) ◃∙ 
       ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p) (∙-unit-r (! (glue (cin i a))))) ◃∙
       ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p)
-        (E₃ (λ x → ! (glue x)) (cglue g a) (ψ-βr G g a) (λ x → idp))) ◃∙
+          (E₃ (λ x → ! (glue x)) (cglue g a) (ψ-βr G g a) (λ x → idp))) ◃∙
       ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p)
-        (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (G <#> g) a)) ∙ cglue g (fun (G # i) a))) ∙
-        ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
-      ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p)
-        (E₁ (snd (G <#> g) a) (! (glue (cin j a))))) ◃∙
+          (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (G <#> g) a)) ∙ cglue g (fun (G # i) a))) ∙
+          ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
+      ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p) (E₁ (snd (G <#> g) a) (! (glue (cin j a))))) ◃∙
       ! (long-red-ap-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g)) (cin i) right
         (snd (nat δ i) a) (snd (G <#> g) a) (snd (F <#> g) a)
         (snd (nat δ j) a) (cglue g (fun (G # i) a)) (! (glue (cin j a)))) ◃∙
       ! (ap (λ p → ! (ap right (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙
-        snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
-        ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
-        (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))) ◃∙
+              snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
+              ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
+              ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+          (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))) ◃∙
       ! (ap (λ p → ! (ap right p) ∙ ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (ap (λ p → ! (ap (cin j) p) ∙
-        cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a))) ◃∎
+              ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+            (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a))) ◃∎
         =ₛ⟨ 0 & 8 & fib-coher-conc ⟩
       ! (ap (λ p → ! p ∙ ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (
-          ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
-          ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
-          ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
-          ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
+              ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+            (
+            ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
+            ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
+            ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
+            ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
       ap (λ p → ! (p ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
-      ap (λ p → ! ((ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
-        ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙
-        !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
+      ap (λ p → ! ((ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
+           ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙ !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙
       long-path-red (snd (F <#> g) a) (ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
         (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)
         (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) idp ◃∙
       ap (λ q → q) (ap-cp-revR 𝕕₀ (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))) ◃∙
       ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₁ (snd (F <#> g) a) (! (glue (cin j a)))))) ◃∙
-      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (! (ap (λ p → ! (ap right (! (ap (cin j)
-        (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p)
-        (ap (ap left) (id-βr g a)))))) ◃∙
-      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₃ (λ x → ! (glue x)) (cglue g a)
-        (ψ-βr F g a) (λ x → idp)))) ◃∙
+      ap (λ q → q)
+        (ap (λ p → p ∙ idp)
+          (ap (ap 𝕕₀)
+            (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p)
+                 (ap (ap left) (id-βr g a)))))) ◃∙
+      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₃ (λ x → ! (glue x)) (cglue g a) (ψ-βr F g a) (λ x → idp)))) ◃∙
       ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (∙-unit-r (! (glue (cin i a)))))) ◃∙
       ! (apd-tr (λ z → ap 𝕕₀ (! (glue z)) ∙ idp) (cglue g a)) ◃∙
       ap (transport (λ z → right (δ₀ (ψ F z)) == left ([id] z)) (cglue g a))
         (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a))) ◃∙
-      transp-inv-comm (left ∘ [id]) (right ∘ δ₀ ∘ ψ F) (cglue g a)
-        (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ◃∙
+      transp-inv-comm (left ∘ [id]) (right ∘ δ₀ ∘ ψ F) (cglue g a) (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ◃∙
       ap ! (apd-ap-∙-l right {F = glue} {G = ℂ} (cglue g a)) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (transp-pth-cmpL δ₀ ψ₁ ψ₂ (cglue g a)
-        (ap (cin j) (snd (nat δ j) a)))) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
-        (ap (λ p → ! (ap δ₀ p) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (ψ₁-βr g a))) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (pre-cmp-!-!-∙ δ₀ (cin j) (snd (F <#> g) a)
-        (cglue g (fun (F # i) a)) (ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)))) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! p ∙
-        ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (δ₀-βr g (fun (F # i) a)))) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! p ∙ ap (cin j ∘ fst (nat δ j))
-        (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a))
-        (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a)))
-        (comSq-coher δ g a)))) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! (! (ap (cin j) (ap (fst (G <#> g))
-        (snd (nat δ i) a) ∙ snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j))
-        (snd (F <#> g) a)))) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) ∙
-        ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ p)
-        (ψ₂-βr g a))) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
-        (long-red-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g))
-        (snd (nat δ i) a) (snd (G <#> g) a) (snd (F <#> g) a)
-        (snd (nat δ j) a) (cglue g (fst (nat δ i) (fun (F # i) a)))
-        (cglue g (fun (G # i) a)))) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
-        (apCommSq (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))) ◃∙
+      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (transp-pth-cmpL δ₀ ψ₁ ψ₂ (cglue g a) (ap (cin j) (snd (nat δ j) a)))) ◃∙
+      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! (ap δ₀ p) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (ψ₁-βr g a))) ◃∙
+      ap !
+        (ap (λ p → glue (cin i a) ∙ ap right (! p))
+          (pre-cmp-!-!-∙ δ₀ (cin j) (snd (F <#> g) a) (cglue g (fun (F # i) a)) (ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)))) ◃∙
+      ap !
+        (ap (λ p → glue (cin i a) ∙ ap right (! p))
+          (ap (λ p → ! p ∙ ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (δ₀-βr g (fun (F # i) a)))) ◃∙
+      ap !
+        (ap (λ p → glue (cin i a) ∙ ap right (! p))
+          (ap (λ p → ! p ∙ ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a))
+            (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a)))) ◃∙
+      ap !
+        (ap (λ p → glue (cin i a) ∙ ap right (! p))
+          (ap (λ p →
+            ! (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙ snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙
+              cglue g (fst (nat δ i) (fun (F # i) a))) ∙ ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ p)
+           (ψ₂-βr g a))) ◃∙
+      ap !
+        (ap (λ p → glue (cin i a) ∙ ap right (! p))
+          (long-red-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g))
+            (snd (nat δ i) a) (snd (G <#> g) a) (snd (F <#> g) a)
+            (snd (nat δ j) a) (cglue g (fst (nat δ i) (fun (F # i) a)))
+            (cglue g (fun (G # i) a)))) ◃∙
+      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (apCommSq (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))) ◃∙
       !-!-ap-∘ (cin i) right (snd (nat δ i) a) (glue (cin i a)) ◃∙    
       ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p) (∙-unit-r (! (glue (cin i a))))) ◃∙
       ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p)
         (E₃ (λ x → ! (glue x)) (cglue g a) (ψ-βr G g a) (λ x → idp))) ◃∙
       ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p)
-        (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (G <#> g) a)) ∙ cglue g (fun (G # i) a))) ∙
-        ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
-      ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p)
-        (E₁ (snd (G <#> g) a) (! (glue (cin j a))))) ◃∙
+           (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (G <#> g) a)) ∙ cglue g (fun (G # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
+      ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p) (E₁ (snd (G <#> g) a) (! (glue (cin j a))))) ◃∙
       ! (long-red-ap-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g)) (cin i) right
-        (snd (nat δ i) a) (snd (G <#> g) a) (snd (F <#> g) a)
-        (snd (nat δ j) a) (cglue g (fun (G # i) a)) (! (glue (cin j a)))) ◃∙
+          (snd (nat δ i) a) (snd (G <#> g) a) (snd (F <#> g) a)
+          (snd (nat δ j) a) (cglue g (fun (G # i) a)) (! (glue (cin j a)))) ◃∙
       ! (ap (λ p → ! (ap right (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙
-        snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
-        ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
-        (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))) ◃∙
+              snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
+              ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
+              ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+            (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))) ◃∙
       ! (ap (λ p → ! (ap right p) ∙ ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (ap (λ p → ! (ap (cin j) p) ∙
-        cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a))) ◃∎ ∎ₛ
+              ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+            (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a))) ◃∎ ∎ₛ

--- a/Colimit-code/Map-Nat/CosColimitMap04.agda
+++ b/Colimit-code/Map-Nat/CosColimitMap04.agda
@@ -2,7 +2,6 @@
 
 open import lib.Basics
 open import lib.types.Pushout
-open import lib.types.Span
 open import Coslice
 open import Diagram
 open import Helper-paths
@@ -16,9 +15,10 @@ module CosColimitMap04 where
 module _ {ℓ₁ ℓ₂ ℓ₃} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type ℓ₃} (h : B → C) {k : A → B} where
 
   !-!-ap-idp-!-inv : {a₁ a₂ : A} (p₂ : a₁ == a₂) {b : B} (p₃ : k a₂ == b) {c : C} (p₁ : c == h (k a₂))
-    → ! (p₁ ∙ ap h (! (! (! (ap k (! p₂ ∙ idp)) ∙ p₃) ∙ ap k p₂ ∙ idp)))
+    →
+    ! (p₁ ∙ ap h (! (! (! (ap k (! p₂ ∙ idp)) ∙ p₃) ∙ ap k p₂ ∙ idp)))
       =-=
-      ! (ap h p₃) ∙ ! p₁ ∙ p₁ ∙ ! p₁
+    ! (ap h p₃) ∙ ! p₁ ∙ p₁ ∙ ! p₁
   !-!-ap-idp-!-inv idp idp p₁ = (!-∙ p₁ idp) ◃∙ ! (∙-unit-r (! p₁)) ◃∙ ap (λ p → ! p₁ ∙ p) (! (!-inv-r p₁)) ◃∎
 
 module ConstrMap5 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ} {F : CosDiag ℓF ℓ A Γ} {G : CosDiag ℓG ℓ A Γ} (δ : CosDiagMor A F G) where
@@ -34,74 +34,66 @@ module ConstrMap5 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
     ψ₂-free-aux3 : {x : P₂} (γ : x == right (cin j (fun (G # j) a)))
       {κ : x == x} (ρ : κ == γ ∙ ! γ)
       {z : Colim ForgG} (m₂ : cin j (fun (G # j) a) == z) {w : ty (G # j)} (σ : w == fun (G # j) a)
-      → ! (γ ∙ ap right (! (! (! (ap (cin j) (! σ ∙ idp)) ∙ m₂) ∙ ap (cin j) σ ∙ idp)))
-      =-=
+      →
+      ! (γ ∙ ap right (! (! (! (ap (cin j) (! σ ∙ idp)) ∙ m₂) ∙ ap (cin j) σ ∙ idp)))
+        =-=
       ! (ap right m₂) ∙ ! γ ∙ κ
     ψ₂-free-aux3 γ idp m₂ σ = !-!-ap-idp-!-inv right σ m₂ γ 
 
     ψ₂-free-aux2 : {x : Colim (ConsDiag Γ A)} (q : cin j a == x)
       {κ : left a == left ([id] x)} (ρ : κ == glue (cin j a) ∙ ap right (ap ψ₂ q) ∙ ! (glue x))
       {z : Colim ForgG} (m₂ : cin j (fun (G # j) a) == z) {w : ty (G # j)} (σ : w == fun (G # j) a) 
-      → ! (glue {d = SpCos₂} x ∙ ap right (! (! (! (ap (cin j) (! σ ∙ idp)) ∙ m₂) ∙ ap (cin j) σ ∙ ap ψ₂ q)))
-      =-= ! (ap right m₂) ∙ ! (glue (cin j a)) ∙ κ
+      →
+      ! (glue {d = SpCos₂} x ∙ ap right (! (! (! (ap (cin j) (! σ ∙ idp)) ∙ m₂) ∙ ap (cin j) σ ∙ ap ψ₂ q)))
+        =-=
+      ! (ap right m₂) ∙ ! (glue (cin j a)) ∙ κ
     ψ₂-free-aux2 idp ρ m₂ σ = ψ₂-free-aux3 (glue (cin j a)) ρ m₂ σ
-
-{-
-  κ = ap left (ap [id] (cglue g a)
-  ρ = apCommSq-cmp left right glue (cglue g a) 
--}  
 
     ψ₂-free-aux : {x : Colim (ConsDiag Γ A)} (q : cin j a == x) {w₁ w₂ : ty (G # j)} (m₁ : w₁ == fun (G # j) a)
       {z : Colim ForgG} (m₂ : cin j w₁ == z) (σ : w₂ == fun (G # j) a)
-      → ! (glue {d = SpCos₂} x ∙ ap right (! (! (! (ap (cin j) (m₁ ∙ ! σ ∙ idp)) ∙ m₂) ∙
-          ap (cin j) σ ∙ ap ψ₂ q)))
+      →
+      ! (glue {d = SpCos₂} x ∙ ap right (! (! (! (ap (cin j) (m₁ ∙ ! σ ∙ idp)) ∙ m₂) ∙ ap (cin j) σ ∙ ap ψ₂ q)))
         =-=
-        ! (ap right (! (ap (cin j) m₁) ∙ m₂)) ∙
-          ! (glue (cin j a)) ∙ ap left (ap [id] q)
+      ! (ap right (! (ap (cin j) m₁) ∙ m₂)) ∙ ! (glue (cin j a)) ∙ ap left (ap [id] q)
     ψ₂-free-aux q idp m₂ σ = ψ₂-free-aux2 q (apCommSq-cmp left right glue q) m₂ σ
     
     ψ₂-free : (q : cin j a == cin i a) {e : ty (F # j)} (s : e == fun (F # j) a) {x₁ x₂ : ty (G # i)} (d : x₁ == x₂)
       (m : fst (G <#> g) x₂ == fun (G # j) a)
-      →  ! (glue {d = SpCos₂} (cin i a) ∙ ap right (! (! (! (ap (cin j)
-           (ap (fst (G <#> g)) d ∙ m ∙ ! (snd (nat δ j) a) ∙
-           ! (ap (fst (nat δ j)) s))) ∙ cglue g x₁) ∙
-           ap (cin j ∘ fst (nat δ j)) s ∙
-           ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ q)))
-      =-=
-        ap (right ∘ cin i) d ∙ ! (ap right (! (ap (cin j) m) ∙ cglue g x₂)) ∙
-          ! (glue (cin j a)) ∙ ap left (ap [id] q)
+      →
+      ! (glue {d = SpCos₂} (cin i a) ∙
+        ap right
+          (! (! (! (ap (cin j) (ap (fst (G <#> g)) d ∙ m ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) s))) ∙ cglue g x₁) ∙
+            ap (cin j ∘ fst (nat δ j)) s ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ q)))
+        =-=
+      ap (right ∘ cin i) d ∙ ! (ap right (! (ap (cin j) m) ∙ cglue g x₂)) ∙ ! (glue (cin j a)) ∙ ap left (ap [id] q)
     ψ₂-free q idp {x₂ = x₂} idp m = ψ₂-free-aux q m (cglue g x₂) (snd (nat δ j) a)
 
-    ψ₂-red-aux3 : {x : P₂} (p : x == right (cin j (fun (G # j) a))) →
+    ψ₂-red-aux3 : {x : P₂} (p : x == right (cin j (fun (G # j) a)))
+      →
       ap ! (∙-unit-r p) ∙ ! (ap (λ q → q) (∙-unit-r (! p))) ∙ idp
-      ==
+        ==
       ↯ (ψ₂-free-aux3 p (! (!-inv-r p)) idp idp)
     ψ₂-red-aux3 idp = idp
 
     ψ₂-red-aux2 : {x : Colim (ConsDiag Γ A)} (q : cin j a == x) {w : ty (G # j)} (σ : w == fun (G # j) a)
-      {m₂ : cin j (fun (G # j) a) == ψ₂ x} (τ : ap ψ₂ q == m₂) → 
-      ap ! (ap (λ p → glue x ∙ ap right (! p))
-        (ap (λ p → ! (! (ap (cin j) (! σ ∙ idp)) ∙ m₂) ∙ ap (cin j) σ ∙ p) τ)) ◃∙
+      {m₂ : cin j (fun (G # j) a) == ψ₂ x} (τ : ap ψ₂ q == m₂)
+      → 
+      ap ! (ap (λ p → glue x ∙ ap right (! p)) (ap (λ p → ! (! (ap (cin j) (! σ ∙ idp)) ∙ m₂) ∙ ap (cin j) σ ∙ p) τ)) ◃∙
       ap ! (ap (λ p → glue x ∙ ap right (! p)) (ap-!-!-!-!-rid (cin j) σ idp m₂ m₂)) ◃∙
       ap ! (ap (λ p → glue x ∙ ap right (! p)) (!-inv-l m₂)) ◃∙
       ap ! (∙-unit-r (glue x)) ◃∙
       ! (ap (λ q → q) (∙-unit-r (! (glue x)))) ◃∙
-        ! (ap (λ q → q) (E₃ (λ x → ! (glue x)) q τ (λ x → idp))) ◃∎
-      =ₛ
+      ! (ap (λ q → q) (E₃ (λ x → ! (glue x)) q τ (λ x → idp))) ◃∎
+        =ₛ
       ↯ (ψ₂-free-aux2 q (apCommSq-cmp left right glue q) m₂ σ) ◃∎
     ψ₂-red-aux2 idp idp idp = =ₛ-in (ψ₂-red-aux3 (glue (cin j a)))
 
--- q = cglue g a
-
     ψ₂-red-aux : {w₁ w₂ : ty (G # j)} (m₁ : w₁ == fun (G # j) a) (m₂ : cin j w₁ == ψ₂ (cin i a))
-      (σ : w₂ == fun (G # j) a) (τ : ap ψ₂ (cglue g a) == ! (ap (cin j) m₁) ∙ m₂) →
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
-        (ap (λ p → ! (! (ap (cin j) (m₁ ∙ ! σ ∙ idp)) ∙
-        m₂) ∙ ap (cin j) σ ∙ p) τ)) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
-        (ap-!-!-!-!-rid (cin j) σ m₁ m₂ m₂)) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
-        (!-inv-l m₂)) ◃∙
+      (σ : w₂ == fun (G # j) a) (τ : ap ψ₂ (cglue g a) == ! (ap (cin j) m₁) ∙ m₂)
+      →
+      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! (! (ap (cin j) (m₁ ∙ ! σ ∙ idp)) ∙ m₂) ∙ ap (cin j) σ ∙ p) τ)) ◃∙
+      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap-!-!-!-!-rid (cin j) σ m₁ m₂ m₂)) ◃∙
+      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (!-inv-l m₂)) ◃∙
       ap ! (∙-unit-r (glue (cin i a))) ◃∙
       ! (ap (λ q → q) (∙-unit-r (! (glue (cin i a))))) ◃∙
       ! (ap (λ q → q) (E₃ (λ x → ! (glue x)) (cglue g a) τ (λ x → idp))) ◃∎
@@ -109,35 +101,23 @@ module ConstrMap5 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
       ↯ (ψ₂-free-aux (cglue g a) m₁ m₂ σ) ◃∎
     ψ₂-red-aux idp m₂ σ τ = ψ₂-red-aux2 (cglue g a) σ τ
 
-{-
-  m₁ = snd (G <#> g) a
-  m₂ = cglue g (fun (G # i) a)
-  σ = snd (nat δ j) a
-  τ = ψ₂-βr g a
--}
-
     abstract
-    
       ψ₂-red : {e : ty (F # j)} (s : e == fun (F # j) a) {x : ty (G # i)} (d : x == fun (G # i) a) →
-        ap ! (ap (λ p → glue {d = SpCos₂} (cin i a) ∙ ap right (! p)) (ap (λ p → ! (! (ap (cin j)
-          (ap (fst (G <#> g)) d ∙ snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙
-          ! (ap (fst (nat δ j)) s))) ∙ cglue g x) ∙ ap (cin j ∘ fst (nat δ j)) s ∙
-          ap (cin j) (snd (nat δ j) a) ∙ p) (ψ₂-βr g a))) ◃∙
-        ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
-          (long-red-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g))
-          d (snd (G <#> g) a) s
-          (snd (nat δ j) a) (cglue g x) (cglue g (fun (G # i) a)))) ◃∙
-        ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
-          (apCommSq (cin j ∘ fst (G <#> g)) (cin i) (cglue g) d)) ◃∙
+        ap !
+          (ap (λ p → glue {d = SpCos₂} (cin i a) ∙ ap right (! p))
+            (ap (λ p →
+                ! (! (ap (cin j) (ap (fst (G <#> g)) d ∙ snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙
+                  ! (ap (fst (nat δ j)) s))) ∙ cglue g x) ∙
+                ap (cin j ∘ fst (nat δ j)) s ∙ ap (cin j) (snd (nat δ j) a) ∙ p)
+              (ψ₂-βr g a))) ◃∙
+        ap !
+          (ap (λ p → glue (cin i a) ∙ ap right (! p))
+            (long-red-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g))  d (snd (G <#> g) a) s (snd (nat δ j) a) (cglue g x) (cglue g (fun (G # i) a)))) ◃∙
+        ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (apCommSq (cin j ∘ fst (G <#> g)) (cin i) (cglue g) d)) ◃∙
         !-!-ap-∘ (cin i) right d (glue (cin i a)) ◃∙
         ! (ap (λ p → ap (right ∘ cin i) d ∙ p) (∙-unit-r (! (glue (cin i a))))) ◃∙
         ! (ap (λ p → ap (right ∘ cin i) d ∙ p)
-          (E₃ {f = left} {u = right} (λ x → ! (glue x)) (cglue g a) (ψ₂-βr g a) (λ x → idp))) ◃∎
-        =ₛ
+            (E₃ {f = left} {u = right} (λ x → ! (glue x)) (cglue g a) (ψ₂-βr g a) (λ x → idp))) ◃∎
+          =ₛ
         ↯ (ψ₂-free (cglue g a) s d (snd (G <#> g) a)) ◃∎
       ψ₂-red idp idp = ψ₂-red-aux (snd (G <#> g) a) (cglue g (fun (G # i) a)) (snd (nat δ j) a) (ψ₂-βr g a)
-
-{-
-  s = snd (F <#> g) a
-  d = snd (nat δ i) a
--}

--- a/Colimit-code/Map-Nat/CosColimitMap05.agda
+++ b/Colimit-code/Map-Nat/CosColimitMap05.agda
@@ -2,7 +2,6 @@
 
 open import lib.Basics
 open import lib.types.Pushout
-open import lib.types.Span
 open import Coslice
 open import Diagram
 open import Helper-paths
@@ -35,7 +34,9 @@ module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄ ℓ₅} {A : Type ℓ₁} {B : Type ℓ₂
   (f₁ : C → D) {f₂ : B → C} {f₃ : A → B} {f₄ : E → C} where
 
   ap4-!-!-!-rid : {a₁ a₂ : A} (p₁ : a₁ == a₂) {b : B} (p₂ : f₃ a₁ == b) {g₁ g₂ : E} (p₄ : g₁ == g₂) (p₃ : f₄ g₁ == f₂ (f₃ a₂))
-    → ap f₁ (! (ap f₂ (! (ap f₃ p₁) ∙ p₂)) ∙ ! p₃ ∙ ap f₄ p₄) ∙ idp ==
+    →
+    ap f₁ (! (ap f₂ (! (ap f₃ p₁) ∙ p₂)) ∙ ! p₃ ∙ ap f₄ p₄) ∙ idp
+      ==
     ! (ap (f₁ ∘ f₂) (! (ap f₃ p₁) ∙ p₂)) ∙ ! (ap f₁ p₃) ∙ ap (f₁ ∘ f₄) p₄
   ap4-!-!-!-rid idp p₂ p₄ p₃ = ap3-!-! f₁ p₄ p₂ p₃
 
@@ -52,37 +53,29 @@ module ConstrMap6 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
     ψ₁-free-aux3 : {x : Colim ForgF} (m₂ : cin j (fun (F # j) a) == x)
       {κ : left a == left a} (ρ : κ == glue (cin j a) ∙ ! (glue (cin j a))) →
       ! (ap (right {d = SpCos₂} ∘ δ₀) m₂) ∙ ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ∙ κ
-      ==
+        ==
       ! (glue (cin j a) ∙ ap right (! (! (ap δ₀ m₂) ∙ ap (cin j) (snd (nat δ j) a) ∙ idp)))
     ψ₁-free-aux3 idp ρ = !-ap-!-∙ right (ap (cin j) (snd (nat δ j) a)) (glue (cin j a)) ρ
 
     ψ₁-free-aux2 : {x : Colim (ConsDiag Γ A)} (q : cin j a == x) (m₂ : cin j (fun (F # j) a) == ψ₁ x)
       {κ : left a == left ([id] x)} (ρ : κ == glue (cin j a) ∙ ap right (ap ψ₂ q) ∙ ! (glue x)) →
       ! (ap (right {d = SpCos₂} ∘ δ₀) m₂) ∙ ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ∙ κ
-      ==
+        ==
       ! (glue x ∙ ap right (! (! (ap δ₀ m₂) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ q)))
     ψ₁-free-aux2 idp m₂ ρ = ψ₁-free-aux3 m₂ ρ
 
-{-
-  κ = ap left (ap [id] (cglue g a)
-  ρ = apCommSq-cmp left right glue (cglue g a)
--}
-
     ψ₁-free-aux : {x : Colim (ConsDiag Γ A)} (q : cin j a == x) {w : ty (F # j)} (m₁ : w == fun (F # j) a)
       (m₂ : cin j w == ψ₁ x) → 
-      ! (ap (right {d = SpCos₂} ∘ δ₀) (! (ap (cin j) m₁) ∙ m₂)) ∙
-        ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a))))  ∙ ap left (ap [id] q)
-      ==
-      ! (glue x ∙ ap right (! (! (ap δ₀ (! (ap (cin j) m₁) ∙ m₂)) ∙
-        ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ q)))
+      ! (ap (right {d = SpCos₂} ∘ δ₀) (! (ap (cin j) m₁) ∙ m₂)) ∙ ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a))))  ∙ ap left (ap [id] q)
+        ==
+      ! (glue x ∙ ap right (! (! (ap δ₀ (! (ap (cin j) m₁) ∙ m₂)) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ q)))
     ψ₁-free-aux q idp m₂ = ψ₁-free-aux2 q m₂ (apCommSq-cmp left right glue q)
 
-    ψ₁-red-aux3 : {x₁ x₂ : Colim ForgG} (t : x₁ == x₂) {y : P₂}
-      (r₂ : y == right x₂) {v : y == right x₁} (s : v == r₂ ∙ ap right (! t)) →
+    ψ₁-red-aux3 : {x₁ x₂ : Colim ForgG} (t : x₁ == x₂) {y : P₂} (r₂ : y == right x₂) {v : y == right x₁} (s : v == r₂ ∙ ap right (! t))
+      →
       ap (λ q → q) (ap ! s) ∙
-      ap ! (ap (λ p → r₂ ∙ ap (right {d = SpCos₂}) (! p))
-        (! (∙-unit-r t))) ∙ idp
-      ==
+      ap ! (ap (λ p → r₂ ∙ ap (right {d = SpCos₂}) (! p)) (! (∙-unit-r t))) ∙ idp
+        ==
       ! (∙-unit-r (! v)) ∙
       ap (λ p → ! p ∙ idp) s ∙
       !-ap-!-∙ right t r₂ (! (!-inv-r r₂))
@@ -92,63 +85,39 @@ module ConstrMap6 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
       (s : ap 𝕕₀ r₁ == r₂ ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) →
       ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (∙-unit-r (! r₁)))) ∙
       ap (λ q → q) (ap-inv-rid 𝕕₀ r₁ ∙ ap ! s) ∙
-      ap ! (ap (λ p → r₂ ∙ ap right (! p))
-        (! (∙-unit-r (ap (cin j) (snd (nat δ j) a))))) ∙ idp
-      ==
-      (ap (λ p → ap 𝕕₀ p ∙ idp) (∙-unit-r (! r₁)) ∙
-      ap (λ p → p ∙ idp) (ap-! 𝕕₀ r₁)) ∙
+      ap ! (ap (λ p → r₂ ∙ ap right (! p)) (! (∙-unit-r (ap (cin j) (snd (nat δ j) a))))) ∙ idp
+        ==
+      (ap (λ p → ap 𝕕₀ p ∙ idp) (∙-unit-r (! r₁)) ∙ ap (λ p → p ∙ idp) (ap-! 𝕕₀ r₁)) ∙
       ap (λ p → ! p ∙ idp) s ∙
       !-ap-!-∙ right (ap (cin j) (snd (nat δ j) a)) r₂ (! (!-inv-r r₂))
     ψ₁-red-aux2 idp r₂ s = ψ₁-red-aux3 (ap (cin j) (snd (nat δ j) a)) r₂ s
 
-{-
-  r₁ = glue {d = SpCos₁} (cin j a)
-  r₂ = glue {d = SpCos₂} (cin j a)
-  s = 𝕕-βr (cin j a)
-  t = ap (cin j) (snd (nat δ j) a)
--}
-
     ψ₁-red-aux : {m₂ : cin j (fun (F # j) a) == cin j (fun (F # j) a)} (τ : idp == m₂) → 
-      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₃ {f = left} {h = [id]} {u = right} (λ x → ! (glue x))
-        idp τ (λ x → idp)))) ∙
+      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₃ {f = left} {h = [id]} {u = right} (λ x → ! (glue x)) idp τ (λ x → idp)))) ∙
       ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (∙-unit-r (! (glue (cin j a)))))) ∙
       ap (λ q → q) (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a))) ∙
       ap ! (ap (λ p → glue (cin j a) ∙ ap right (! p)) (! (∙-unit-r (ap (cin j) (snd (nat δ j) a))))) ∙
-      ap ! (ap (λ p → glue (cin j a) ∙ ap right (! p))
-        (ap (λ p → ! (ap δ₀ p) ∙ ap (cin j) (snd (nat δ j) a) ∙ idp) τ))
-      ==
+      ap ! (ap (λ p → glue (cin j a) ∙ ap right (! p)) (ap (λ p → ! (ap δ₀ p) ∙ ap (cin j) (snd (nat δ j) a) ∙ idp) τ))
+        ==
       ap2-!-!-rid 𝕕₀ m₂ (glue (cin j a)) ∙
       ap (λ p → ! (ap (right ∘ δ₀) m₂) ∙ ! p ∙ idp) (𝕕-βr (cin j a)) ∙
       ψ₁-free-aux3 m₂ (apCommSq-cmp left right glue idp)
     ψ₁-red-aux idp = ψ₁-red-aux2 (glue {d = SpCos₁} (cin j a)) (glue {d = SpCos₂} (cin j a)) (𝕕-βr (cin j a)) 
 
     abstract
-
       ψ₁-red : {x : Colim (ConsDiag Γ A)} (q : cin j a == x) {w : ty (F # j)} (m₁ : w == fun (F # j) a)
         {m₂ : cin j w == ψ₁ x} (τ : ap ψ₁ q == ! (ap (cin j) m₁) ∙ m₂) → 
-        ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₃ {f = left} {h = [id]} {u = right} (λ x → ! (glue x)) q
-          τ (λ x → idp)))) ◃∙
+        ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₃ {f = left} {h = [id]} {u = right} (λ x → ! (glue x)) q τ (λ x → idp)))) ◃∙
         ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (∙-unit-r (! (glue x))))) ◃∙
         ! (apd-tr (λ z → ap 𝕕₀ (! (glue z)) ∙ idp) q) ◃∙
         ap (transport (λ z → right (δ₀ (ψ₁ z)) == left ([id] z)) q)
           (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a))) ◃∙
-        transp-inv-comm (left ∘ [id]) (right ∘ δ₀ ∘ ψ₁) q
-          (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ◃∙
+        transp-inv-comm (left ∘ [id]) (right ∘ δ₀ ∘ ψ₁) q (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ◃∙
         ap ! (apd-ap-∙-l right {F = glue} {G = ℂ} q) ◃∙
-        ap ! (ap (λ p → glue x ∙ ap right (! p)) (transp-pth-cmpL δ₀ ψ₁ ψ₂ q
-          (ap (cin j) (snd (nat δ j) a)))) ◃∙
-        ap ! (ap (λ p → glue x ∙ ap right (! p))
-          (ap (λ p → ! (ap δ₀ p) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ q) τ)) ◃∎
-        =ₛ
+        ap ! (ap (λ p → glue x ∙ ap right (! p)) (transp-pth-cmpL δ₀ ψ₁ ψ₂ q (ap (cin j) (snd (nat δ j) a)))) ◃∙
+        ap ! (ap (λ p → glue x ∙ ap right (! p)) (ap (λ p → ! (ap δ₀ p) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ q) τ)) ◃∎
+          =ₛ
         ap4-!-!-!-rid 𝕕₀ m₁ m₂ (ap [id] q) (glue (cin j a)) ◃∙
-        ap (λ p → ! (ap (right ∘ δ₀) (! (ap (cin j) m₁) ∙ m₂)) ∙
-          ! p ∙ ap left (ap [id] q)) (𝕕-βr (cin j a)) ◃∙
+        ap (λ p → ! (ap (right ∘ δ₀) (! (ap (cin j) m₁) ∙ m₂)) ∙ ! p ∙ ap left (ap [id] q)) (𝕕-βr (cin j a)) ◃∙
         ψ₁-free-aux q m₁ m₂ ◃∎
       ψ₁-red idp idp τ = =ₛ-in (ψ₁-red-aux τ)
-
-{-
-  q = cglue g a
-  m₁ = snd (F <#> g) a
-  m₂ = cglue g (fun (F # i) a)
-  τ = ψ₁-βr g a
--}

--- a/Colimit-code/Map-Nat/CosColimitMap06.agda
+++ b/Colimit-code/Map-Nat/CosColimitMap06.agda
@@ -2,7 +2,6 @@
 
 open import lib.Basics
 open import lib.types.Pushout
-open import lib.types.Span
 open import Coslice
 open import Diagram
 open import Colim
@@ -17,7 +16,7 @@ module _ {ℓ} {A : Type ℓ} where
 
   ap-!-rid-unit-r : {a₁ a₂ : A} (q₁ q₂ : a₁ == a₂) (α : q₂ == q₁ ∙ idp) →
     ap (λ p → ! p ∙ idp) α ∙ ap (λ p → ! p ∙ idp) (∙-unit-r q₁)
-    ==
+      ==
     ∙-unit-r (! q₂) ∙ ap ! α ∙ ap (λ v → v) (ap ! (∙-unit-r q₁) ∙ ! (∙-unit-r (! q₁))) ∙ idp
   ap-!-rid-unit-r idp q₂ idp = idp
 
@@ -28,13 +27,11 @@ module _ {ℓ₁ ℓ₂} {A : Type ℓ₁} {B : Type ℓ₂} {f : A → B} where
   ap-!-!-rid-∙ idp p₂ p₃ = ap (λ p → ! p ∙ p₃) (∙-unit-r p₂) 
 
   long-coher : {a₁ a₂ : A} (p₁ : a₁ == a₂) (p₂ : f a₁ == f a₂) (α : ap f p₁ == p₂ ∙ idp) →
-    (ap (λ p → ap f p ∙ idp) (∙-unit-r (! p₁)) ∙
-      ap (λ p → p ∙ idp) (ap-! f p₁)) ∙
+    (ap (λ p → ap f p ∙ idp) (∙-unit-r (! p₁)) ∙ ap (λ p → p ∙ idp) (ap-! f p₁)) ∙
     ap (λ p → ! p ∙ idp) α ∙
     ap (λ p → ! p ∙ idp) (∙-unit-r p₂)
-    ==
-    (∙-unit-r (ap f (! p₁ ∙ idp)) ∙
-      ap (ap f) (∙-unit-r (! p₁)) ∙ ap-! f p₁) ∙
+      ==
+    (∙-unit-r (ap f (! p₁ ∙ idp)) ∙ ap (ap f) (∙-unit-r (! p₁)) ∙ ap-! f p₁) ∙
     ap ! α ∙
     ap (λ q → q) (ap ! (∙-unit-r p₂) ∙ ! (∙-unit-r (! p₂))) ∙ idp
   long-coher idp p₂ α = ap-!-rid-unit-r p₂ idp α
@@ -44,7 +41,7 @@ module _ {ℓ₁ ℓ₂ ℓ₃} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type �
   ap2-!5-rid : {a₁ a₂ : A} (p₁ : a₁ == a₂) {b : B} (p₂ : f₂ a₂ == b) {c : C} (p₃ : c == f₁ (f₂ a₂)) →
     ! (ap f₁ (! (ap f₂ (! p₁ ∙ idp)) ∙ p₂ ∙ idp)) ∙
     ! (p₃ ∙ ap f₁ (! (ap f₂ p₁)))
-    ==
+      ==
     ! (ap f₁ p₂) ∙ ! p₃ ∙ idp
   ap2-!5-rid idp p₂ p₃ =
     ap (λ p → ! (ap f₁ p) ∙ ! (p₃ ∙ idp)) (∙-unit-r p₂) ∙
@@ -54,37 +51,36 @@ module _ {ℓ₁ ℓ₂ ℓ₃} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type �
     {c : C} (p₃ : c == f₁ (f₂ a₂)) →
     ! (ap f₁ (! (ap f₂ (p₀ ∙ ! p₁ ∙ idp)) ∙ p₂ ∙ idp)) ∙
     ! (p₃ ∙ ap f₁ (! (ap f₂ p₁)))
-    ==
+      ==
     ! (ap f₁ (! (ap f₂ p₀) ∙ p₂)) ∙ ! p₃ ∙ idp
   ap2-!5-rid-del idp p₁ p₂ p₃ = ap2-!5-rid p₁ p₂ p₃
 
   ap2-!-!-rid2 : {a₁ a₂ : A} (p₁ : a₁ == a₂) {b : B} (p₂ : b == f₂ a₁) →
     ap f₁ (! (ap f₂ p₁) ∙ ! p₂ ∙ idp) ∙ idp
-    ==
+      ==
     ! (ap (f₁ ∘ f₂) p₁) ∙ ! (ap f₁ p₂)
   ap2-!-!-rid2 idp p₂  = ∙-unit-r (ap f₁ (! p₂ ∙ idp)) ∙ ap (ap f₁) (∙-unit-r (! p₂)) ∙ ap-! f₁ p₂
 
   ap-!5-rid-∙ : {a₁ a₂ : A} (p₁ : a₁ == a₂) {b : B} (p₂ : f₂ a₂ == b) {c₁ c₂ : C} (p₃ : c₁ == f₁ (f₂ a₂))
     (p₄ : c₁ == c₂) →
     ! (ap f₁ (! (ap f₂ (! p₁ ∙ idp)) ∙ p₂)) ∙ ! (p₃ ∙ ap f₁ (! (ap f₂ p₁))) ∙ p₄
-    ==
+      ==
     ! (ap f₁ p₂) ∙ ! p₃ ∙ p₄
   ap-!5-rid-∙ idp p₂ p₃ p₄ = ap-!-!-rid-∙ p₂ p₃ p₄ 
 
-  long-coher2 : {a₁ a₂ : A} (p₁ : a₁ == a₂) {c : C} (p₂ : c == f₁ (f₂ a₂)) (p₃ : f₂ a₂ == f₂ a₁)
-    (t : idp == ! (ap f₂ (! p₁ ∙ idp)) ∙ p₃) → 
+  long-coher2 : {a₁ a₂ : A} (p₁ : a₁ == a₂) {c : C} (p₂ : c == f₁ (f₂ a₂)) (p₃ : f₂ a₂ == f₂ a₁) (t : idp == ! (ap f₂ (! p₁ ∙ idp)) ∙ p₃)
+    → 
     !-ap-!-∙ f₁ (ap f₂ p₁) p₂ idp ∙
-    ap ! (ap (λ p → p₂ ∙ ap f₁ (! p))
-      (ap (λ p → ! p ∙ ap f₂ p₁ ∙ idp) t)) ∙
+    ap ! (ap (λ p → p₂ ∙ ap f₁ (! p)) (ap (λ p → ! p ∙ ap f₂ p₁ ∙ idp) t)) ∙
     ↯ (!-!-ap-idp-!-inv f₁ p₁ p₃ p₂) ∙ idp
-    ==
+      ==
     ap (λ p → ! (ap f₁ p) ∙ ! (p₂ ∙ ap f₁ (! (ap f₂ p₁))) ∙ p₂ ∙ ! p₂) t ∙
     ap-!5-rid-∙ p₁ p₃ p₂ (p₂ ∙ ! p₂)
   long-coher2 {a₁ = a₁} idp idp p₃ t = lemma t
     where
       lemma : {q : f₂ a₁ == f₂ a₁} (u : idp == q) →
         ap ! (ap (λ p → ap f₁ (! p)) (ap (λ p → ! p ∙ idp) u)) ∙ ↯ (!-!-ap-idp-!-inv f₁ {k = f₂} idp q idp) ∙ idp
-        ==
+          ==
         ap (λ p → ! (ap f₁ p) ∙ idp) u ∙ ap-!5-rid-∙ idp q idp idp
       lemma idp = idp
 
@@ -92,7 +88,7 @@ module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄} {A : Type ℓ₁} {B : Type ℓ₂} {C : 
 
   ap2-!-!-!-rid2 : {a₁ a₂ : A} (p₁ : a₁ == a₂) {b : B} (p₂ : f₃ a₁ == b) {c : C} (p₃ : c == f₂ (f₃ a₂)) →
     ap f₁ (! (ap f₂ (! (ap f₃ p₁) ∙ p₂)) ∙ ! p₃ ∙ idp) ∙ idp
-    ==
+      ==
     ! (! (ap (f₁ ∘ f₂ ∘ f₃) p₁) ∙ ap (f₁ ∘ f₂) p₂) ∙ ! (ap f₁ p₃)
   ap2-!-!-!-rid2 idp p₂ p₃ = ap2-!-!-rid2 f₁ p₂ p₃ 
 
@@ -102,11 +98,9 @@ module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄ ℓ₅} {A : Type ℓ₁} {B : Type ℓ₂
   long-red-ap5-rid : {a₁ a₂ : A} (p₁ : a₁ == a₂) {e₁ e₂ : E} (p₂ : e₁ == e₂) {b : B} (p₃ : f₄ e₂ == b) (p₄ : f₃ a₂ == b)
     (p₅ : f₂ (f₄ e₂) == f₅ e₂) {d : D} (p₆ : d == f₁ (f₂ b)) →
     ! (! (ap (f₁ ∘ f₂ ∘ f₃) p₁) ∙
-    ap f₁ (! (ap f₂ (ap f₄ p₂ ∙ p₃ ∙ ! p₄ ∙ ! (ap f₃ p₁))) ∙
-    ap (f₂ ∘ f₄) p₂ ∙
-    p₅ ∙ ! (ap f₅ p₂))) ∙
+      ap f₁ (! (ap f₂ (ap f₄ p₂ ∙ p₃ ∙ ! p₄ ∙ ! (ap f₃ p₁))) ∙ ap (f₂ ∘ f₄) p₂ ∙ p₅ ∙ ! (ap f₅ p₂))) ∙
     ! (p₆ ∙ ap f₁ (! (ap f₂ p₄)))
-    ==
+      ==
     ap (f₁ ∘ f₅) p₂ ∙ ! (ap f₁ (! (ap f₂ p₃) ∙ p₅)) ∙ ! p₆ ∙ idp
   long-red-ap5-rid idp idp p₃ p₄ p₅ p₆ = ap2-!5-rid-del f₁ p₃ p₄ p₅ p₆ 
 
@@ -128,14 +122,13 @@ module ConstrMap7 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
       (c : cin j (fun (G # j) a) == δ₀ x)
       (t₂ : ap δ₀ r == ! (ap (cin j) (! (snd (nat δ j) a) ∙ idp)) ∙ c) →
       ψ₁-free-aux3 r idp ∙
-      ap ! (ap (λ p → glue (cin j a) ∙ ap right (! p))
-        (ap (λ p → ! p ∙ ap (cin j) (snd (nat δ j) a) ∙ idp) t₂)) ∙
+      ap ! (ap (λ p → glue (cin j a) ∙ ap right (! p)) (ap (λ p → ! p ∙ ap (cin j) (snd (nat δ j) a) ∙ idp) t₂)) ∙
       ↯ (!-!-ap-idp-!-inv right (snd (nat δ j) a) c (glue (cin j a))) ∙ idp
-      ==
-      ap (λ p → ! p ∙ ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ∙
-        glue (cin j a) ∙ ! (glue (cin j a))) (ap-∘ right δ₀ r) ∙
-      ap (λ p → ! (ap right p) ∙ ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ∙
-        glue (cin j a) ∙ ! (glue (cin j a))) t₂ ∙
+        ==
+      ap (λ p →
+           ! p ∙ ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ∙
+           glue (cin j a) ∙ ! (glue (cin j a))) (ap-∘ right δ₀ r) ∙
+      ap (λ p → ! (ap right p) ∙ ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ∙ glue (cin j a) ∙ ! (glue (cin j a))) t₂ ∙
       ap-!5-rid-∙ right (snd (nat δ j) a) c (glue (cin j a)) (glue (cin j a) ∙ ! (glue (cin j a)))
     id-free-aux4-aux2 idp c t₂ = long-coher2 right (snd (nat δ j) a) (glue (cin j a)) c t₂ 
 
@@ -148,8 +141,7 @@ module ConstrMap7 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
       (α : z == glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) →
       ap (λ p → ! (ap (right ∘ δ₀) r) ∙ ! p ∙ κ) α ◃∙
       ψ₁-free-aux2 q r ξ ◃∙
-      ap ! (ap (λ p → glue x ∙ ap right (! p))
-        (ap (λ p → ! p ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ q) t₂)) ◃∙
+      ap ! (ap (λ p → glue x ∙ ap right (! p)) (ap (λ p → ! p ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ q) t₂)) ◃∙
       ↯ (ψ₂-free-aux2 q ξ c (snd (nat δ j) a)) ◃∙
       idp ◃∎
         =ₛ
@@ -163,19 +155,16 @@ module ConstrMap7 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
       (γ₂ : left {d = SpCos₂} a == right (cin j (fst (nat δ j) x)))
       (α : ap 𝕕₀ γ₁ == γ₂ ∙ idp)
       {c : cin j (fst (nat δ j) x) == cin j (fst (nat δ j) x)} (t₂ : idp == c) →
-      (ap (λ p → ap 𝕕₀ p ∙ idp) (∙-unit-r (! γ₁)) ∙
-        ap (λ p → p ∙ idp) (ap-! 𝕕₀ γ₁)) ∙
+      (ap (λ p → ap 𝕕₀ p ∙ idp) (∙-unit-r (! γ₁)) ∙ ap (λ p → p ∙ idp) (ap-! 𝕕₀ γ₁)) ∙
       ap (λ p → ! p ∙ idp) α ∙
       ap (λ p → ! (ap right p) ∙ ! (γ₂ ∙ idp) ∙ idp) t₂ ∙
       ap-!-!-rid-∙ c γ₂ idp
-      ==
-      (∙-unit-r (ap 𝕕₀ (! γ₁ ∙ idp)) ∙
-        ap (ap 𝕕₀) (∙-unit-r (! γ₁)) ∙ ap-! 𝕕₀ γ₁) ∙
+        ==
+      (∙-unit-r (ap 𝕕₀ (! γ₁ ∙ idp)) ∙ ap (ap 𝕕₀) (∙-unit-r (! γ₁)) ∙ ap-! 𝕕₀ γ₁) ∙
       ap ! α ∙
       ap (λ p → ! (ap right p) ∙ ! (γ₂ ∙ idp)) t₂ ∙
       ap (λ p → ! (ap right p) ∙ ! (γ₂ ∙ idp)) (! (∙-unit-r c)) ∙
-      (ap (λ p → ! (ap right p) ∙ ! (γ₂ ∙ idp)) (∙-unit-r c) ∙
-        ap (_∙_ (! (ap right c))) (ap ! (∙-unit-r γ₂) ∙ ! (∙-unit-r (! γ₂)))) ∙
+      (ap (λ p → ! (ap right p) ∙ ! (γ₂ ∙ idp)) (∙-unit-r c) ∙ ap (_∙_ (! (ap right c))) (ap ! (∙-unit-r γ₂) ∙ ! (∙-unit-r (! γ₂)))) ∙
       idp
     id-free-aux4-aux-post-aux2 γ₁ γ₂ α idp = long-coher γ₁ γ₂ α
 
@@ -184,17 +173,15 @@ module ConstrMap7 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
       (γ₂ : left {d = SpCos₂} a == right (cin j y))
       (α : ap 𝕕₀ γ₁ == γ₂ ∙ ap right (! (ap (cin j) σ)))
       (t₂ : idp == ! (ap (cin j) (! σ ∙ idp)) ∙ c) → 
-      (ap (λ p → ap 𝕕₀ p ∙ idp) (∙-unit-r (! γ₁)) ∙
-        ap (λ p → p ∙ idp) (ap-! 𝕕₀ γ₁)) ∙
+      (ap (λ p → ap 𝕕₀ p ∙ idp) (∙-unit-r (! γ₁)) ∙ ap (λ p → p ∙ idp) (ap-! 𝕕₀ γ₁)) ∙
       ap (λ p → ! p ∙ idp) α ∙
       ap (λ p → ! (ap right p) ∙ ! (γ₂ ∙ ap right (! (ap (cin j) σ))) ∙ idp) t₂ ∙
       ap-!5-rid-∙ right σ c γ₂ idp
-      ==
+        ==
       (∙-unit-r (ap 𝕕₀ (! γ₁ ∙ idp)) ∙ ap (ap 𝕕₀) (∙-unit-r (! γ₁)) ∙ ap-! 𝕕₀ γ₁) ∙
       ap (λ p → ! p) α ∙
       ap (λ p → ! (ap right p) ∙ ! (γ₂ ∙ ap right (! (ap (cin j) σ)))) t₂ ∙
-      ap (λ p → ! (ap right (! (ap (cin j) (! σ ∙ idp)) ∙ p)) ∙
-        ! (γ₂ ∙ ap right (! (ap (cin j) σ)))) (! (∙-unit-r c)) ∙
+      ap (λ p → ! (ap right (! (ap (cin j) (! σ ∙ idp)) ∙ p)) ∙ ! (γ₂ ∙ ap right (! (ap (cin j) σ)))) (! (∙-unit-r c)) ∙
       ap2-!5-rid right σ c γ₂ ∙ idp
     id-free-aux4-aux-post-aux γ₁ idp c γ₂ α t₂ = id-free-aux4-aux-post-aux2 γ₁ γ₂ α t₂
 
@@ -207,14 +194,14 @@ module ConstrMap7 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
         (ap-∘ right δ₀ r) ∙
       ap (λ p → ! (ap right p) ∙ ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ∙ idp) t₂ ∙
       ap-!5-rid-∙ right (snd (nat δ j) a) c (glue (cin j a)) idp
-      ==
+        ==
       ap2-!-!-rid2 𝕕₀ r (glue (cin j a)) ∙
       ap (λ p → ! (ap (right ∘ δ₀) r) ∙ ! p) (𝕕-βr (cin j a)) ∙
       ap (λ p → ! p ∙ ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
         (ap-∘ right δ₀ r) ∙
       ap (λ p → ! (ap right p) ∙ ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a))))) t₂ ∙
-      ap (λ p → ! (ap right (! (ap (cin j) (! (snd (nat δ j) a) ∙ idp)) ∙ p)) ∙
-        ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a))))) (! (∙-unit-r c)) ∙
+      ap (λ p → ! (ap right (! (ap (cin j) (! (snd (nat δ j) a) ∙ idp)) ∙ p)) ∙ ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
+        (! (∙-unit-r c)) ∙
       ap2-!5-rid right (snd (nat δ j) a) c (glue (cin j a)) ∙ idp
     id-free-aux4-aux-post idp c t₂ =
       id-free-aux4-aux-post-aux (glue {d = SpCos₁} (cin j a)) (snd (nat δ j) a) c (glue {d = SpCos₂} (cin j a)) (𝕕-βr (cin j a)) t₂
@@ -226,26 +213,24 @@ module ConstrMap7 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
       ap2-!-!-rid 𝕕₀ {f₂ = right {d = SpCos₁}} r (glue (cin j a)) ◃∙
       ap (λ p → ! (ap (right ∘ δ₀) r) ∙ ! p ∙ idp) (𝕕-βr (cin j a)) ◃∙
       ψ₁-free-aux2 (cglue g a) r ξ ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
-        (ap (λ p → ! p ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) t₂)) ◃∙
+      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! p ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) t₂)) ◃∙
       ↯ (ψ₂-free-aux2 (cglue g a) ξ c (snd (nat δ j) a)) ◃∙
       idp ◃∎
-      =ₛ
+        =ₛ
       ap2-!-!-rid2 𝕕₀ r (glue (cin j a)) ◃∙
       ap (λ p → ! (ap (right ∘ δ₀) r) ∙ ! p) (𝕕-βr (cin j a)) ◃∙
       ap (λ p → ! p ∙ ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
         (ap-∘ right δ₀ r) ◃∙
       ap (λ p → ! (ap right p) ∙ ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a))))) t₂ ◃∙
-      ap (λ p → ! (ap right (! (ap (cin j) (! (snd (nat δ j) a) ∙ idp)) ∙ p)) ∙
-        ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a))))) (! (∙-unit-r c)) ◃∙
+      ap (λ p → ! (ap right (! (ap (cin j) (! (snd (nat δ j) a) ∙ idp)) ∙ p)) ∙ ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
+        (! (∙-unit-r c)) ◃∙
       ap2-!5-rid right (snd (nat δ j) a) c (glue (cin j a)) ◃∙
       idp ◃∎
     id-free-aux4 r c t₂ ξ =
       ap2-!-!-rid 𝕕₀ r (glue (cin j a)) ◃∙
       ap (λ p → ! (ap (right ∘ δ₀) r) ∙ ! p ∙ idp) (𝕕-βr (cin j a)) ◃∙
       ψ₁-free-aux2 (cglue g a) r ξ ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
-        (ap (λ p → ! p ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) t₂)) ◃∙
+      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! p ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) t₂)) ◃∙
       ↯ (ψ₂-free-aux2 (cglue g a) ξ c (snd (nat δ j) a)) ◃∙
       idp ◃∎
         =ₛ⟨ 1 & 5 & id-free-aux4-aux-pre (cglue g a) r c t₂ ξ (𝕕-βr (cin j a)) ⟩
@@ -261,8 +246,8 @@ module ConstrMap7 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
       ap (λ p → ! p ∙ ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
         (ap-∘ right δ₀ r) ◃∙
       ap (λ p → ! (ap right p) ∙ ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a))))) t₂ ◃∙
-      ap (λ p →  ! (ap right (! (ap (cin j) (! (snd (nat δ j) a) ∙ idp)) ∙ p)) ∙
-        ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a))))) (! (∙-unit-r c)) ◃∙
+      ap (λ p →  ! (ap right (! (ap (cin j) (! (snd (nat δ j) a) ∙ idp)) ∙ p)) ∙ ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
+        (! (∙-unit-r c)) ◃∙
       ap2-!5-rid right (snd (nat δ j) a) c (glue (cin j a)) ◃∙
       idp ◃∎ ∎ₛ    
 
@@ -270,22 +255,20 @@ module ConstrMap7 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
 
       pre-loop : (ρ : m == m') {e : ty (F # j)} (s : e == fun (F # j) a)
         {x : Colim ForgF} (d : cin j e == x) →  
-        ap 𝕕₀ (! (ap right (! (ap (cin j) s) ∙ d)) ∙
-          ! (glue (cin j a)) ∙ ap left m) ∙ idp
-        ==
-        ap 𝕕₀ (! (ap right (! (ap (cin j) s) ∙
-          d)) ∙ ! (glue (cin j a)) ∙ ap left m') ∙ idp
+        ap 𝕕₀ (! (ap right (! (ap (cin j) s) ∙ d)) ∙ ! (glue (cin j a)) ∙ ap left m) ∙ idp
+          ==
+        ap 𝕕₀ (! (ap right (! (ap (cin j) s) ∙ d)) ∙ ! (glue (cin j a)) ∙ ap left m') ∙ idp
       pre-loop idp s d = idp
       
       post-loop : (ρ : m == m') {e : ty (G # j)} (s : e == fun (G # j) a)
         {x₁ x₂ : ty (G # i)} (v : x₁ == x₂) (d : cin j e == cin i x₂) → 
         ap (right {d = SpCos₂} ∘ cin i) v ∙
-          ! (ap right (! (ap (cin j) s) ∙ d)) ∙
-          ! (glue (cin j a)) ∙ ap left m'
-        ==
+        ! (ap right (! (ap (cin j) s) ∙ d)) ∙
+        ! (glue (cin j a)) ∙ ap left m'
+          ==
         ap (right ∘ cin i) v ∙
-          ! (ap right (! (ap (cin j) s) ∙ d)) ∙
-          ! (glue (cin j a)) ∙ ap left m
+        ! (ap right (! (ap (cin j) s) ∙ d)) ∙
+        ! (glue (cin j a)) ∙ ap left m
       post-loop idp s v d = idp
 
     id-free-aux3 : {u : a == a} (ρ : u == idp) (r : cin j (fun (F # j) a) == ψ₁ (cin i a))
@@ -295,17 +278,16 @@ module ConstrMap7 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
       ap3-!-! 𝕕₀ {f₂ = right} u r (glue (cin j a)) ∙
       ap (λ p → ! (ap (right ∘ δ₀) r) ∙ ! p ∙ ap left u) (𝕕-βr (cin j a)) ∙
       ψ₁-free-aux2 (cglue g a) r ξ ∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
-        (ap (λ p → ! p ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) t₂)) ∙
+      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! p ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) t₂)) ∙
       ↯ (ψ₂-free-aux2 (cglue g a) ξ c (snd (nat δ j) a)) ∙ idp
-      ==
+        ==
       pre-loop ρ idp r ∙
       ap2-!-!-rid2 𝕕₀ r (glue (cin j a)) ∙
       ap (λ p → ! (ap (right ∘ δ₀) r) ∙ ! p) (𝕕-βr (cin j a)) ∙
       ap (λ p → ! p ∙ ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a))))) (ap-∘ right δ₀ r) ∙
       ap (λ p → ! (ap right p) ∙ ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a))))) t₂ ∙
-      ap (λ p → ! (ap right (! (ap (cin j) (! (snd (nat δ j) a) ∙ idp)) ∙ p)) ∙
-        ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a))))) (! (∙-unit-r c)) ∙
+      ap (λ p → ! (ap right (! (ap (cin j) (! (snd (nat δ j) a) ∙ idp)) ∙ p)) ∙ ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
+        (! (∙-unit-r c)) ∙
       ap2-!5-rid right (snd (nat δ j) a) c (glue (cin j a)) ∙
       post-loop ρ idp idp c
     id-free-aux3 idp r c t₂ ξ = =ₛ-out (id-free-aux4 r c t₂ ξ)
@@ -316,19 +298,17 @@ module ConstrMap7 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
       ap4-!-!-!-rid 𝕕₀ {f₂ = right} {f₃ = cin j} idp r (ap [id] (cglue g a)) (glue {d = SpCos₁} (cin j a)) ∙
       ap (λ p → ! (ap (right ∘ δ₀) r) ∙ ! p ∙ ap left (ap [id] (cglue g a))) (𝕕-βr (cin j a)) ∙
       ψ₁-free-aux2 (cglue g a) r (apCommSq-cmp left right glue (cglue g a)) ∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
-        (ap (λ p → ! p ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) t₂)) ∙
+      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! p ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) t₂)) ∙
       ↯ (ψ₂-free-aux (cglue g a) e c (snd (nat δ j) a)) ∙
       idp
-      ==
+        ==
       pre-loop ρ idp r ∙
       ap2-!-!-!-rid2 𝕕₀  {f₂ = right} {f₃ = cin j} idp r (glue {d = SpCos₁} (cin j a)) ∙
       ap (λ p → ! (ap (right ∘ δ₀) r) ∙ ! p) (𝕕-βr (cin j a)) ∙
       ap (λ p → ! p ∙ ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
         (ap-∘ right δ₀ r) ∙
       ap (λ p → ! (ap right p) ∙ ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a))))) t₂ ∙
-      ap (λ p → ! (ap right (! (ap (cin j) (e ∙ ! (snd (nat δ j) a) ∙ idp)) ∙ p)) ∙
-        ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
+      ap (λ p → ! (ap right (! (ap (cin j) (e ∙ ! (snd (nat δ j) a) ∙ idp)) ∙ p)) ∙ ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
         (! (∙-unit-r c)) ∙
       ap2-!5-rid-del right e (snd (nat δ j) a) c (glue (cin j a)) ∙
       post-loop ρ e idp c
@@ -336,82 +316,63 @@ module ConstrMap7 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
 
     id-red-aux : (ρ : ap [id] (cglue g a) == idp) (r : cin j (fun (F # j) a) == cin i (fun (F # i) a))
       {x : ty (G # i)} (d : fst (nat δ i) (fun (F # i) a) == x) (e : fst (G <#> g) x == fun (G # j) a)
-      (t₂ : ap δ₀ r == ! (ap (cin j) (ap (fst (G <#> g)) d ∙ e ∙ ! (snd (nat δ j) a) ∙ idp)) ∙
-        cglue g (fst (nat δ i) (fun (F # i) a))) → 
+      (t₂ : ap δ₀ r == ! (ap (cin j) (ap (fst (G <#> g)) d ∙ e ∙ ! (snd (nat δ j) a) ∙ idp)) ∙ cglue g (fst (nat δ i) (fun (F # i) a)))
+      → 
       ap4-!-!-!-rid 𝕕₀ {f₂ = right} {f₃ = cin j} idp r (ap [id] (cglue g a)) (glue {d = SpCos₁} (cin j a)) ∙
       ap (λ p → ! (ap (right ∘ δ₀) r) ∙ ! p ∙ ap left (ap [id] (cglue g a))) (𝕕-βr (cin j a)) ∙
       ψ₁-free-aux2 (cglue g a) r (apCommSq-cmp left right glue (cglue g a)) ∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
-        (ap (λ p → ! p ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) t₂)) ∙
+      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! p ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) t₂)) ∙
       ↯ (ψ₂-free (cglue g a) idp d e) ∙ idp
-      ==
+        ==
       pre-loop ρ idp r ∙
       ap2-!-!-!-rid2 𝕕₀ {f₂ = right} {f₃ = cin j} idp r (glue {d = SpCos₁} (cin j a)) ∙
       ap (λ p → ! (ap (right ∘ δ₀) r) ∙ ! p) (𝕕-βr (cin j a)) ∙
       ap (λ p → ! p ∙ ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
         (ap-∘ right δ₀ r) ∙
       ap (λ p → ! (ap right p) ∙ ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a))))) t₂ ∙
-      ap (λ p → ! (ap right (! (ap (cin j) (ap (fst (G <#> g)) d ∙ e ∙ ! (snd (nat δ j) a) ∙ idp)) ∙ p)) ∙
-        ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
-      (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) d) ∙
+      ap (λ p →
+           ! (ap right (! (ap (cin j) (ap (fst (G <#> g)) d ∙ e ∙ ! (snd (nat δ j) a) ∙ idp)) ∙ p)) ∙
+           ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
+        (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) d) ∙
       long-red-ap5-rid right {f₃ = fst (nat δ j)} idp d e (snd (nat δ j) a) (cglue g x) (glue (cin j a)) ∙
       post-loop ρ e d (cglue g x)
     id-red-aux ρ r idp e t₂ = id-free-aux2 ρ r e (cglue g (fst (nat δ i) (fun (F # i) a))) t₂
 
     abstract
-
       id-red : {m : a == a} (τ : ap [id] (cglue g a) == m) (ρ : m == idp)
         {e : ty (F # j)} (s : e == fun (F # j) a) (r : cin j e == cin i (fun (F # i) a))
         {w : fst (G <#> g) (fst (nat δ i) (fun (F # i) a)) == fst (nat δ j) e}
         (t₁ : w == ap (fst (G <#> g)) (snd (nat δ i) a) ∙ snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) s))
         (t₂ : ap δ₀ r == ! (ap (cin j) w) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) → 
-        ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (! (ap (λ p → ! (ap right (! (ap (cin j)
-          s) ∙ r)) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) τ))))) ◃∙
+        ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (! (ap (λ p → ! (ap right (! (ap (cin j) s) ∙ r)) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) τ))))) ◃∙
         ap4-!-!-!-rid 𝕕₀ s r (ap [id] (cglue g a)) (glue (cin j a)) ◃∙
-        ap (λ p → ! (ap (right ∘ δ₀) (! (ap (cin j) s) ∙ r)) ∙
-          ! p ∙ ap left (ap [id] (cglue g a))) (𝕕-βr (cin j a)) ◃∙ -- 𝕕
+        ap (λ p → ! (ap (right ∘ δ₀) (! (ap (cin j) s) ∙ r)) ∙ ! p ∙ ap left (ap [id] (cglue g a))) (𝕕-βr (cin j a)) ◃∙
         ψ₁-free-aux (cglue g a) s r ◃∙
-        ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (pre-cmp-!-!-∙ δ₀ (cin j) s
-          r (ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)))) ◃∙
-        ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! p ∙
-          ap (cin j ∘ fst (nat δ j)) s ∙
-          ap (cin j) (snd (nat δ j) a)  ∙ ap ψ₂ (cglue g a)) t₂)) ◃∙ -- δ₀
-        ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! p ∙ ap (cin j ∘ fst (nat δ j))
-          s ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a))
-          (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) t₁))) ◃∙ -- comSq
+        ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (pre-cmp-!-!-∙ δ₀ (cin j) s r (ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)))) ◃∙
+        ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! p ∙ ap (cin j ∘ fst (nat δ j)) s ∙
+          ap (cin j) (snd (nat δ j) a)  ∙ ap ψ₂ (cglue g a)) t₂)) ◃∙
+        ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! p ∙ ap (cin j ∘ fst (nat δ j)) s ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a))
+          (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) t₁))) ◃∙
         ↯ (ψ₂-free (cglue g a) s (snd (nat δ i) a) (snd (G <#> g) a)) ◃∙
         ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p)
-          (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (G <#> g) a)) ∙ cglue g (fun (G # i) a))) ∙
-          ! (glue (cin j a)) ∙ p) (ap (ap left) τ)))) ◃∎
+             (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (G <#> g) a)) ∙ cglue g (fun (G # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) τ)))) ◃∎
           =ₛ
         pre-loop ρ s r ◃∙
         ap2-!-!-!-rid2 𝕕₀ s r (glue (cin j a)) ◃∙
         ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) s) ∙ ap (right ∘ δ₀) r) ∙ ! p)
           (𝕕-βr (cin j a)) ◃∙
-        ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) s) ∙ p) ∙
-          ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
+        ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) s) ∙ p) ∙ ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
           (ap-∘ right δ₀ r) ◃∙
-        ap (λ p →  ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) s) ∙ ap right p) ∙
-          ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a))))) t₂ ◃∙
-        ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) s) ∙
-          ap right (! (ap (cin j) p) ∙
-          cglue g (fst (nat δ i) (fun (F # i) a)))) ∙
-          ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a))))) t₁ ◃∙
-        ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) s) ∙
-          ap (right {d = SpCos₂}) (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙
-          snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) s))) ∙ p)) ∙
-          ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
-          (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a)) ◃∙
-        long-red-ap5-rid right s (snd (nat δ i) a) (snd (G <#> g) a) (snd (nat δ j) a)
-          (cglue g (fun (G # i) a)) (glue (cin j a)) ◃∙
+        ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) s) ∙ ap right p) ∙ ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a))))) t₂ ◃∙
+        ap (λ p →
+             ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) s) ∙ ap right (! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a)))) ∙
+             ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
+           t₁ ◃∙
+        ap (λ p →
+             ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) s) ∙
+               ap (right {d = SpCos₂}) (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a)∙ snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) s))) ∙ p)) ∙
+             ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
+           (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a)) ◃∙
+        long-red-ap5-rid right s (snd (nat δ i) a) (snd (G <#> g) a) (snd (nat δ j) a) (cglue g (fun (G # i) a)) (glue (cin j a)) ◃∙
         post-loop ρ (snd (G <#> g) a) (snd (nat δ i) a) (cglue g (fun (G # i) a)) ◃∎
       id-red idp ρ idp r idp t₂ = =ₛ-in (id-red-aux ρ r (snd (nat δ i) a) (snd (G <#> g) a) t₂)
-
-{-
-  s = snd (F <#> g) a
-  r = cglue g (fun (F # i) a)
-  t₁ = comSq-coher δ g a
-  t₂ = δ₀-βr g (fun (F # i) a)
-  τ = id-βr g a
-  ρ = idp
--}

--- a/Colimit-code/Map-Nat/CosColimitMap07.agda
+++ b/Colimit-code/Map-Nat/CosColimitMap07.agda
@@ -2,7 +2,6 @@
 
 open import lib.Basics
 open import lib.types.Pushout
-open import lib.types.Span
 open import Coslice
 open import Diagram
 open import AuxPaths
@@ -18,7 +17,7 @@ module _ {ℓ₁ ℓ₂ ℓ₃} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type �
   ap2-!5-2 : {b₁ b₂ b₃ : B} (p₁ : b₁ == b₂) (κ : b₁ == b₃) {a₁ a₂ : A} (p₄ : a₁ == a₂) (p₂ : f₁ b₃ == f₁ (f₂ a₁))
     {c : C} (p₃ : c == f₁ (f₂ a₂)) →
     ! (! p₂ ∙ ap f₁ (! κ ∙ p₁)) ∙ ! (p₃ ∙ ap f₁ (! (ap f₂ p₄)))
-    =-=
+      =-=
     ! (ap f₁ (! κ ∙ p₁)) ∙ p₂ ∙ ap (f₁ ∘ f₂) p₄ ∙ ! p₃
   ap2-!5-2 idp idp idp p₂ p₃ =
     ap (λ p → p ∙ ! (p₃ ∙ idp)) (!-∙ (! p₂) idp ∙ !-! p₂) ◃∙
@@ -28,7 +27,7 @@ module _ {ℓ₁ ℓ₂ ℓ₃} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type �
     ap2-!5-rid-del f₁ p₁ d p₂ idp ∙
     ! (ap (λ q → q) (E₁ p₁ idp)) ∙
     ! (!-!-!-∘-rid f₂ f₁ p₁ d idp p₂) ∙ idp
-    ==
+      ==
     ↯ (ap2-!5-2 (p₂ ∙ idp) (ap f₂ (p₁ ∙ ! d ∙ idp)) d idp idp)
   ap2-E₁-coher idp idp idp = idp
  
@@ -48,12 +47,11 @@ module ConstrMap8 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
       {x₃ : P₂} (γ : x₃ == right (cin j (fun (G # j) a))) → 
       long-red-ap5-rid (right {d = SpCos₂}) {f₄ = fst (G <#> g)} {f₅ = cin i} σ idp c₁ d c₂ γ ∙
       ! (ap (λ q → q) (E₁ c₁ (! γ))) ∙
-      ! (long-red-ap-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g)) (cin i)
-        right idp c₁ σ d c₂ (! γ)) ∙ idp
-      ==
-      ↯ (ap2-!5-2 right (cin j) (c₂ ∙ idp) (ap (cin j) (c₁ ∙ ! d ∙
-        ! (ap (fst (nat δ j)) σ))) d
-        (ap (right ∘ cin j ∘ fst (nat δ j)) σ) γ)
+      ! (long-red-ap-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g)) (cin i) right idp c₁ σ d c₂ (! γ)) ∙ idp
+        ==
+      ↯ (ap2-!5-2 right (cin j) (c₂ ∙ idp)
+          (ap (cin j) (c₁ ∙ ! d ∙ ! (ap (fst (nat δ j)) σ))) d
+          (ap (right ∘ cin j ∘ fst (nat δ j)) σ) γ)
     comSq-red-aux c₁ c₂ idp d idp = ap2-E₁-coher right (cin j) c₁ d c₂
 
     abstract
@@ -66,37 +64,26 @@ module ConstrMap8 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
         {κ : fst (G <#> g) y₁ == fst (nat δ j) (fst (F <#> g) (fun (F # i) a))}
         (ρ : κ == ap (fst (G <#> g)) c₃ ∙ c₄ ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a))) → 
         ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙
-          ap right (! (ap (cin j) p) ∙ c₁)) ∙
-          ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a))))) ρ ◃∙
+             ap right (! (ap (cin j) p) ∙ c₁)) ∙ ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
+           ρ ◃∙
         ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙
-          ap (right {d = SpCos₂}) (! (ap (cin j) (ap (fst (G <#> g)) c₃ ∙
-          c₄ ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
-          ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a))))) ω ◃∙
-        long-red-ap5-rid right (snd (F <#> g) a) c₃ c₄ (snd (nat δ j) a)
-          c₂ (glue (cin j a)) ◃∙
+             ap (right {d = SpCos₂}) (! (ap (cin j) (ap (fst (G <#> g)) c₃ ∙
+             c₄ ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
+             ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
+           ω ◃∙
+        long-red-ap5-rid right (snd (F <#> g) a) c₃ c₄ (snd (nat δ j) a)  c₂ (glue (cin j a)) ◃∙
         idp ◃∙
-        ! (ap (λ p → ap (right ∘ cin i) c₃ ∙ p)
-          (E₁ c₄ (! (glue (cin j a))))) ◃∙
-        ! (long-red-ap-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g)) (cin i) right
-          c₃ c₄ (snd (F <#> g) a)
-          (snd (nat δ j) a) c₂ (! (glue (cin j a)))) ◃∙
+        ! (ap (λ p → ap (right ∘ cin i) c₃ ∙ p)  (E₁ c₄ (! (glue (cin j a))))) ◃∙
+        ! (long-red-ap-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g)) (cin i) right  c₃ c₄ (snd (F <#> g) a)
+            (snd (nat δ j) a) c₂ (! (glue (cin j a)))) ◃∙
         ! (ap (λ p → ! (ap right (! (ap (cin j) (ap (fst (G <#> g)) c₃ ∙
-          c₄ ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
-          ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-          ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) ω) ◃∙
+                c₄ ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
+                ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
+                ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) ω) ◃∙
         ! (ap (λ p → ! (ap right p) ∙ ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-          ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (ap (λ p → ! (ap (cin j) p) ∙ c₁) ρ)) ◃∎
+                ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (ap (λ p → ! (ap (cin j) p) ∙ c₁) ρ)) ◃∎
           =ₛ
         ↯ (ap2-!5-2 right (cin j) c₁ (ap (cin j) κ) (snd (nat δ j) a)
-          (ap (right {d = SpCos₂} ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) (glue (cin j a))) ◃∎
+            (ap (right {d = SpCos₂} ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a))
+            (glue (cin j a))) ◃∎
       comSq-red idp c₄ c₂ idp idp = =ₛ-in (comSq-red-aux c₄ c₂ (snd (F <#> g) a) (snd (nat δ j) a) (glue (cin j a))) 
-    
-{-
-  c₁ = cglue g (fst (nat δ i) (fun (F # i) a))
-  c₂ = cglue g (fun (G # i) a)
-  c₃ = snd (nat δ i) a
-  c₄ = snd (G <#> g) a
-  κ = comSq δ g (fun (F # i) a)
-  ρ = comSq-coher δ g a
-  ω = apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a)
--}

--- a/Colimit-code/Map-Nat/CosColimitMap08.agda
+++ b/Colimit-code/Map-Nat/CosColimitMap08.agda
@@ -2,7 +2,6 @@
 
 open import lib.Basics
 open import lib.types.Pushout
-open import lib.types.Span
 open import Coslice
 open import Diagram
 open import AuxPaths
@@ -19,10 +18,9 @@ module CosColimitMap08 where
 module _ {ℓ} {A : Type ℓ} where
 
   !-∙-!-!-unit-r : {a₁ a₂ : A} (p : a₁ == a₂) →
-    (! (!-∙ (! p) idp ∙ ap (λ q → q) (!-! p ∙ ! (∙-unit-r p))) ∙
-      ! (∙-unit-r (! (! p ∙ idp)))) ∙
-      ap (λ p → p ∙ idp) (!-∙ (! p) idp ∙ !-! p) ∙ idp
-    ==
+    (! (!-∙ (! p) idp ∙ ap (λ q → q) (!-! p ∙ ! (∙-unit-r p))) ∙ ! (∙-unit-r (! (! p ∙ idp)))) ∙
+    ap (λ p → p ∙ idp) (!-∙ (! p) idp ∙ !-! p) ∙ idp
+      ==
     idp
   !-∙-!-!-unit-r idp = idp
 
@@ -34,7 +32,7 @@ module _ {ℓ} {A : Type ℓ} where
     ap (λ p → ! (((p ∙ p₁') ∙ ! p₁') ∙ p₁') ∙ ! p₁)
       (ap ! p₂ ∙ ap ! (∙-unit-r p₁)) ∙
     neg-rid-trip-inv (! p₁) p₁' ∙ ap (λ p → ! p) p₂
-    ==
+      ==
     !-!-!-∙-! p₁ p₁' ∙ ap (λ p → ! p) (! (∙-unit-r p₁))
   loop-!-!-unit-r idp p₁' idp = idp
 
@@ -42,11 +40,11 @@ module _ {ℓ₁ ℓ₂ ℓ₃} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type �
 
   long-coher3 : {a₁ a₂ : A} (p₄ : a₁ == a₂) {c₁ c₂ c₃ c₄ : C} (p₁ : c₁ == f₁ (f₂ a₁))
     (p₂ : f₁ (f₂ a₁) == c₃) (p₃ : c₂ == f₁ (f₂ a₂)) (p₅ : c₁ == c₄) →
-    ! ((p₁ ∙ (p₂ ∙ ! p₂) ∙ ! p₁) ∙ p₅ ∙ idp) ∙ p₁ ∙
-    ap (f₁ ∘ f₂) p₄ ∙ ! p₃
-    =-=
+    ! ((p₁ ∙ (p₂ ∙ ! p₂) ∙ ! p₁) ∙ p₅ ∙ idp) ∙ p₁ ∙ ap (f₁ ∘ f₂) p₄ ∙ ! p₃
+      =-=
     ! (! p₁ ∙ p₅) ∙ ! (p₃ ∙ ap f₁ (! (ap f₂ p₄)))
-  long-coher3 idp idp idp p₂ p₃ = ap (λ p → ! p ∙ ! p₂) (∙-unit-r p₃) ◃∙ ap (λ p → ! p₃ ∙ ! p) (! (∙-unit-r p₂)) ◃∎ 
+  long-coher3 idp idp idp p₂ p₃ =
+    ap (λ p → ! p ∙ ! p₂) (∙-unit-r p₃) ◃∙ ap (λ p → ! p₃ ∙ ! p) (! (∙-unit-r p₂)) ◃∎ 
 
 module ConstrMap9 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ} {F : CosDiag ℓF ℓ A Γ} {G : CosDiag ℓG ℓ A Γ} (δ : CosDiagMor A F G) where
 
@@ -59,17 +57,18 @@ module ConstrMap9 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
   module MapCoher8 {i j : Obj Γ} (g : Hom Γ i j) (a : A) where     
 
     𝕕-red-aux : {x : Colim ForgF} (c : cin j (fst (F <#> g) (fun (F # i) a)) == x)
-      (d₂ : right (cin j (fst (nat δ j) (fst (F <#> g) (fun (F # i) a)))) ==
+      (d₂ :
+        right (cin j (fst (nat δ j) (fst (F <#> g) (fun (F # i) a))))
+          ==
         right (cin j (fst (nat δ j) (fst (F <#> g) (fun (F # i) a)))))
       (ρ : idp == d₂ ∙ idp) →
-      ap (λ p → ! (((p ∙ idp) ∙ idp) ∙
-        ap 𝕕₀ (ap right c) ∙ idp) ∙ ! d₂)
+      ap (λ p → ! (((p ∙ idp) ∙ idp) ∙ ap 𝕕₀ (ap right c) ∙ idp) ∙ ! d₂)
         (ap ! ρ ∙ ap ! (∙-unit-r d₂)) ∙
       !-∙-!-rid-∙-rid (ap 𝕕₀ (ap (right {d = SpCos₁}) c)) (! d₂) idp ∙
       ap (λ q → q) (!-ap-∙-s 𝕕₀ (ap right c)) ∙
       ap2-!-!-rid2 𝕕₀ c idp ∙
       ap (λ p → ! (ap (𝕕₀ ∘ right) c) ∙ ! p) ρ
-      ==
+        ==
       ap (λ p → ! (p ∙ idp) ∙ ! d₂)
         (∘-ap 𝕕₀ (right {d = SpCos₁}) c) ∙
       ap (λ p → ! p ∙ ! d₂) (∙-unit-r (ap (right ∘ δ₀) c)) ∙
@@ -80,12 +79,10 @@ module ConstrMap9 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
       {x : ty (G # j)} (d₁ : fst (nat δ j) z == x)
       {y : P₁} (d₃ : y == right (cin j z)) (d₂ : 𝕕₀ y == right (cin j x))
       (ρ : ap 𝕕₀ d₃ == d₂ ∙ ap right (! (ap (cin j) d₁))) →
-      ap (λ p → ! ((ap (right ∘ cin j ∘ (fst (nat δ j))) d₄ ∙
-        (p ∙ ! (ap 𝕕₀ (! d₃) ∙ idp)) ∙
-        ! (ap (𝕕₀ ∘ right ∘ cin j) d₄)) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) d₄ ∙ ap (right ∘ cin j) d₁ ∙ ! d₂)
-        (ap-inv-rid 𝕕₀ d₃ ∙ ap ! ρ ∙
-        !-!-ap-∘ (cin j) right d₁ d₂) ◃∙
+      ap (λ p → ! ((ap (right ∘ cin j ∘ (fst (nat δ j))) d₄ ∙ (p ∙ ! (ap 𝕕₀ (! d₃) ∙ idp)) ∙
+           ! (ap (𝕕₀ ∘ right ∘ cin j) d₄)) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) d₄ ∙ ap (right ∘ cin j) d₁ ∙ ! d₂)
+         (ap-inv-rid 𝕕₀ d₃ ∙ ap ! ρ ∙ !-!-ap-∘ (cin j) right d₁ d₂) ◃∙
       long-path-red d₄ (ap (right ∘ cin j) d₁ ∙ ! d₂)
         (ap 𝕕₀ (! d₃) ∙ idp)
         (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) idp ◃∙
@@ -93,26 +90,16 @@ module ConstrMap9 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
       ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₁ d₄ (! d₃)))) ◃∙
       idp ◃∙
       ap2-!-!-!-rid2 𝕕₀ d₄ (cglue g (fun (F # i) a)) d₃ ◃∙
-      ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) d₄) ∙
-        ap (𝕕₀ ∘ right) (cglue g (fun (F # i) a))) ∙ ! p) ρ ◃∎
+      ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) d₄) ∙ ap (𝕕₀ ∘ right) (cglue g (fun (F # i) a))) ∙ ! p) ρ ◃∎
         =ₛ
-      ap (λ p → ! ((ap (right ∘ cin j ∘ fst (nat δ j)) d₄ ∙
-        ((ap 𝕕₀ (! d₃) ∙ idp) ∙
-        ! (ap 𝕕₀ (! d₃) ∙ idp)) ∙
-        ! (ap (right ∘ δ₀ ∘ cin j) d₄)) ∙ p ∙ idp) ∙
-        ap (right ∘ cin j ∘ fst (nat δ j)) d₄ ∙
-        ap (right ∘ cin j) d₁ ∙ ! d₂) (∘-ap 𝕕₀ right (cglue g (fun (F # i) a))) ◃∙
+      ap (λ p →
+           ! ((ap (right ∘ cin j ∘ fst (nat δ j)) d₄ ∙
+             ((ap 𝕕₀ (! d₃) ∙ idp) ∙ ! (ap 𝕕₀ (! d₃) ∙ idp)) ∙ ! (ap (right ∘ δ₀ ∘ cin j) d₄)) ∙ p ∙ idp) ∙
+           ap (right ∘ cin j ∘ fst (nat δ j)) d₄ ∙
+           ap (right ∘ cin j) d₁ ∙ ! d₂) (∘-ap 𝕕₀ right (cglue g (fun (F # i) a))) ◃∙
       ↯ (long-coher3 (right {d = SpCos₂}) (cin j) d₁ (ap (right ∘ cin j ∘ fst (nat δ j)) d₄)
         (ap 𝕕₀ (! d₃) ∙ idp) d₂ (ap (right ∘ δ₀) (cglue g (fun (F # i) a)))) ◃∎
     𝕕-red idp idp idp d₂ ρ = =ₛ-in (𝕕-red-aux (cglue g (fun (F # i) a)) d₂ ρ)
-
-{-
-  d₁ = snd (nat δ j) a
-  d₂ = glue {d = SpCos₂} (cin j a)
-  d₃ = glue {d = SpCos₁} (cin j a)
-  d₄ = snd (F <#> g) a
-  ρ = 𝕕-βr (cin j a)
--}
 
     δ₀-free : {x₁ x₂ : Colim ForgG} (κ : x₁ == x₂) {z₁ z₂ : ty (G # j)}
       (p₂ : z₁ == z₂) {y : P₂} (p₃ : y == right (cin j z₂))
@@ -120,7 +107,7 @@ module ConstrMap9 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
       ! (ap (right {d = SpCos₂}) κ) ∙
       p₁ ∙
       ap (right ∘ cin j) p₂ ∙ ! p₃
-      =-=
+        =-=
       ! (! p₁ ∙ ap right κ) ∙
       ! (p₃ ∙ ap right (! (ap (cin j) p₂)))
     δ₀-free κ idp idp p₁ = 
@@ -128,83 +115,75 @@ module ConstrMap9 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
       ! (∙-unit-r (! (! p₁ ∙ ap right κ))) ◃∎
 
     δ₀-red-aux2 : {v : ty (F # j)} {x : P₁} (e₁ : x == right (cin j v))
-      {z : ty (G # j)} (d : fst (nat δ j) v == z) {y : P₂} (e₂ : y == right (cin j z))  → 
-      ap (λ p → ! (p ∙ idp) ∙
-        ap (right ∘ cin j) d ∙ ! e₂)
+      {z : ty (G # j)} (d : fst (nat δ j) v == z) {y : P₂} (e₂ : y == right (cin j z)) → 
+      ap (λ p → ! (p ∙ idp) ∙ ap (right ∘ cin j) d ∙ ! e₂)
         (!-∙-!-!-rid (ap 𝕕₀ (! e₁) ∙ idp) idp) ∙
-      ↯ (long-coher3 right (cin j) d idp
-        (ap 𝕕₀ (! e₁) ∙ idp) e₂ idp) ∙ idp
-      ==
+      ↯ (long-coher3 right (cin j) d idp (ap 𝕕₀ (! e₁) ∙ idp) e₂ idp) ∙ idp
+        ==
       ↯ (δ₀-free idp d e₂ idp)
     δ₀-red-aux2 idp idp idp = idp
 
     δ₀-red-aux : {z : ty (F # j)} (s : z == fun (F # j) a)
       {x : Colim ForgF} (c : cin j z == x) →
-      ! (ap (λ p → ! p ∙ ap (right ∘ cin j ∘ fst (nat δ j)) s ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
-        (∙-unit-r (ap 𝕕₀ (ap right c)) ∙
-        ∘-ap 𝕕₀ right c ∙
-        ap-∘ right δ₀ c ∙ idp)) ∙
+      ! (ap (λ p → ! p ∙ ap (right ∘ cin j ∘ fst (nat δ j)) s ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+          (∙-unit-r (ap 𝕕₀ (ap right c)) ∙ ∘-ap 𝕕₀ right c ∙ ap-∘ right δ₀ c ∙ idp)) ∙
       ap (λ p → ! (p ∙ ap 𝕕₀ (ap right c) ∙ idp) ∙
-        ap (right ∘ cin j ∘ fst (nat δ j)) s ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
-        (hmtpy-nat-rev (λ x → idp) s
-        (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
+           ap (right ∘ cin j ∘ fst (nat δ j)) s ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (hmtpy-nat-rev (λ x → idp) s (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
       ap (λ p → ! ((ap (right ∘ cin j ∘ fst (nat δ j)) s ∙
-        ((ap 𝕕₀ (! (glue (cin j a))) ∙ idp) ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
-        ! (ap (right ∘ δ₀ ∘ cin j) s)) ∙ p ∙ idp) ∙
-        ap (right ∘ cin j ∘ fst (nat δ j)) s ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
-        (∘-ap 𝕕₀ right c) ∙
+           ((ap 𝕕₀ (! (glue (cin j a))) ∙ idp) ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
+           ! (ap (right ∘ δ₀ ∘ cin j) s)) ∙ p ∙ idp) ∙
+           ap (right ∘ cin j ∘ fst (nat δ j)) s ∙
+           ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (∘-ap 𝕕₀ right c) ∙
       ↯ (long-coher3 right (cin j) (snd (nat δ j) a)
-        (ap (right ∘ cin j ∘ fst (nat δ j)) s)
-        (ap 𝕕₀ (! (glue (cin j a))) ∙ idp) (glue (cin j a))
-        (ap (right ∘ δ₀) c)) ∙
+          (ap (right ∘ cin j ∘ fst (nat δ j)) s)
+          (ap 𝕕₀ (! (glue (cin j a))) ∙ idp) (glue (cin j a))
+          (ap (right ∘ δ₀) c)) ∙
       ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) s) ∙ p) ∙
-        ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
-        (ap-∘ right δ₀ c) ∙ idp
-      ==
+           ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
+         (ap-∘ right δ₀ c) ∙ idp
+        ==
       ↯ (δ₀-free (ap δ₀ c) (snd (nat δ j) a) (glue (cin j a)) (ap (right ∘ cin j ∘ fst (nat δ j)) s))
     δ₀-red-aux idp idp = δ₀-red-aux2 (glue (cin j a)) (snd (nat δ j) a) (glue (cin j a))
 
-    δ₀-red : {κ : cin j (fst (nat δ j) (fst (F <#> g) (fun (F # i) a))) ==
-      cin i (fst (nat δ i) (fun (F # i) a))} (τ : ap δ₀ (cglue g (fun (F # i) a)) == κ) →
+    δ₀-red :
+      {κ :
+        cin j (fst (nat δ j) (fst (F <#> g) (fun (F # i) a)))
+          ==
+        cin i (fst (nat δ i) (fun (F # i) a))}
+      (τ : ap δ₀ (cglue g (fun (F # i) a)) == κ) →
       ! (ap (λ p → ! p ∙ ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (
-          ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
-          ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
-          ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
-          ap (ap right) τ)) ◃∙
+            ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+            (
+            ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
+            ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
+            ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
+            ap (ap right) τ)) ◃∙
       ap (λ p → ! (p ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
       ap (λ p → ! ((ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ((ap 𝕕₀ (! (glue {d = SpCos₁} (cin j a))) ∙ idp) ∙
-        ! (ap 𝕕₀ (! (glue {d = SpCos₁} (cin j a))) ∙ idp)) ∙
-        ! (ap (right ∘ δ₀ ∘ cin j) (snd (F <#> g) a))) ∙ p ∙ idp) ∙
-      ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-      ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue {d = SpCos₂} (cin j a))) (∘-ap 𝕕₀ right (cglue g (fun (F # i) a))) ◃∙
+           ((ap 𝕕₀ (! (glue {d = SpCos₁} (cin j a))) ∙ idp) ∙
+           ! (ap 𝕕₀ (! (glue {d = SpCos₁} (cin j a))) ∙ idp)) ∙
+           ! (ap (right ∘ δ₀ ∘ cin j) (snd (F <#> g) a))) ∙ p ∙ idp) ∙
+           ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
+           ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue {d = SpCos₂} (cin j a)))
+         (∘-ap 𝕕₀ right (cglue g (fun (F # i) a))) ◃∙
       ↯ (long-coher3 (right {d = SpCos₂}) (cin j) (snd (nat δ j) a) (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a))
-        (ap 𝕕₀ (! (glue {d = SpCos₁} (cin j a))) ∙ idp) (glue {d = SpCos₂} (cin j a)) (ap (right ∘ δ₀)
-        (cglue g (fun (F # i) a)))) ◃∙
+          (ap 𝕕₀ (! (glue {d = SpCos₁} (cin j a))) ∙ idp) (glue {d = SpCos₂} (cin j a)) (ap (right ∘ δ₀)
+          (cglue g (fun (F # i) a)))) ◃∙
       ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ p) ∙
-        ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
-        (ap-∘ right δ₀ (cglue g (fun (F # i) a))) ◃∙
+           ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
+         (ap-∘ right δ₀ (cglue g (fun (F # i) a))) ◃∙
       ap (λ p →  ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ ap right p) ∙
-      ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a))))) τ ◃∎
+           ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a))))) τ ◃∎
         =ₛ
       ↯ (δ₀-free κ (snd (nat δ j) a) (glue (cin j a))
         (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a))) ◃∎
     δ₀-red idp = =ₛ-in (δ₀-red-aux (snd (F <#> g) a) (cglue g (fun (F # i) a)))
 
-{-
-  κ = ! (ap (cin j) (comSq δ g (fun (F # i) a))) ∙
-        cglue g (fst (nat δ i) (fun (F # i) a))
-  τ = δ₀-βr g (fun (F # i) a)
--}
-
     abstract
-    
       δ₀-comSq-red : {x₁ x₂ x₃ : Colim ForgG} (c₁ : x₁ == x₂) (c₂ : x₁ == x₃)
         {y₁ y₂ : ty (G # j)} (c₃ : y₁ == y₂) (c₄ : right x₃ == right (cin j y₁))
         {z : P₂} (c₅ : z == right (cin j y₂)) →
@@ -213,11 +192,3 @@ module ConstrMap9 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ
           =ₛ
         idp ◃∎
       δ₀-comSq-red idp idp idp c₄ idp = =ₛ-in (!-∙-!-!-unit-r c₄)
-
-{-
-  c₁ = cglue g (fst (nat δ i) (fun (F # i) a))
-  c₂ = ap (cin j) (comSq δ g (fun (F # i) a))
-  c₃ = snd (nat δ j) a
-  c₄ = ap (right {d = SpCos₂} ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)
-  c₅ = glue (cin j a)
--}

--- a/Colimit-code/Map-Nat/CosColimitMap09.agda
+++ b/Colimit-code/Map-Nat/CosColimitMap09.agda
@@ -2,7 +2,6 @@
 
 open import lib.Basics
 open import lib.types.Pushout
-open import lib.types.Span
 open import Coslice
 open import Diagram
 open import Colim
@@ -29,30 +28,31 @@ module ConstrMap10 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type �
 
     fib-coher-pre0 = 
       ! (ap (λ p → ! p ∙ ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (
-          ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
-          ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
-          ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
-          ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
+              ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+            (
+            ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
+            ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
+            ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
+            ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
       ap (λ p → ! (p ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
       ap (λ p → ! ((ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
-        ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙
-        !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙ 
+             (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
+             ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙ !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙ 
       long-path-red (snd (F <#> g) a) (ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
         (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)
         (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) idp ◃∙
       ap (λ q → q) (ap-cp-revR 𝕕₀ (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))) ◃∙
       ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₁ (snd (F <#> g) a) (! (glue (cin j a)))))) ◃∙
-      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (! (ap (λ p → ! (ap right (! (ap (cin j)
-        (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p)
-        (ap (ap left) (id-βr g a)))))) ◃∙
-      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₃ (λ x → ! (glue x)) (cglue g a)
-        (ψ₁-βr g a) (λ x → idp)))) ◃∙ 
+      ap (λ q → q)
+        (ap (λ p → p ∙ idp)
+          (ap (ap 𝕕₀)
+            (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p)
+                 (ap (ap left) (id-βr g a)))))) ◃∙
+      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₃ (λ x → ! (glue x)) (cglue g a) (ψ₁-βr g a) (λ x → idp)))) ◃∙ 
       ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (∙-unit-r (! (glue (cin i a)))))) ◃∙
       ! (apd-tr (λ z → ap 𝕕₀ (! (glue z)) ∙ idp) (cglue g a)) ◃∙
       ap (transport (λ z → right (δ₀ (ψ F z)) == left ([id] z)) (cglue g a))
@@ -60,111 +60,112 @@ module ConstrMap10 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type �
       transp-inv-comm (left ∘ [id]) (right ∘ δ₀ ∘ ψ F) (cglue g a)
         (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ◃∙
       ap ! (apd-ap-∙-l right {F = glue} {G = ℂ} (cglue g a)) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (transp-pth-cmpL δ₀ ψ₁ ψ₂ (cglue g a)
-        (ap (cin j) (snd (nat δ j) a)))) ◃∙
+      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (transp-pth-cmpL δ₀ ψ₁ ψ₂ (cglue g a) (ap (cin j) (snd (nat δ j) a)))) ◃∙
+      ap !
+        (ap (λ p → glue (cin i a) ∙ ap right (! p))
+          (ap (λ p → ! (ap δ₀ p) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (ψ₁-βr g a))) ◃∙ 
+      ap !
+        (ap (λ p → glue (cin i a) ∙ ap right (! p))
+          (pre-cmp-!-!-∙ δ₀ (cin j) (snd (F <#> g) a) (cglue g (fun (F # i) a))
+          (ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)))) ◃∙
       ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
-        (ap (λ p → ! (ap δ₀ p) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (ψ₁-βr g a))) ◃∙ 
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (pre-cmp-!-!-∙ δ₀ (cin j) (snd (F <#> g) a)
-        (cglue g (fun (F # i) a)) (ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)))) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! p ∙
-        ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (δ₀-βr g (fun (F # i) a)))) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! p ∙ ap (cin j ∘ fst (nat δ j))
-        (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a))
-        (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a)))
-        (comSq-coher δ g a)))) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! (! (ap (cin j) (ap (fst (G <#> g))
-        (snd (nat δ i) a) ∙ snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j))
-        (snd (F <#> g) a)))) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) ∙
-        ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ p)
-        (ψ₂-βr g a))) ◃∙ 
+             (ap (λ p → ! p ∙ ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
+               ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (δ₀-βr g (fun (F # i) a)))) ◃∙
       ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
-        (long-red-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g))
-        (snd (nat δ i) a) (snd (G <#> g) a) (snd (F <#> g) a)
-        (snd (nat δ j) a) (cglue g (fst (nat δ i) (fun (F # i) a)))
-        (cglue g (fun (G # i) a)))) ◃∙
+             (ap (λ p → ! p ∙ ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a))
+               (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a)))) ◃∙
       ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
-        (apCommSq (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))) ◃∙
+             (ap (λ p → ! (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙
+                 snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙
+                 cglue g (fst (nat δ i) (fun (F # i) a))) ∙
+                 ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ p)
+               (ψ₂-βr g a))) ◃∙ 
+      ap !
+        (ap (λ p → glue (cin i a) ∙ ap right (! p))
+          (long-red-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g))
+            (snd (nat δ i) a) (snd (G <#> g) a) (snd (F <#> g) a)
+            (snd (nat δ j) a) (cglue g (fst (nat δ i) (fun (F # i) a)))
+            (cglue g (fun (G # i) a)))) ◃∙
+      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (apCommSq (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))) ◃∙
       !-!-ap-∘ (cin i) right (snd (nat δ i) a) (glue (cin i a)) ◃∙    
       ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p) (∙-unit-r (! (glue (cin i a))))) ◃∙
       ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p)
-        (E₃ (λ x → ! (glue x)) (cglue g a) (ψ₂-βr g a) (λ x → idp))) ◃∙ 
+          (E₃ (λ x → ! (glue x)) (cglue g a) (ψ₂-βr g a) (λ x → idp))) ◃∙ 
       ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p)
-        (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (G <#> g) a)) ∙ cglue g (fun (G # i) a))) ∙
-        ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
-      ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p)
-        (E₁ (snd (G <#> g) a) (! (glue (cin j a))))) ◃∙
-      ! (long-red-ap-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g)) (cin i) right
-        (snd (nat δ i) a) (snd (G <#> g) a) (snd (F <#> g) a)
-        (snd (nat δ j) a) (cglue g (fun (G # i) a)) (! (glue (cin j a)))) ◃∙
+          (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (G <#> g) a)) ∙ cglue g (fun (G # i) a))) ∙ ! (glue (cin j a)) ∙ p)
+               (ap (ap left) (id-βr g a))))) ◃∙
+      ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p) (E₁ (snd (G <#> g) a) (! (glue (cin j a))))) ◃∙
+      ! (long-red-ap-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g)) (cin i) right (snd (nat δ i) a) (snd (G <#> g) a)
+          (snd (F <#> g) a) (snd (nat δ j) a) (cglue g (fun (G # i) a)) (! (glue (cin j a)))) ◃∙
       ! (ap (λ p → ! (ap right (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙
-        snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
-        ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
-        (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))) ◃∙
+              snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
+              ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
+              ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+            (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))) ◃∙
       ! (ap (λ p → ! (ap right p) ∙ ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (ap (λ p → ! (ap (cin j) p) ∙
-        cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a))) ◃∎
+            ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+          (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a))) ◃∎
         =ₛ⟨ 18 & 6 & ψ₂-red (snd (F <#> g) a) (snd (nat δ i) a) ⟩
       ! (ap (λ p → ! p ∙ ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (
-          ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
-          ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
-          ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
-          ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
+              ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+            (
+            ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
+            ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
+            ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
+            ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
       ap (λ p → ! (p ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
       ap (λ p → ! ((ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
-        ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙
-        !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙ 
+             (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
+             ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙ !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙ 
       long-path-red (snd (F <#> g) a) (ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
         (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)
         (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) idp ◃∙
       ap (λ q → q) (ap-cp-revR 𝕕₀ (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))) ◃∙
       ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₁ (snd (F <#> g) a) (! (glue (cin j a)))))) ◃∙
-      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (! (ap (λ p → ! (ap right (! (ap (cin j)
-        (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p)
-        (ap (ap left) (id-βr g a)))))) ◃∙
-      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₃ (λ x → ! (glue x)) (cglue g a)
-        (ψ₁-βr g a) (λ x → idp)))) ◃∙ 
+      ap (λ q → q)
+        (ap (λ p → p ∙ idp)
+          (ap (ap 𝕕₀)
+            (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p)
+                 (ap (ap left) (id-βr g a)))))) ◃∙
+      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₃ (λ x → ! (glue x)) (cglue g a) (ψ₁-βr g a) (λ x → idp)))) ◃∙ 
       ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (∙-unit-r (! (glue (cin i a)))))) ◃∙
       ! (apd-tr (λ z → ap 𝕕₀ (! (glue z)) ∙ idp) (cglue g a)) ◃∙
       ap (transport (λ z → right (δ₀ (ψ F z)) == left ([id] z)) (cglue g a))
-        (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a))) ◃∙
+        (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a))) ◃∙ 
       transp-inv-comm (left ∘ [id]) (right ∘ δ₀ ∘ ψ F) (cglue g a)
         (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ◃∙
       ap ! (apd-ap-∙-l right {F = glue} {G = ℂ} (cglue g a)) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (transp-pth-cmpL δ₀ ψ₁ ψ₂ (cglue g a)
-        (ap (cin j) (snd (nat δ j) a)))) ◃∙
+      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (transp-pth-cmpL δ₀ ψ₁ ψ₂ (cglue g a) (ap (cin j) (snd (nat δ j) a)))) ◃∙
+      ap !
+        (ap (λ p → glue (cin i a) ∙ ap right (! p))
+          (ap (λ p → ! (ap δ₀ p) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (ψ₁-βr g a))) ◃∙ 
+      ap !
+        (ap (λ p → glue (cin i a) ∙ ap right (! p))
+          (pre-cmp-!-!-∙ δ₀ (cin j) (snd (F <#> g) a) (cglue g (fun (F # i) a))
+          (ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)))) ◃∙
       ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
-        (ap (λ p → ! (ap δ₀ p) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (ψ₁-βr g a))) ◃∙ 
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (pre-cmp-!-!-∙ δ₀ (cin j) (snd (F <#> g) a)
-        (cglue g (fun (F # i) a)) (ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)))) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! p ∙
-        ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (δ₀-βr g (fun (F # i) a)))) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! p ∙ ap (cin j ∘ fst (nat δ j))
-        (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a))
-        (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a)))
-        (comSq-coher δ g a)))) ◃∙
+             (ap (λ p → ! p ∙ ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
+               ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (δ₀-βr g (fun (F # i) a)))) ◃∙
+      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
+             (ap (λ p → ! p ∙ ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a))
+               (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a)))) ◃∙
       ↯ (ψ₂-free (cglue g a) (snd (F <#> g) a) (snd (nat δ i) a) (snd (G <#> g) a)) ◃∙
       ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p)
-        (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (G <#> g) a)) ∙ cglue g (fun (G # i) a))) ∙
-        ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
-      ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p)
-        (E₁ (snd (G <#> g) a) (! (glue (cin j a))))) ◃∙
+          (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (G <#> g) a)) ∙ cglue g (fun (G # i) a))) ∙ ! (glue (cin j a)) ∙ p)
+               (ap (ap left) (id-βr g a))))) ◃∙
+      ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p) (E₁ (snd (G <#> g) a) (! (glue (cin j a))))) ◃∙
       ! (long-red-ap-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g)) (cin i) right
-        (snd (nat δ i) a) (snd (G <#> g) a) (snd (F <#> g) a)
-        (snd (nat δ j) a) (cglue g (fun (G # i) a)) (! (glue (cin j a)))) ◃∙
+          (snd (nat δ i) a) (snd (G <#> g) a) (snd (F <#> g) a)
+          (snd (nat δ j) a) (cglue g (fun (G # i) a)) (! (glue (cin j a)))) ◃∙
       ! (ap (λ p → ! (ap right (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙
-        snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
-        ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
-        (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))) ◃∙
+            snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
+            ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
+            ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+          (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))) ◃∙
       ! (ap (λ p → ! (ap right p) ∙ ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (ap (λ p → ! (ap (cin j) p) ∙
-        cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a))) ◃∎ ∎ₛ
+            ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+            (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a))) ◃∎ ∎ₛ

--- a/Colimit-code/Map-Nat/CosColimitMap10.agda
+++ b/Colimit-code/Map-Nat/CosColimitMap10.agda
@@ -2,7 +2,6 @@
 
 open import lib.Basics
 open import lib.types.Pushout
-open import lib.types.Span
 open import Coslice
 open import Diagram
 open import Helper-paths
@@ -32,119 +31,121 @@ module ConstrMap11 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type �
 
     fib-coher-pre1 =
       ! (ap (λ p → ! p ∙ ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (
-          ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
-          ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
-          ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
-          ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
+              ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+            (
+            ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
+            ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
+            ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
+            ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
       ap (λ p → ! (p ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
       ap (λ p → ! ((ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
-        ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙
-        !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙
+             (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
+             ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙ !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙ 
       long-path-red (snd (F <#> g) a) (ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
         (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)
         (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) idp ◃∙
       ap (λ q → q) (ap-cp-revR 𝕕₀ (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))) ◃∙
       ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₁ (snd (F <#> g) a) (! (glue (cin j a)))))) ◃∙
-      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (! (ap (λ p → ! (ap right (! (ap (cin j)
-        (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p)
-        (ap (ap left) (id-βr g a)))))) ◃∙
-      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₃ (λ x → ! (glue x)) (cglue g a)
-        (ψ₁-βr g a) (λ x → idp)))) ◃∙
+      ap (λ q → q)
+        (ap (λ p → p ∙ idp)
+          (ap (ap 𝕕₀)
+            (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p)
+                 (ap (ap left) (id-βr g a)))))) ◃∙
+      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₃ (λ x → ! (glue x)) (cglue g a) (ψ₁-βr g a) (λ x → idp)))) ◃∙ 
       ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (∙-unit-r (! (glue (cin i a)))))) ◃∙
       ! (apd-tr (λ z → ap 𝕕₀ (! (glue z)) ∙ idp) (cglue g a)) ◃∙
       ap (transport (λ z → right (δ₀ (ψ F z)) == left ([id] z)) (cglue g a))
-        (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a))) ◃∙
+        (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a))) ◃∙ 
       transp-inv-comm (left ∘ [id]) (right ∘ δ₀ ∘ ψ F) (cglue g a)
         (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ◃∙
       ap ! (apd-ap-∙-l right {F = glue} {G = ℂ} (cglue g a)) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (transp-pth-cmpL δ₀ ψ₁ ψ₂ (cglue g a)
-        (ap (cin j) (snd (nat δ j) a)))) ◃∙
+      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (transp-pth-cmpL δ₀ ψ₁ ψ₂ (cglue g a) (ap (cin j) (snd (nat δ j) a)))) ◃∙
+      ap !
+        (ap (λ p → glue (cin i a) ∙ ap right (! p))
+          (ap (λ p → ! (ap δ₀ p) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (ψ₁-βr g a))) ◃∙ 
+      ap !
+        (ap (λ p → glue (cin i a) ∙ ap right (! p))
+          (pre-cmp-!-!-∙ δ₀ (cin j) (snd (F <#> g) a) (cglue g (fun (F # i) a))
+          (ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)))) ◃∙
       ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
-        (ap (λ p → ! (ap δ₀ p) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (ψ₁-βr g a))) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (pre-cmp-!-!-∙ δ₀ (cin j) (snd (F <#> g) a)
-        (cglue g (fun (F # i) a)) (ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)))) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! p ∙
-        ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (δ₀-βr g (fun (F # i) a)))) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! p ∙ ap (cin j ∘ fst (nat δ j))
-        (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a))
-        (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a)))
-        (comSq-coher δ g a)))) ◃∙
+             (ap (λ p → ! p ∙ ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
+               ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (δ₀-βr g (fun (F # i) a)))) ◃∙
+      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
+             (ap (λ p → ! p ∙ ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a))
+               (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a)))) ◃∙
       ↯ (ψ₂-free (cglue g a) (snd (F <#> g) a) (snd (nat δ i) a) (snd (G <#> g) a)) ◃∙
       ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p)
-        (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (G <#> g) a)) ∙ cglue g (fun (G # i) a))) ∙
-        ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
-      ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p)
-        (E₁ (snd (G <#> g) a) (! (glue (cin j a))))) ◃∙
+          (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (G <#> g) a)) ∙ cglue g (fun (G # i) a))) ∙ ! (glue (cin j a)) ∙ p)
+               (ap (ap left) (id-βr g a))))) ◃∙
+      ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p) (E₁ (snd (G <#> g) a) (! (glue (cin j a))))) ◃∙
       ! (long-red-ap-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g)) (cin i) right
-        (snd (nat δ i) a) (snd (G <#> g) a) (snd (F <#> g) a)
-        (snd (nat δ j) a) (cglue g (fun (G # i) a)) (! (glue (cin j a)))) ◃∙
+          (snd (nat δ i) a) (snd (G <#> g) a) (snd (F <#> g) a)
+          (snd (nat δ j) a) (cglue g (fun (G # i) a)) (! (glue (cin j a)))) ◃∙
       ! (ap (λ p → ! (ap right (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙
-        snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
-        ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
-        (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))) ◃∙
+            snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
+            ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
+            ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+          (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))) ◃∙
       ! (ap (λ p → ! (ap right p) ∙ ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (ap (λ p → ! (ap (cin j) p) ∙
-        cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a))) ◃∎
+            ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+            (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a))) ◃∎
         =ₛ⟨ 7 & 8 & ψ₁-red (cglue g a) (snd (F <#> g) a) (ψ₁-βr g a) ⟩
       ! (ap (λ p → ! p ∙ ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (
-          ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
-          ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
-          ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
-          ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
+              ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+            (
+            ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
+            ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
+            ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
+            ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
       ap (λ p → ! (p ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
       ap (λ p → ! ((ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
-        ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙
-        !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙
+             (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
+             ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙ !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙ 
       long-path-red (snd (F <#> g) a) (ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
         (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)
         (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) idp ◃∙
       ap (λ q → q) (ap-cp-revR 𝕕₀ (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))) ◃∙
       ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₁ (snd (F <#> g) a) (! (glue (cin j a)))))) ◃∙
-      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (! (ap (λ p → ! (ap right (! (ap (cin j)
-        (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p)
-        (ap (ap left) (id-βr g a)))))) ◃∙
-      ap4-!-!-!-rid 𝕕₀ (snd (F <#> g) a) (cglue g (fun (F # i) a)) (ap [id] (cglue g a))
-        (glue (cin j a)) ◃∙
-      ap (λ p → ! (ap (right ∘ δ₀) (! (ap (cin j) (snd (F <#> g) a)) ∙ (cglue g (fun (F # i) a)))) ∙
-        ! p ∙ ap left (ap [id] (cglue g a))) (𝕕-βr (cin j a)) ◃∙
+      ap (λ q → q)
+        (ap (λ p → p ∙ idp)
+          (ap (ap 𝕕₀)
+            (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p)
+                 (ap (ap left) (id-βr g a)))))) ◃∙
+      ap4-!-!-!-rid 𝕕₀ (snd (F <#> g) a) (cglue g (fun (F # i) a)) (ap [id] (cglue g a)) (glue (cin j a)) ◃∙
+      ap (λ p → ! (ap (right ∘ δ₀) (! (ap (cin j) (snd (F <#> g) a)) ∙ (cglue g (fun (F # i) a)))) ∙ ! p ∙
+           ap left (ap [id] (cglue g a))) (𝕕-βr (cin j a)) ◃∙
       ψ₁-free-aux (cglue g a) (snd (F <#> g) a) (cglue g (fun (F # i) a)) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (pre-cmp-!-!-∙ δ₀ (cin j) (snd (F <#> g) a)
-        (cglue g (fun (F # i) a)) (ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)))) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! p ∙
-        ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (δ₀-βr g (fun (F # i) a)))) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! p ∙ ap (cin j ∘ fst (nat δ j))
-        (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a))
-        (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a)))
-        (comSq-coher δ g a)))) ◃∙
+      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
+             (pre-cmp-!-!-∙ δ₀ (cin j) (snd (F <#> g) a)
+               (cglue g (fun (F # i) a)) (ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)))) ◃∙
+      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
+             (ap (λ p → ! p ∙ ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
+             ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (δ₀-βr g (fun (F # i) a)))) ◃∙
+      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
+             (ap (λ p → ! p ∙ ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a))
+               (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a)))) ◃∙
       ↯ (ψ₂-free (cglue g a) (snd (F <#> g) a) (snd (nat δ i) a) (snd (G <#> g) a)) ◃∙
       ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p)
-        (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (G <#> g) a)) ∙ cglue g (fun (G # i) a))) ∙
-        ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
-      ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p)
-        (E₁ (snd (G <#> g) a) (! (glue (cin j a))))) ◃∙
+          (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (G <#> g) a)) ∙ cglue g (fun (G # i) a))) ∙ ! (glue (cin j a)) ∙ p)
+               (ap (ap left) (id-βr g a))))) ◃∙
+      ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p) (E₁ (snd (G <#> g) a) (! (glue (cin j a))))) ◃∙
       ! (long-red-ap-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g)) (cin i) right
-        (snd (nat δ i) a) (snd (G <#> g) a) (snd (F <#> g) a)
-        (snd (nat δ j) a) (cglue g (fun (G # i) a)) (! (glue (cin j a)))) ◃∙
+          (snd (nat δ i) a) (snd (G <#> g) a) (snd (F <#> g) a)
+          (snd (nat δ j) a) (cglue g (fun (G # i) a)) (! (glue (cin j a)))) ◃∙
       ! (ap (λ p → ! (ap right (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙
-        snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
-        ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
-        (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))) ◃∙
+              snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
+              ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
+              ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+            (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))) ◃∙
       ! (ap (λ p → ! (ap right p) ∙ ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (ap (λ p → ! (ap (cin j) p) ∙
-        cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a))) ◃∎ ∎ₛ
+              ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+              (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a)))
+                (comSq-coher δ g a))) ◃∎ ∎ₛ

--- a/Colimit-code/Map-Nat/CosColimitMap11.agda
+++ b/Colimit-code/Map-Nat/CosColimitMap11.agda
@@ -2,7 +2,6 @@
 
 open import lib.Basics
 open import lib.types.Pushout
-open import lib.types.Span
 open import Coslice
 open import Diagram
 open import Helper-paths
@@ -35,76 +34,76 @@ module ConstrMap12 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type �
 
     fib-coher-pre2 = 
       ! (ap (λ p → ! p ∙ ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (
-          ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
-          ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
-          ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
-          ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
+              ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+            (
+            ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
+            ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
+            ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
+            ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
       ap (λ p → ! (p ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
       ap (λ p → ! ((ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
-        ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙
-        !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙
+             (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
+             ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙ !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙ 
       long-path-red (snd (F <#> g) a) (ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
         (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)
         (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) idp ◃∙
       ap (λ q → q) (ap-cp-revR 𝕕₀ (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))) ◃∙
       ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₁ (snd (F <#> g) a) (! (glue (cin j a)))))) ◃∙
-      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (! (ap (λ p → ! (ap right (! (ap (cin j)
-        (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p)
-        (ap (ap left) (id-βr g a)))))) ◃∙
-      ap4-!-!-!-rid 𝕕₀ (snd (F <#> g) a) (cglue g (fun (F # i) a)) (ap [id] (cglue g a))
-        (glue (cin j a)) ◃∙
-      ap (λ p → ! (ap (right ∘ δ₀) (! (ap (cin j) (snd (F <#> g) a)) ∙ (cglue g (fun (F # i) a)))) ∙
-        ! p ∙ ap left (ap [id] (cglue g a))) (𝕕-βr (cin j a)) ◃∙
+      ap (λ q → q)
+        (ap (λ p → p ∙ idp)
+          (ap (ap 𝕕₀)
+            (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p)
+                 (ap (ap left) (id-βr g a)))))) ◃∙
+      ap4-!-!-!-rid 𝕕₀ (snd (F <#> g) a) (cglue g (fun (F # i) a)) (ap [id] (cglue g a)) (glue (cin j a)) ◃∙
+      ap (λ p → ! (ap (right ∘ δ₀) (! (ap (cin j) (snd (F <#> g) a)) ∙ (cglue g (fun (F # i) a)))) ∙ ! p ∙
+           ap left (ap [id] (cglue g a))) (𝕕-βr (cin j a)) ◃∙
       ψ₁-free-aux (cglue g a) (snd (F <#> g) a) (cglue g (fun (F # i) a)) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (pre-cmp-!-!-∙ δ₀ (cin j) (snd (F <#> g) a)
-        (cglue g (fun (F # i) a)) (ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)))) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! p ∙
-        ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (δ₀-βr g (fun (F # i) a)))) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! p ∙ ap (cin j ∘ fst (nat δ j))
-        (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a))
-        (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a)))
-        (comSq-coher δ g a)))) ◃∙
+      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
+             (pre-cmp-!-!-∙ δ₀ (cin j) (snd (F <#> g) a)
+               (cglue g (fun (F # i) a)) (ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)))) ◃∙
+      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
+             (ap (λ p → ! p ∙ ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
+             ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (δ₀-βr g (fun (F # i) a)))) ◃∙
+      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
+             (ap (λ p → ! p ∙ ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a))
+               (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a)))) ◃∙
       ↯ (ψ₂-free (cglue g a) (snd (F <#> g) a) (snd (nat δ i) a) (snd (G <#> g) a)) ◃∙
       ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p)
-        (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (G <#> g) a)) ∙ cglue g (fun (G # i) a))) ∙
-        ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
-      ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p)
-        (E₁ (snd (G <#> g) a) (! (glue (cin j a))))) ◃∙
+          (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (G <#> g) a)) ∙ cglue g (fun (G # i) a))) ∙ ! (glue (cin j a)) ∙ p)
+               (ap (ap left) (id-βr g a))))) ◃∙
+      ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p) (E₁ (snd (G <#> g) a) (! (glue (cin j a))))) ◃∙
       ! (long-red-ap-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g)) (cin i) right
-        (snd (nat δ i) a) (snd (G <#> g) a) (snd (F <#> g) a)
-        (snd (nat δ j) a) (cglue g (fun (G # i) a)) (! (glue (cin j a)))) ◃∙
+          (snd (nat δ i) a) (snd (G <#> g) a) (snd (F <#> g) a)
+          (snd (nat δ j) a) (cglue g (fun (G # i) a)) (! (glue (cin j a)))) ◃∙
       ! (ap (λ p → ! (ap right (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙
-        snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
-        ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
-        (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))) ◃∙
+              snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
+              ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
+              ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+            (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))) ◃∙
       ! (ap (λ p → ! (ap right p) ∙ ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (ap (λ p → ! (ap (cin j) p) ∙
-        cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a))) ◃∎
-        =ₛ⟨ 6 & 9 & id-red (id-βr g a) idp (snd (F <#> g) a) (cglue g (fun (F # i) a))
-          (comSq-coher δ g a) (δ₀-βr g (fun (F # i) a)) ⟩
+              ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+              (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a)))
+                (comSq-coher δ g a))) ◃∎
+        =ₛ⟨ 6 & 9 & id-red (id-βr g a) idp (snd (F <#> g) a) (cglue g (fun (F # i) a)) (comSq-coher δ g a) (δ₀-βr g (fun (F # i) a)) ⟩
       ! (ap (λ p → ! p ∙ ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (
-          ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
-          ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
-          ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
-          ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
+              ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+            (
+            ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
+            ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
+            ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
+            ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
       ap (λ p → ! (p ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
       ap (λ p → ! ((ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
-        ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙
-        !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙
+             (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
+             ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙ !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙ 
       long-path-red (snd (F <#> g) a) (ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
         (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)
         (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) idp ◃∙
@@ -112,35 +111,34 @@ module ConstrMap12 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type �
       ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₁ (snd (F <#> g) a) (! (glue (cin j a)))))) ◃∙
       idp ◃∙
       ap2-!-!-!-rid2 𝕕₀ (snd (F <#> g) a) (cglue g (fun (F # i) a)) (glue (cin j a)) ◃∙
-      ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ ap (right ∘ δ₀) (cglue g (fun (F # i) a))) ∙ ! p)
-        (𝕕-βr (cin j a)) ◃∙
-      ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ p) ∙
-        ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
-        (ap-∘ right δ₀ (cglue g (fun (F # i) a))) ◃∙
-      ap (λ p →  ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ ap right p) ∙
-        ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a))))) (δ₀-βr g (fun (F # i) a)) ◃∙
+      ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ ap (right ∘ δ₀) (cglue g (fun (F # i) a))) ∙
+           ! p) (𝕕-βr (cin j a)) ◃∙
+      ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ p) ∙ ! (glue (cin j a) ∙
+           ap right (! (ap (cin j) (snd (nat δ j) a)))))
+         (ap-∘ right δ₀ (cglue g (fun (F # i) a))) ◃∙
+      ap (λ p →  ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ ap right p) ∙ ! (glue (cin j a) ∙
+           ap right (! (ap (cin j) (snd (nat δ j) a)))))
+         (δ₀-βr g (fun (F # i) a)) ◃∙
+      ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ ap right (! (ap (cin j) p) ∙
+           cglue g (fst (nat δ i) (fun (F # i) a)))) ∙
+           ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
+         (comSq-coher δ g a) ◃∙
       ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙
-        ap right (! (ap (cin j) p) ∙
-        cglue g (fst (nat δ i) (fun (F # i) a)))) ∙
-        ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a))))) (comSq-coher δ g a) ◃∙
-      ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙
-        ap (right {d = SpCos₂}) (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙
-        snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
-        ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
-        (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a)) ◃∙
+           ap (right {d = SpCos₂}) (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙ snd (G <#> g) a ∙
+           ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
+           ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
+         (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a)) ◃∙
       long-red-ap5-rid right (snd (F <#> g) a) (snd (nat δ i) a) (snd (G <#> g) a) (snd (nat δ j) a)
         (cglue g (fun (G # i) a)) (glue (cin j a)) ◃∙
       idp ◃∙
-      ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p)
-        (E₁ (snd (G <#> g) a) (! (glue (cin j a))))) ◃∙
+      ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p) (E₁ (snd (G <#> g) a) (! (glue (cin j a))))) ◃∙
       ! (long-red-ap-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g)) (cin i) right
-        (snd (nat δ i) a) (snd (G <#> g) a) (snd (F <#> g) a)
-        (snd (nat δ j) a) (cglue g (fun (G # i) a)) (! (glue (cin j a)))) ◃∙
-      ! (ap (λ p → ! (ap right (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙
-        snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
-        ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
-        (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))) ◃∙
+          (snd (nat δ i) a) (snd (G <#> g) a) (snd (F <#> g) a)
+          (snd (nat δ j) a) (cglue g (fun (G # i) a)) (! (glue (cin j a)))) ◃∙
+      ! (ap (λ p → ! (ap right (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙ snd (G <#> g) a ∙
+            ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
+            ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+          (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))) ◃∙
       ! (ap (λ p → ! (ap right p) ∙ ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (ap (λ p → ! (ap (cin j) p) ∙
-        cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a))) ◃∎ ∎ₛ
+            ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+            (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a))) ◃∎ ∎ₛ

--- a/Colimit-code/Map-Nat/CosColimitMap12.agda
+++ b/Colimit-code/Map-Nat/CosColimitMap12.agda
@@ -2,7 +2,6 @@
 
 open import lib.Basics
 open import lib.types.Pushout
-open import lib.types.Span
 open import Coslice
 open import Diagram
 open import Helper-paths
@@ -32,20 +31,20 @@ module ConstrMap13 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type �
 
     fib-coher-pre3 =
       ! (ap (λ p → ! p ∙ ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (
-          ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
-          ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
-          ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
-          ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
+              ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+            (
+            ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
+            ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
+            ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
+            ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
       ap (λ p → ! (p ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
       ap (λ p → ! ((ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
-        ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙
-        !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙
+             (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
+             ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙ !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙ 
       long-path-red (snd (F <#> g) a) (ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
         (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)
         (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) idp ◃∙
@@ -53,56 +52,55 @@ module ConstrMap13 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type �
       ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₁ (snd (F <#> g) a) (! (glue (cin j a)))))) ◃∙
       idp ◃∙
       ap2-!-!-!-rid2 𝕕₀ (snd (F <#> g) a) (cglue g (fun (F # i) a)) (glue (cin j a)) ◃∙
-      ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ ap (right ∘ δ₀) (cglue g (fun (F # i) a))) ∙ ! p)
-        (𝕕-βr (cin j a)) ◃∙
-      ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ p) ∙
-        ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
-        (ap-∘ right δ₀ (cglue g (fun (F # i) a))) ◃∙
-      ap (λ p →  ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ ap right p) ∙
-        ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a))))) (δ₀-βr g (fun (F # i) a)) ◃∙
+      ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ ap (right ∘ δ₀) (cglue g (fun (F # i) a))) ∙
+           ! p) (𝕕-βr (cin j a)) ◃∙
+      ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ p) ∙ ! (glue (cin j a) ∙
+           ap right (! (ap (cin j) (snd (nat δ j) a)))))
+         (ap-∘ right δ₀ (cglue g (fun (F # i) a))) ◃∙
+      ap (λ p →  ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ ap right p) ∙ ! (glue (cin j a) ∙
+           ap right (! (ap (cin j) (snd (nat δ j) a)))))
+         (δ₀-βr g (fun (F # i) a)) ◃∙
+      ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ ap right (! (ap (cin j) p) ∙
+           cglue g (fst (nat δ i) (fun (F # i) a)))) ∙
+           ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
+         (comSq-coher δ g a) ◃∙
       ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙
-        ap right (! (ap (cin j) p) ∙
-        cglue g (fst (nat δ i) (fun (F # i) a)))) ∙
-        ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a))))) (comSq-coher δ g a) ◃∙
-      ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙
-        ap (right {d = SpCos₂}) (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙
-        snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
-        ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
-        (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a)) ◃∙
+           ap (right {d = SpCos₂}) (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙ snd (G <#> g) a ∙
+           ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
+           ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
+         (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a)) ◃∙
       long-red-ap5-rid right (snd (F <#> g) a) (snd (nat δ i) a) (snd (G <#> g) a) (snd (nat δ j) a)
         (cglue g (fun (G # i) a)) (glue (cin j a)) ◃∙
       idp ◃∙
-      ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p)
-        (E₁ (snd (G <#> g) a) (! (glue (cin j a))))) ◃∙
+      ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p) (E₁ (snd (G <#> g) a) (! (glue (cin j a))))) ◃∙
       ! (long-red-ap-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g)) (cin i) right
-        (snd (nat δ i) a) (snd (G <#> g) a) (snd (F <#> g) a)
-        (snd (nat δ j) a) (cglue g (fun (G # i) a)) (! (glue (cin j a)))) ◃∙
-      ! (ap (λ p → ! (ap right (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙
-        snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
-        ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
-        (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))) ◃∙
+          (snd (nat δ i) a) (snd (G <#> g) a) (snd (F <#> g) a)
+          (snd (nat δ j) a) (cglue g (fun (G # i) a)) (! (glue (cin j a)))) ◃∙
+      ! (ap (λ p → ! (ap right (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙ snd (G <#> g) a ∙
+            ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
+            ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+          (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))) ◃∙
       ! (ap (λ p → ! (ap right p) ∙ ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (ap (λ p → ! (ap (cin j) p) ∙
-        cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a))) ◃∎
-        =ₛ⟨ 11 & 8 & comSq-red (snd (nat δ i) a) (snd (G <#> g) a) (cglue g (fun (G # i) a))
-          (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))
-          (comSq-coher δ g a) ⟩
+            ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+            (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a))) ◃∎
+        =ₛ⟨ 11 & 8 &
+          comSq-red (snd (nat δ i) a) (snd (G <#> g) a) (cglue g (fun (G # i) a))
+            (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a)) (comSq-coher δ g a) ⟩
       ! (ap (λ p → ! p ∙ ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (
-          ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
-          ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
-          ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
-          ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
+              ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+            (
+            ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
+            ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
+            ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
+            ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
       ap (λ p → ! (p ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
       ap (λ p → ! ((ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
-        ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙
-        !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙
+             (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
+             ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙ !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙ 
       long-path-red (snd (F <#> g) a) (ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
         (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)
         (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) idp ◃∙
@@ -110,13 +108,14 @@ module ConstrMap13 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type �
       ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₁ (snd (F <#> g) a) (! (glue (cin j a)))))) ◃∙
       idp ◃∙
       ap2-!-!-!-rid2 𝕕₀ (snd (F <#> g) a) (cglue g (fun (F # i) a)) (glue (cin j a)) ◃∙
-      ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ ap (right ∘ δ₀) (cglue g (fun (F # i) a))) ∙ ! p)
-        (𝕕-βr (cin j a)) ◃∙
-      ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ p) ∙
-        ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
-        (ap-∘ right δ₀ (cglue g (fun (F # i) a))) ◃∙
-      ap (λ p →  ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ ap right p) ∙
-        ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a))))) (δ₀-βr g (fun (F # i) a)) ◃∙
+      ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ ap (right ∘ δ₀) (cglue g (fun (F # i) a))) ∙
+           ! p) (𝕕-βr (cin j a)) ◃∙
+      ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ p) ∙ ! (glue (cin j a) ∙
+           ap right (! (ap (cin j) (snd (nat δ j) a)))))
+         (ap-∘ right δ₀ (cglue g (fun (F # i) a))) ◃∙
+      ap (λ p →  ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ ap right p) ∙ ! (glue (cin j a) ∙
+           ap right (! (ap (cin j) (snd (nat δ j) a)))))
+         (δ₀-βr g (fun (F # i) a)) ◃∙
       ↯ (ap2-!5-2 right (cin j) (cglue g (fst (nat δ i) (fun (F # i) a)))
-        (ap (cin j) (comSq δ g (fun (F # i) a))) (snd (nat δ j) a)
-        (ap (right {d = SpCos₂} ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) (glue (cin j a))) ◃∎ ∎ₛ
+          (ap (cin j) (comSq δ g (fun (F # i) a))) (snd (nat δ j) a)
+          (ap (right {d = SpCos₂} ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) (glue (cin j a))) ◃∎ ∎ₛ

--- a/Colimit-code/Map-Nat/CosColimitMap13.agda
+++ b/Colimit-code/Map-Nat/CosColimitMap13.agda
@@ -2,7 +2,6 @@
 
 open import lib.Basics
 open import lib.types.Pushout
-open import lib.types.Span
 open import Coslice
 open import Diagram
 open import Helper-paths
@@ -35,20 +34,20 @@ module ConstrMap14 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type �
 
     fib-coher-pre4 = 
       ! (ap (λ p → ! p ∙ ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (
-          ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
-          ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
-          ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
-          ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
+              ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+            (
+            ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
+            ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
+            ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
+            ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
       ap (λ p → ! (p ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
       ap (λ p → ! ((ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
-        ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙
-        !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙
+             (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
+             ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙ !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙ 
       long-path-red (snd (F <#> g) a) (ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
         (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)
         (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) idp ◃∙
@@ -56,78 +55,75 @@ module ConstrMap14 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type �
       ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₁ (snd (F <#> g) a) (! (glue (cin j a)))))) ◃∙
       idp ◃∙
       ap2-!-!-!-rid2 𝕕₀ (snd (F <#> g) a) (cglue g (fun (F # i) a)) (glue (cin j a)) ◃∙
-      ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ ap (right ∘ δ₀) (cglue g (fun (F # i) a))) ∙ ! p)
-        (𝕕-βr (cin j a)) ◃∙
-      ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ p) ∙
-        ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
-        (ap-∘ right δ₀ (cglue g (fun (F # i) a))) ◃∙
-      ap (λ p →  ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ ap right p) ∙
-        ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a))))) (δ₀-βr g (fun (F # i) a)) ◃∙
+      ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ ap (right ∘ δ₀) (cglue g (fun (F # i) a))) ∙
+           ! p) (𝕕-βr (cin j a)) ◃∙
+      ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ p) ∙ ! (glue (cin j a) ∙
+           ap right (! (ap (cin j) (snd (nat δ j) a)))))
+         (ap-∘ right δ₀ (cglue g (fun (F # i) a))) ◃∙
+      ap (λ p →  ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ ap right p) ∙ ! (glue (cin j a) ∙
+           ap right (! (ap (cin j) (snd (nat δ j) a)))))
+         (δ₀-βr g (fun (F # i) a)) ◃∙
       ↯ (ap2-!5-2 right (cin j) (cglue g (fst (nat δ i) (fun (F # i) a)))
-        (ap (cin j) (comSq δ g (fun (F # i) a))) (snd (nat δ j) a)
-        (ap (right {d = SpCos₂} ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) (glue (cin j a))) ◃∎
-        =ₛ⟨ 2 & 7 & 𝕕-red (snd (F <#> g) a) (snd (nat δ j) a) (glue {d = SpCos₁} (cin j a))
-          (glue {d = SpCos₂} (cin j a)) (𝕕-βr (cin j a)) ⟩
+          (ap (cin j) (comSq δ g (fun (F # i) a))) (snd (nat δ j) a)
+          (ap (right {d = SpCos₂} ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) (glue (cin j a))) ◃∎
+        =ₛ⟨ 2 & 7 & 𝕕-red (snd (F <#> g) a) (snd (nat δ j) a) (glue {d = SpCos₁} (cin j a)) (glue {d = SpCos₂} (cin j a)) (𝕕-βr (cin j a)) ⟩
       ! (ap (λ p → ! p ∙ ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (
-          ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
-          ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
-          ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
-          ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
+              ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+            (
+            ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
+            ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
+            ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
+            ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
       ap (λ p → ! (p ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
-      ap (λ p → ! ((ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ((ap 𝕕₀ (! (glue (cin j a))) ∙ idp) ∙
-        ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
-        ! (ap (right ∘ δ₀ ∘ cin j) (snd (F <#> g) a))) ∙ p ∙ idp) ∙
-        ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (∘-ap 𝕕₀ right (cglue g (fun (F # i) a))) ◃∙
-      ↯ (long-coher3 (right {d = SpCos₂}) (cin j) (snd (nat δ j) a) (ap (right ∘ cin j ∘ fst (nat δ j))
-        (snd (F <#> g) a)) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp) (glue (cin j a))
-        (ap (right ∘ δ₀) (cglue g (fun (F # i) a)))) ◃∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
+      ap (λ p → ! ((ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ((ap 𝕕₀ (! (glue (cin j a))) ∙ idp) ∙
+           ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙ ! (ap (right ∘ δ₀ ∘ cin j) (snd (F <#> g) a))) ∙ p ∙ idp) ∙
+           ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (∘-ap 𝕕₀ right (cglue g (fun (F # i) a))) ◃∙
+      ↯ (long-coher3 (right {d = SpCos₂}) (cin j) (snd (nat δ j) a)
+          (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp) (glue (cin j a))
+          (ap (right ∘ δ₀) (cglue g (fun (F # i) a)))) ◃∙
       ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ p) ∙
-        ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
-        (ap-∘ right δ₀ (cglue g (fun (F # i) a))) ◃∙
-      ap (λ p →  ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ ap right p) ∙
-        ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a))))) (δ₀-βr g (fun (F # i) a)) ◃∙
+           ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
+         (ap-∘ right δ₀ (cglue g (fun (F # i) a))) ◃∙
+      ap (λ p →  ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ ap right p) ∙ ! (glue (cin j a) ∙
+           ap right (! (ap (cin j) (snd (nat δ j) a))))) (δ₀-βr g (fun (F # i) a)) ◃∙
       ↯ (ap2-!5-2 right (cin j) (cglue g (fst (nat δ i) (fun (F # i) a)))
-        (ap (cin j) (comSq δ g (fun (F # i) a))) (snd (nat δ j) a)
-        (ap (right {d = SpCos₂} ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) (glue (cin j a))) ◃∎ ∎ₛ
+          (ap (cin j) (comSq δ g (fun (F # i) a))) (snd (nat δ j) a)
+          (ap (right {d = SpCos₂} ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) (glue (cin j a))) ◃∎ ∎ₛ
 
     fib-coher-pre5 =
       ! (ap (λ p → ! p ∙ ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (
-          ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
-          ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
-          ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
-          ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
+              ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+            (
+            ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
+            ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
+            ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
+            ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
       ap (λ p → ! (p ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
-      ap (λ p → ! ((ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ((ap 𝕕₀ (! (glue (cin j a))) ∙ idp) ∙
-        ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
-        ! (ap (right ∘ δ₀ ∘ cin j) (snd (F <#> g) a))) ∙ p ∙ idp) ∙
-        ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (∘-ap 𝕕₀ right (cglue g (fun (F # i) a))) ◃∙
-      ↯ (long-coher3 (right {d = SpCos₂}) (cin j) (snd (nat δ j) a) (ap (right ∘ cin j ∘ fst (nat δ j))
-        (snd (F <#> g) a)) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp) (glue (cin j a))
-        (ap (right ∘ δ₀) (cglue g (fun (F # i) a)))) ◃∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
+      ap (λ p → ! ((ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ((ap 𝕕₀ (! (glue (cin j a))) ∙ idp) ∙
+           ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙ ! (ap (right ∘ δ₀ ∘ cin j) (snd (F <#> g) a))) ∙ p ∙ idp) ∙
+           ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+         (∘-ap 𝕕₀ right (cglue g (fun (F # i) a))) ◃∙
+      ↯ (long-coher3 (right {d = SpCos₂}) (cin j) (snd (nat δ j) a)
+          (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp) (glue (cin j a))
+          (ap (right ∘ δ₀) (cglue g (fun (F # i) a)))) ◃∙
       ap (λ p → ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ p) ∙
-        ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
-        (ap-∘ right δ₀ (cglue g (fun (F # i) a))) ◃∙
-      ap (λ p →  ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ ap right p) ∙
-        ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a))))) (δ₀-βr g (fun (F # i) a)) ◃∙
+           ! (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))))
+         (ap-∘ right δ₀ (cglue g (fun (F # i) a))) ◃∙
+      ap (λ p →  ! (! (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) ∙ ap right p) ∙ ! (glue (cin j a) ∙
+           ap right (! (ap (cin j) (snd (nat δ j) a))))) (δ₀-βr g (fun (F # i) a)) ◃∙
       ↯ (ap2-!5-2 right (cin j) (cglue g (fst (nat δ i) (fun (F # i) a)))
-        (ap (cin j) (comSq δ g (fun (F # i) a))) (snd (nat δ j) a)
-        (ap (right {d = SpCos₂} ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) (glue (cin j a))) ◃∎
+          (ap (cin j) (comSq δ g (fun (F # i) a))) (snd (nat δ j) a)
+          (ap (right {d = SpCos₂} ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) (glue (cin j a))) ◃∎
         =ₛ⟨ 0 & 6 & δ₀-red (δ₀-βr g (fun (F # i) a)) ⟩
       ↯ (δ₀-free (! (ap (cin j) (comSq δ g (fun (F # i) a))) ∙ cglue g (fst (nat δ i) (fun (F # i) a)))
-        (snd (nat δ j) a) (glue (cin j a)) (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a))) ◃∙
-      ↯ (ap2-!5-2 right (cin j) (cglue g (fst (nat δ i) (fun (F # i) a)))
-        (ap (cin j) (comSq δ g (fun (F # i) a))) (snd (nat δ j) a)
-        (ap (right {d = SpCos₂} ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) (glue (cin j a))) ◃∎
+          (snd (nat δ j) a) (glue (cin j a)) (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a))) ◃∙
+      ↯ (ap2-!5-2 right (cin j) (cglue g (fst (nat δ i) (fun (F # i) a))) (ap (cin j) (comSq δ g (fun (F # i) a)))
+          (snd (nat δ j) a) (ap (right {d = SpCos₂} ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) (glue (cin j a))) ◃∎
         =ₛ⟨ δ₀-comSq-red (cglue g (fst (nat δ i) (fun (F # i) a))) (ap (cin j) (comSq δ g (fun (F # i) a)))
-              (snd (nat δ j) a) (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) (glue (cin j a))  ⟩
+              (snd (nat δ j) a) (ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a)) (glue (cin j a)) ⟩
       idp ◃∎ ∎ₛ

--- a/Colimit-code/Map-Nat/CosColimitMap14.agda
+++ b/Colimit-code/Map-Nat/CosColimitMap14.agda
@@ -2,7 +2,6 @@
 
 open import lib.Basics
 open import lib.types.Pushout
-open import lib.types.Span
 open import Coslice
 open import Diagram
 open import Colim

--- a/Colimit-code/Map-Nat/CosColimitMap15.agda
+++ b/Colimit-code/Map-Nat/CosColimitMap15.agda
@@ -2,7 +2,6 @@
 
 open import lib.Basics
 open import lib.types.Pushout
-open import lib.types.Span
 open import Coslice
 open import Diagram
 open import Colim
@@ -33,85 +32,3 @@ module ConstrMap16 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type �
     open ConstrMap15.MapCoher14 δ g a
 
     fib-coher-pre = fib-coher-pre012 ∙ₛ fib-coher-pre345
-{-
-    fib-coher-pre :
-      ! (ap (λ p → ! p ∙ ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (
-          ∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
-          ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
-          ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
-          ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙ -- δ₀
-      ap (λ p → ! (p ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
-      ap (λ p → ! ((ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
-        ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙
-        !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙ -- 𝕕
-      long-path-red (snd (F <#> g) a) (ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
-        (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)
-        (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) idp ◃∙
-      ap (λ q → q) (ap-cp-revR 𝕕₀ (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a)))) ◃∙
-      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₁ (snd (F <#> g) a) (! (glue (cin j a)))))) ◃∙
-      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (! (ap (λ p → ! (ap right (! (ap (cin j)
-        (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p)
-        (ap (ap left) (id-βr g a)))))) ◃∙ -- id
-      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (E₃ (λ x → ! (glue x)) (cglue g a)
-        (ψ₁-βr g a) (λ x → idp)))) ◃∙ -- ψ₁
-      ap (λ q → q) (ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (∙-unit-r (! (glue (cin i a)))))) ◃∙
-      ! (apd-tr (λ z → ap 𝕕₀ (! (glue z)) ∙ idp) (cglue g a)) ◃∙
-      ap (transport (λ z → right (δ₀ (ψ F z)) == left ([id] z)) (cglue g a))
-        (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a))) ◃∙ -- 𝕕
-      transp-inv-comm (left ∘ [id]) (right ∘ δ₀ ∘ ψ F) (cglue g a)
-        (glue (cin j a) ∙ ap right (! (ap (cin j) (snd (nat δ j) a)))) ◃∙
-      ap ! (apd-ap-∙-l right {F = glue} {G = ℂ} (cglue g a)) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (transp-pth-cmpL δ₀ ψ₁ ψ₂ (cglue g a)
-        (ap (cin j) (snd (nat δ j) a)))) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
-        (ap (λ p → ! (ap δ₀ p) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (ψ₁-βr g a))) ◃∙ -- ψ₁
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (pre-cmp-!-!-∙ δ₀ (cin j) (snd (F <#> g) a)
-        (cglue g (fun (F # i) a)) (ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)))) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! p ∙
-        ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a)) (δ₀-βr g (fun (F # i) a)))) ◃∙ -- δ₀
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! p ∙ ap (cin j ∘ fst (nat δ j))
-        (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ ap ψ₂ (cglue g a))
-        (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a)))
-        (comSq-coher δ g a)))) ◃∙ -- comSq
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p)) (ap (λ p → ! (! (ap (cin j) (ap (fst (G <#> g))
-        (snd (nat δ i) a) ∙ snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j))
-        (snd (F <#> g) a)))) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) ∙
-        ap (cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (cin j) (snd (nat δ j) a) ∙ p)
-        (ψ₂-βr g a))) ◃∙ -- ψ₂
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
-        (long-red-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g))
-        (snd (nat δ i) a) (snd (G <#> g) a) (snd (F <#> g) a)
-        (snd (nat δ j) a) (cglue g (fst (nat δ i) (fun (F # i) a)))
-        (cglue g (fun (G # i) a)))) ◃∙
-      ap ! (ap (λ p → glue (cin i a) ∙ ap right (! p))
-        (apCommSq (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))) ◃∙
-      !-!-ap-∘ (cin i) right (snd (nat δ i) a) (glue (cin i a)) ◃∙    
-      ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p) (∙-unit-r (! (glue (cin i a))))) ◃∙
-      ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p)
-        (E₃ (λ x → ! (glue x)) (cglue g a) (ψ₂-βr g a) (λ x → idp))) ◃∙ -- ψ₂
-      ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p)
-        (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (G <#> g) a)) ∙ cglue g (fun (G # i) a))) ∙
-        ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙ -- id
-      ! (ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p)
-        (E₁ (snd (G <#> g) a) (! (glue (cin j a))))) ◃∙
-      ! (long-red-ap-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g)) (cin i) right
-        (snd (nat δ i) a) (snd (G <#> g) a) (snd (F <#> g) a)
-        (snd (nat δ j) a) (cglue g (fun (G # i) a)) (! (glue (cin j a)))) ◃∙
-      ! (ap (λ p → ! (ap right (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙
-        snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
-        ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
-        (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a))) ◃∙
-      ! (ap (λ p → ! (ap right p) ∙ ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (ap (λ p → ! (ap (cin j) p) ∙
-        cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a))) ◃∎ -- comSq
-        =ₛ
-      idp ◃∎ ∎ₛ
--}

--- a/Colimit-code/Map-Nat/CosColimitMap16.agda
+++ b/Colimit-code/Map-Nat/CosColimitMap16.agda
@@ -2,7 +2,6 @@
 
 open import lib.Basics
 open import lib.types.Pushout
-open import lib.types.Span
 open import Coslice
 open import Diagram
 open import Colim
@@ -32,90 +31,83 @@ module _ {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ} {F : Co
 
     fib-coher : 
       ! (ap (λ p → ! p ∙ ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
-        (∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙
-        ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
-        ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙
-        ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
+            ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+            (∙-unit-r (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) ∙ ∘-ap 𝕕₀ right (cglue g (fun (F # i) a)) ∙
+            ap-∘ right δ₀ (cglue g (fun (F # i) a)) ∙ ap (ap right) (δ₀-βr g (fun (F # i) a)))) ◃∙
       ap (λ p → ! (p ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
-      ap (λ p → ! ((ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙
-        (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
-        ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
-        ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙
-        !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙
+           ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
+           ! (glue (cin j a))) (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a) (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ◃∙
+      ap (λ p → ! ((ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ (p ∙ ! (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)) ∙
+          ! (ap (𝕕₀ ∘ right ∘ cin j) (snd (F <#> g) a))) ∙ ap 𝕕₀ (ap right (cglue g (fun (F # i) a))) ∙ idp) ∙
+          ap (right ∘ cin j ∘ (fst (nat δ j))) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+        (ap-inv-rid 𝕕₀ (glue (cin j a)) ∙ ap ! (𝕕-βr (cin j a)) ∙ !-!-ap-∘ (cin j) right (snd (nat δ j) a) (glue (cin j a))) ◃∙
       long-path-red (snd (F <#> g) a) (ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
-        (ap 𝕕₀ (! (glue (cin j a))) ∙ idp)
-        (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) idp ◃∙
-      ap (λ q → q) (ap-cp-revR 𝕕₀ (right ∘ cin j) (snd (F <#> g) a)
-        (ap right (cglue g (fun (F # i) a))) ∙
-        ap (λ p → p ∙ idp) (ap (ap 𝕕₀) (
-        E₁ (snd (F <#> g) a) (! (glue {d = SpCos₁} (cin j a))) ∙
-        ! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙
-          cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p)
-          (ap (ap left) (id-βr g a))) ∙
-        E₃ (λ x → ! (glue x)) (cglue g a) (ψ₁-βr g a) (λ x → idp) ∙
-        ∙-unit-r (! (glue (cin i a)))))) ◃∙
+        (ap 𝕕₀ (! (glue (cin j a))) ∙ idp) (ap 𝕕₀ (ap right (cglue g (fun (F # i) a)))) idp ◃∙
+      ap (λ q → q)
+        (ap-cp-revR 𝕕₀ (right ∘ cin j) (snd (F <#> g) a) (ap right (cglue g (fun (F # i) a))) ∙
+          ap (λ p → p ∙ idp)
+            (ap (ap 𝕕₀)
+              (E₁ (snd (F <#> g) a) (! (glue {d = SpCos₁} (cin j a))) ∙
+              ! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p)
+                  (ap (ap left) (id-βr g a))) ∙
+              E₃ (λ x → ! (glue x)) (cglue g a) (ψ₁-βr g a) (λ x → idp) ∙ ∙-unit-r (! (glue (cin i a)))))) ◃∙
       ap-inv-rid 𝕕₀ (glue (cin i a)) ◃∙
       ap ! (𝕕-βr (cin i a)) ◃∙
       !-!-ap-∘ (cin i) right (snd (nat δ i) a) (glue (cin i a)) ◃∎
         =ₛ
-      ap (λ p → ! (ap (right {d = SpCos₂}) p) ∙ ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (ap (λ p → ! (ap (cin j) p) ∙
-        cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a)) ◃∙
+      ap
+        (λ p → ! (ap (right {d = SpCos₂}) p) ∙ ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
+            ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+          (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a)) ◃∙
       ap (λ p → ! (ap (right {d = SpCos₂}) (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙
-        snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
-        ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙
-        ! (glue (cin j a))) (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a)) ◃∙
+          snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
+          ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
+          ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+        (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a)) ◃∙
       long-red-ap-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g)) (cin i) right (snd (nat δ i) a)
-        (snd (G <#> g) a) (snd (F <#> g) a) (snd (nat δ j) a) (cglue g (fun (G # i) a))
-        (! (glue (cin j a))) ◃∙
+        (snd (G <#> g) a) (snd (F <#> g) a) (snd (nat δ j) a) (cglue g (fun (G # i) a)) (! (glue (cin j a))) ◃∙
       ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p) (E₁ (snd (G <#> g) a) (! (glue (cin j a)))) ◃∙
       ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p)
-        (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (G <#> g) a)) ∙
-        cglue g (fun (G # i) a))) ∙ ! (glue (cin j a)) ∙ p)
-        (ap (ap left) (id-βr g a)))) ◃∙
-      ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p)
-        (E₃ (λ x → ! (glue x)) (cglue g a) (ψ₂-βr g a) (λ x → idp)) ◃∙
+        (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (G <#> g) a)) ∙ cglue g (fun (G # i) a))) ∙ ! (glue (cin j a)) ∙ p)
+          (ap (ap left) (id-βr g a)))) ◃∙
+      ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p) (E₃ (λ x → ! (glue x)) (cglue g a) (ψ₂-βr g a) (λ x → idp)) ◃∙
       ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p) (∙-unit-r (! (glue (cin i a)))) ◃∎
     fib-coher = post-rotate'-seq-out-idp (fib-coher3 ∙ₛ fib-coher-pre)
 
     fib-coher-post =
       ap (λ p → ! (ap (right {d = SpCos₂}) p) ∙ ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i)
-        (fun (F # i) a))) (comSq-coher δ g a)) ◃∙
+          ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+          (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a)) ◃∙
       ap (λ p → ! (ap (right {d = SpCos₂}) (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙ snd (G <#> g) a ∙
-        ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙ ap (right ∘ cin j ∘ fst (nat δ j))
-        (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (apCommSq2 (cin j ∘ fst (G <#> g))
-        (cin i) (cglue g) (snd (nat δ i) a)) ◃∙
+          ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
+          ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+        (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a)) ◃∙
       long-red-ap-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g)) (cin i) right (snd (nat δ i) a) (snd (G <#> g) a)
         (snd (F <#> g) a) (snd (nat δ j) a) (cglue g (fun (G # i) a)) (! (glue (cin j a))) ◃∙
       ap-seq (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p) (ϵ G g g a)
-        =ₛ⟨ 3 & 4 & ∙-ap-seq (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p) (ϵ G g g a)  ⟩
+        =ₛ⟨ 3 & 4 & ∙-ap-seq (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p) (ϵ G g g a) ⟩
       ap (λ p → ! (ap (right {d = SpCos₂}) p) ∙ ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙
-        ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i)
-        (fun (F # i) a))) (comSq-coher δ g a)) ◃∙
+          ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+          (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) (comSq-coher δ g a)) ◃∙
       ap (λ p → ! (ap (right {d = SpCos₂}) (! (ap (cin j) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙ snd (G <#> g) a ∙
-        ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙ ap (right ∘ cin j ∘ fst (nat δ j))
-        (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a))) (apCommSq2 (cin j ∘ fst (G <#> g))
-        (cin i) (cglue g) (snd (nat δ i) a)) ◃∙
+          ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a)))) ∙ p)) ∙
+          ap (right ∘ cin j ∘ fst (nat δ j)) (snd (F <#> g) a) ∙ ap (right ∘ cin j) (snd (nat δ j) a) ∙ ! (glue (cin j a)))
+        (apCommSq2 (cin j ∘ fst (G <#> g)) (cin i) (cglue g) (snd (nat δ i) a)) ◃∙
       long-red-ap-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g)) (cin i) right (snd (nat δ i) a) (snd (G <#> g) a)
         (snd (F <#> g) a) (snd (nat δ j) a) (cglue g (fun (G # i) a)) (! (glue (cin j a))) ◃∙
       ap (λ p → ap (right ∘ cin i) (snd (nat δ i) a) ∙ p) (↯ (ϵ G g g a)) ◃∎ ∎ₛ      
 
   fib-inhab : CosCocEq F (Cos P₂ left) (PostComp (ColCoC F) 𝕕) K-diag
   W fib-inhab i x = idp
-  u fib-inhab i a = ↯ (
+  u fib-inhab i a = ↯ $
     ap 𝕕₀ (! (glue (cin i a))) ∙ idp
       =⟪ ap-inv-rid 𝕕₀ (glue (cin i a)) ⟫
     ! (ap 𝕕₀ (glue (cin i a)))
       =⟪ ap ! (𝕕-βr (cin i a)) ⟫
     ! (glue (cin i a) ∙ ap right (! (ap (cin i) (snd (nat δ i) a))))
       =⟪ !-!-ap-∘ (cin i) right (snd (nat δ i) a) (glue (cin i a)) ⟫
-    ap (right ∘ cin i) (snd (nat δ i) a) ∙ ! (glue (cin i a)) ∎∎ )
-  fst (Λ fib-inhab {i} {j} g) x = ↯ (
+    ap (right ∘ cin i) (snd (nat δ i) a) ∙ ! (glue (cin i a)) ∎∎
+  fst (Λ fib-inhab {i} {j} g) x = ↯ $
     ap 𝕕₀ (ap right (cglue g x)) ∙ idp
       =⟪ ∙-unit-r (ap 𝕕₀ (ap right (cglue g x))) ⟫
     ap 𝕕₀ (ap right (cglue g x))
@@ -124,5 +116,5 @@ module _ {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ} {F : Co
       =⟪ ap-∘ right δ₀ (cglue g x) ⟫
     ap right (ap δ₀ (cglue g x))
       =⟪ ap (ap right) (δ₀-βr g x) ⟫
-    ap right (! (ap (cin j) (comSq δ g x)) ∙ cglue g (fst (nat δ i) x)) ∎∎ )
+    ap right (! (ap (cin j) (comSq δ g x)) ∙ cglue g (fst (nat δ i) x)) ∎∎
   snd (Λ fib-inhab {i} {j} g) a = =ₛ-in (=ₛ-out (fib-coher g a ∙ₛ fib-coher-post g a))

--- a/Colimit-code/Map-Nat/CosColimitMap17.agda
+++ b/Colimit-code/Map-Nat/CosColimitMap17.agda
@@ -3,7 +3,6 @@
 open import lib.Basics
 open import lib.Equivalence2
 open import lib.types.Pushout
-open import lib.types.Span
 open import Coslice
 open import Diagram
 open import Cocone
@@ -27,7 +26,9 @@ module _ {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ} {F : Co
   colim-contr = equiv-is-contr-map (Colim-Iso F (Cos P₂ left))
 
   K-diag-𝕕-eq : (Recc.recCosCoc F (Cos P₂ left)) K-diag == 𝕕
-  K-diag-𝕕-eq = ap fst (contr-has-all-paths {{colim-contr K-diag}}
-    ((Recc.recCosCoc F (Cos P₂ left)) K-diag , LRfunEq K-diag)
-    (𝕕 , CosCocEq-ind F (Cos P₂ left) (PostComp (ColCoC F) 𝕕) (fib-inhab δ)))
+  K-diag-𝕕-eq =
+    ap fst
+      (contr-has-all-paths {{colim-contr K-diag}}
+      ((Recc.recCosCoc F (Cos P₂ left)) K-diag , LRfunEq K-diag)
+      (𝕕 , CosCocEq-ind F (Cos P₂ left) (PostComp (ColCoC F) 𝕕) (fib-inhab δ)))
 

--- a/Colimit-code/Map-Nat/CosColimitMap18.agda
+++ b/Colimit-code/Map-Nat/CosColimitMap18.agda
@@ -2,7 +2,6 @@
 
 open import lib.Basics
 open import lib.types.Pushout
-open import lib.types.Span
 open import AuxPaths
 open import Helper-paths
 open import FTID
@@ -40,8 +39,10 @@ module _ {ℓ₀ ℓ₁ ℓ₂ ℓ₃} {A₁ : Type ℓ₀} {A₂ : Type ℓ₁}
 
   long-path-red-V : {c₁ c₂ : C} (p₁ : c₁ == c₂) {a₁ a₂ : A₂} (p₂ : a₁ == a₂) (p₃ : c₂ == f (h a₂))
     {b : B} (p₄ : h a₂ == b) {z₁ z₂ : A₁} (p₆ : z₁  == z₂) (p₅ : g z₂ == b) {c : C} (p₇ : f b == c)
-    → (p₁ ∙ p₃ ∙ ! (ap (f ∘ h) p₂)) ∙ ap f (ap h p₂ ∙ p₄ ∙ ! p₅ ∙ ! (ap g p₆)) ∙ ap (f ∘ g) p₆ ∙ ap f p₅ ∙ p₇
-    == p₁ ∙ p₃ ∙ ap f p₄ ∙ p₇
+    →
+    (p₁ ∙ p₃ ∙ ! (ap (f ∘ h) p₂)) ∙ ap f (ap h p₂ ∙ p₄ ∙ ! p₅ ∙ ! (ap g p₆)) ∙ ap (f ∘ g) p₆ ∙ ap f p₅ ∙ p₇
+      ==
+    p₁ ∙ p₃ ∙ ap f p₄ ∙ p₇
   long-path-red-V idp idp p₃ p₄ idp p₅ p₇ = rid-ap-!-!-rid-ap f p₅ p₃ p₄ p₇
 
 module ConstrMap19 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type ℓ} {F : CosDiag ℓF ℓ A Γ} {G : CosDiag ℓG ℓ A Γ} (δ : CosDiagMor A F G) where
@@ -49,39 +50,41 @@ module ConstrMap19 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type �
   open MapsCos A
 
   Diag-to-Lim-map : ∀ {ℓc} {T : Coslice ℓc ℓ A} → CosCocone A G T → CosCocone A F T
-  Diag-to-Lim-map (comp₁ & comTri₁) = (λ i → < A > comp₁ i ∘ nat δ i) &
+  Diag-to-Lim-map (comp₁ & comTri₁) =
+    (λ i → < A > comp₁ i ∘ nat δ i) &
     λ {j} {i} g → (λ x → ! (ap (fst (comp₁ j)) (comSq δ g x)) ∙ fst (comTri₁ g) (fst (nat δ i) x)) , λ a → ↯ (V g a)
       where
         V : {j i : Obj Γ} (g : Hom Γ i j) (a : A) →
           ! (! (ap (fst (comp₁ j)) (comSq δ g (fun (F # i) a))) ∙ fst (comTri₁ g) (fst (nat δ i) (fun (F # i) a))) ∙
-            snd (< A > < A > comp₁ j ∘ nat δ j ∘ F <#> g) a
-          =-= snd (< A > comp₁ i ∘ nat δ i) a
+          snd (< A > < A > comp₁ j ∘ nat δ j ∘ F <#> g) a
+            =-=
+          snd (< A > comp₁ i ∘ nat δ i) a
         V {j} {i} g a =
           ! (! (ap (fst (comp₁ j)) (comSq δ g (fun (F # i) a))) ∙ fst (comTri₁ g) (fst (nat δ i) (fun (F # i) a))) ∙
-            snd (< A > < A > comp₁ j ∘ nat δ j ∘ F <#> g) a
+          snd (< A > < A > comp₁ j ∘ nat δ j ∘ F <#> g) a
             =⟪ !-!-∙-pth (ap (fst (comp₁ j)) (comSq δ g (fun (F # i) a))) (fst (comTri₁ g) (fst (nat δ i) (fun (F # i) a))) ⟫
-          ! (fst (comTri₁ g) (fst (nat δ i) (fun (F # i) a))) ∙ ap (fst (comp₁ j)) (comSq δ g (fun (F # i) a)) ∙
-            snd (< A > < A > comp₁ j ∘ nat δ j ∘ F <#> g) a
+          ! (fst (comTri₁ g) (fst (nat δ i) (fun (F # i) a))) ∙
+          ap (fst (comp₁ j)) (comSq δ g (fun (F # i) a)) ∙
+          snd (< A > < A > comp₁ j ∘ nat δ j ∘ F <#> g) a
             =⟪ ap (λ p → ! (fst (comTri₁ g) (fst (nat δ i) (fun (F # i) a))) ∙ ap (fst (comp₁ j)) p ∙
-              snd (< A > < A > comp₁ j ∘ nat δ j ∘ F <#> g) a) (comSq-coher δ g a) ⟫
+                 snd (< A > < A > comp₁ j ∘ nat δ j ∘ F <#> g) a) (comSq-coher δ g a) ⟫
           ! (fst (comTri₁ g) (fst (nat δ i) (fun (F # i) a))) ∙
           ap (fst (comp₁ j)) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙
           snd (G <#> g) a ∙
           ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a))) ∙
           snd (< A > < A > comp₁ j ∘ nat δ j ∘ F <#> g) a
-            =⟪ ap (λ p → p ∙ ap (fst (comp₁ j)) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙
-              snd (G <#> g) a ∙
-              ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a))) ∙
-              snd (< A > < A > comp₁ j ∘ nat δ j ∘ F <#> g) a) (hmtpy-nat-! (fst (comTri₁ g)) (snd (nat δ i) a)) ⟫
+            =⟪ ap (λ p → p ∙ ap (fst (comp₁ j)) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙ snd (G <#> g) a ∙
+                   ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a))) ∙ snd (< A > < A > comp₁ j ∘ nat δ j ∘ F <#> g) a)
+                 (hmtpy-nat-! (fst (comTri₁ g)) (snd (nat δ i) a)) ⟫
           (ap (λ z → fst (comp₁ i) z) (snd (nat δ i) a) ∙
           ! (fst (comTri₁ g) (fun (G # i) a)) ∙
           ! (ap (λ z → fst (< A > comp₁ j ∘ G <#> g) z) (snd (nat δ i) a))) ∙
-          ap (fst (comp₁ j)) (ap (fst (G <#> g)) (snd (nat δ i) a) ∙
-            snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a))) ∙
+          ap (fst (comp₁ j))
+            (ap (fst (G <#> g)) (snd (nat δ i) a) ∙ snd (G <#> g) a ∙ ! (snd (nat δ j) a) ∙ ! (ap (fst (nat δ j)) (snd (F <#> g) a))) ∙
           snd (< A > < A > comp₁ j ∘ nat δ j ∘ F <#> g) a
             =⟪ long-path-red-V  (fst (comp₁ j)) (fst (G <#> g)) (fst (nat δ j)) (ap (fst (comp₁ i)) (snd (nat δ i) a))
-              (snd (nat δ i) a) (! (fst (comTri₁ g) (fun (G # i) a)))
-              (snd (G <#> g) a) (snd (F <#> g) a) (snd (nat δ j) a) (snd (comp₁ j) a) ⟫
+                 (snd (nat δ i) a) (! (fst (comTri₁ g) (fun (G # i) a)))
+                 (snd (G <#> g) a) (snd (F <#> g) a) (snd (nat δ j) a) (snd (comp₁ j) a) ⟫
           ap (fst (comp₁ i)) (snd (nat δ i) a) ∙
           ! (fst (comTri₁ g) (fun (G # i) a)) ∙
           snd (< A > comp₁ j ∘ G <#> g) a
@@ -100,31 +103,30 @@ module ConstrMap19 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type �
 
       NatSq2-Λ-coher-aux3 : {w y : ty (G # i)} (τ₁₀ : w == y)
         {z : ty (F # j)} (τ₁₃ : fst (G <#> g) y == fst (nat δ j) z) →
-        ! (ap (λ p → ! p ∙ idp) (ap-∘-∘-!-∙-rid f right (cin j)
-          (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp) idp)) ∙
+        ! (ap (λ p → ! p ∙ idp) (ap-∘-∘-!-∙-rid f right (cin j) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp) idp)) ∙
         long-path-red {f = f ∘ right ∘ cin j ∘ fst (nat δ j)} {g = f ∘ right ∘ cin j ∘ fst (nat δ j)}
           idp idp idp (ap f (ap right (! (ap (cin j) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp)) ∙ idp))) idp ∙
-        ap (λ q → q) (ap-cp-revR f (right ∘ cin j ∘ fst (nat δ j)) idp
-          (ap right (! (ap (cin j) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp)) ∙ idp)) ∙
-        ap (λ p → ap f p ∙ idp) (ap (λ p → ! (ap right (! (ap (cin j) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp)) ∙ p)) ∙ idp)
-          (apCommSq2 (λ x → cin j (fst (G <#> g) x)) (λ v → cin j (fst (G <#> g) v)) (λ x → idp) τ₁₀) ∙
-          !-!-!-∘-∘-∘-rid (cin j) (fst (G <#> g)) (λ v → cin j (fst (G <#> g) v)) right τ₁₀ τ₁₃ idp idp idp ∙ idp)) ∙
+        ap (λ q → q)
+          (ap-cp-revR f (right ∘ cin j ∘ fst (nat δ j)) idp (ap right (! (ap (cin j) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp)) ∙ idp)) ∙
+          ap (λ p → ap f p ∙ idp)
+            (ap (λ p → ! (ap right (! (ap (cin j) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp)) ∙ p)) ∙ idp)
+              (apCommSq2 (λ x → cin j (fst (G <#> g) x)) (λ v → cin j (fst (G <#> g) v)) (λ x → idp) τ₁₀) ∙
+              !-!-!-∘-∘-∘-rid (cin j) (fst (G <#> g)) (λ v → cin j (fst (G <#> g) v)) right τ₁₀ τ₁₃ idp idp idp ∙ idp)) ∙
         ap-∘-∙-∙ f (right ∘ (λ v → cin j (fst (G <#> g) v))) τ₁₀ (ap (right ∘ cin j) τ₁₃ ∙ idp)
           ==
         !-!-∙-pth (ap (λ x → f (right (cin j x))) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp)) idp ∙
         ap (λ p → p ∙ ap (λ x → f (right (cin j x))) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp) ∙ idp) (hmtpy-nat-! (λ x → idp) τ₁₀) ∙
         long-path-red-V (λ x → f (right (cin j x))) (fst (G <#> g)) (fst (nat δ j))
           (ap (λ x → f (right (cin j (fst (G <#> g) x)))) τ₁₀) τ₁₀ idp τ₁₃ idp idp idp ∙
-        ap (_∙_ (ap (λ x → f (right (cin j (fst (G <#> g) x)))) τ₁₀))
-          (ap-cp-revR f (λ x → right (cin j x)) τ₁₃ idp ∙ idp)
+        ap (_∙_ (ap (λ x → f (right (cin j (fst (G <#> g) x)))) τ₁₀)) (ap-cp-revR f (λ x → right (cin j x)) τ₁₃ idp ∙ idp)
       NatSq2-Λ-coher-aux3 {w} idp τ₁₃ = lemma τ₁₃
         where
-          lemma : {z : ty (G # j)} (τ : fst (G <#> g) w == z)
-            →
+          lemma : {z : ty (G # j)} (τ : fst (G <#> g) w == z) →
             ! (ap (λ p → ! p ∙ idp) (ap-∘-∘-!-∙-rid f right (cin j) (τ ∙ idp) idp)) ∙
             !-∙-!-rid-∙-rid (ap f (ap right (! (ap (cin j) (τ ∙ idp)) ∙ idp))) idp idp ∙
-            ap (λ q → q) (!-ap-∙-s f (ap right (! (ap (cin j) (τ ∙ idp)) ∙ idp)) ∙
-            ap (λ p → ap f p ∙ idp) (!-!-!-∘-rid (cin j) right τ idp idp idp ∙ idp)) ∙ idp
+            ap (λ q → q)
+              (!-ap-∙-s f (ap right (! (ap (cin j) (τ ∙ idp)) ∙ idp)) ∙
+              ap (λ p → ap f p ∙ idp) (!-!-!-∘-rid (cin j) right τ idp idp idp ∙ idp)) ∙ idp
               ==
             !-!-∙-pth (ap (λ x → f (right (cin j x))) (τ ∙ idp)) idp ∙
             ap-rid-∙ (λ x → f (right (cin j x))) τ idp ∙
@@ -133,84 +135,83 @@ module ConstrMap19 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type �
 
       NatSq2-Λ-coher-aux2 : (τ₁₀ : fst (nat δ i) (fun (F # i) a) == fun (G # i) a)
         {x : ty (F # j)} (τ₁₃ : fst (G <#> g) (fun (G # i) a) == fst (nat δ j) x) →
-        ! (ap (λ p → ! p ∙ idp) (ap-∘-∘-!-∙-rid f right (cin j) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp)
-          (cglue g (fst (nat δ i) (fun (F # i) a))))) ∙
-        long-path-red {f = f ∘ right ∘ cin j ∘ fst (nat δ j)} {g = f ∘ right ∘ cin j ∘ fst (nat δ j)} idp idp idp (ap f
-          (ap right (! (ap (cin j) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp)) ∙
-          cglue g (fst (nat δ i) (fun (F # i) a))))) idp ∙
-        ap (λ q → q) (ap-cp-revR f (right ∘ cin j ∘ fst (nat δ j)) idp
-          (ap right (! (ap (cin j) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp)) ∙ cglue g (fst (nat δ i) (fun (F # i) a)))) ∙
+        ! (ap (λ p → ! p ∙ idp)
+            (ap-∘-∘-!-∙-rid f right (cin j) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp) (cglue g (fst (nat δ i) (fun (F # i) a))))) ∙
+        long-path-red {f = f ∘ right ∘ cin j ∘ fst (nat δ j)} {g = f ∘ right ∘ cin j ∘ fst (nat δ j)} idp idp idp
+          (ap f (ap right (! (ap (cin j) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp)) ∙ cglue g (fst (nat δ i) (fun (F # i) a))))) idp ∙
+        ap (λ q → q)
+          (ap-cp-revR f (right ∘ cin j ∘ fst (nat δ j)) idp
+            (ap right (! (ap (cin j) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp)) ∙ cglue g (fst (nat δ i) (fun (F # i) a)))) ∙
           ap (λ p → ap f p ∙ idp)
-          (ap (λ p → ! (ap right (! (ap (cin j) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp)) ∙ p)) ∙ idp)
-          (apCommSq2 (λ x → cin j (fst (G <#> g) x)) (cin i) (cglue g) τ₁₀) ∙
-          !-!-!-∘-∘-∘-rid (cin j) (fst (G <#> g)) (cin i) right τ₁₀ τ₁₃ idp
-          idp (cglue g (fun (G # i) a)) ∙ idp)) ∙
+            (ap (λ p → ! (ap right (! (ap (cin j) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp)) ∙ p)) ∙ idp)
+              (apCommSq2 (λ x → cin j (fst (G <#> g) x)) (cin i) (cglue g) τ₁₀) ∙
+            !-!-!-∘-∘-∘-rid (cin j) (fst (G <#> g)) (cin i) right τ₁₀ τ₁₃ idp idp (cglue g (fun (G # i) a)) ∙ idp)) ∙
         ap-∘-∙-∙ f (right ∘ cin i) τ₁₀ (! (ap right (cglue g (fun (G # i) a))) ∙ ap (right ∘ cin j) τ₁₃ ∙ idp)
           ==
         !-!-∙-pth (ap (λ x → f (right (cin j x))) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp))
           (ap f (ap right (cglue g (fst (nat δ i) (fun (F # i) a))))) ∙
         ap (λ p → p ∙ ap (λ x → f (right (cin j x))) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp) ∙ idp)
           (hmtpy-nat-! (λ x → ap f (ap right (cglue g x))) τ₁₀) ∙
-        long-path-red-V (λ x → f (right (cin j x))) (fst (G <#> g))
-          (fst (nat δ j)) (ap (λ x → f (right (cin i x))) τ₁₀) τ₁₀
-          (! (ap f (ap right (cglue g (fun (G # i) a))))) τ₁₃ idp idp idp ∙
-        ap (_∙_ (ap (λ x → f (right (cin i x))) τ₁₀)) (ap-cp-revR f (λ x → right (cin j x)) τ₁₃
-          (ap right (cglue g (fun (G # i) a))) ∙ idp)
-      NatSq2-Λ-coher-aux2 τ₁₀ τ₁₃ = IndFunHom {P = λ h H →
-        ! (ap (λ p → ! p ∙ idp) (ap-∘-∘-!-∙-rid f right (cin j) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp)
-          (H (fst (nat δ i) (fun (F # i) a))))) ∙
-        long-path-red {f = f ∘ right ∘ cin j ∘ fst (nat δ j)} {g = f ∘ right ∘ cin j ∘ fst (nat δ j)} idp idp idp
-          (ap f (ap right (! (ap (cin j) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp)) ∙
-          H (fst (nat δ i) (fun (F # i) a))))) idp ∙
-        ap (λ q → q) (ap-cp-revR f (right ∘ cin j ∘ fst (nat δ j)) idp
-          (ap right (! (ap (cin j) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp)) ∙ H (fst (nat δ i) (fun (F # i) a)))) ∙
-          ap (λ p → ap f p ∙ idp)
-          (ap (λ p → ! (ap right (! (ap (cin j) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp)) ∙ p)) ∙ idp)
-          (apCommSq2 (λ x → cin j (fst (G <#> g) x)) h H τ₁₀) ∙
-          !-!-!-∘-∘-∘-rid (cin j) (fst (G <#> g)) h right τ₁₀ τ₁₃ idp
-          idp (H (fun (G # i) a)) ∙ idp)) ∙
-        ap-∘-∙-∙ f (right ∘ h) τ₁₀ (! (ap right (H (fun (G # i) a))) ∙ ap (right ∘ cin j) τ₁₃ ∙ idp)
-          ==
-        !-!-∙-pth (ap (λ x → f (right (cin j x))) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp))
-          (ap f (ap right (H (fst (nat δ i) (fun (F # i) a))))) ∙
-        ap (λ p → p ∙ ap (λ x → f (right (cin j x))) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp) ∙ idp)
-          (hmtpy-nat-! (λ x → ap f (ap right (H x))) τ₁₀) ∙
-        long-path-red-V (λ x → f (right (cin j x))) (fst (G <#> g))
-          (fst (nat δ j)) (ap (λ x → f (right (h x))) τ₁₀) τ₁₀
-          (! (ap f (ap right (H (fun (G # i) a))))) τ₁₃ idp idp idp ∙
-        ap (_∙_ (ap (λ x → f (right (h x))) τ₁₀)) (ap-cp-revR f (λ x → right (cin j x)) τ₁₃
-          (ap right (H (fun (G # i) a))) ∙ idp)} (NatSq2-Λ-coher-aux3 τ₁₀ τ₁₃) (cin i) (cglue g)
+        long-path-red-V (λ x → f (right (cin j x))) (fst (G <#> g)) (fst (nat δ j))
+          (ap (λ x → f (right (cin i x))) τ₁₀) τ₁₀ (! (ap f (ap right (cglue g (fun (G # i) a))))) τ₁₃ idp idp idp ∙
+        ap (_∙_ (ap (λ x → f (right (cin i x))) τ₁₀))
+          (ap-cp-revR f (λ x → right (cin j x)) τ₁₃ (ap right (cglue g (fun (G # i) a))) ∙ idp)
+      NatSq2-Λ-coher-aux2 τ₁₀ τ₁₃ =
+        IndFunHom
+          {P = λ h H →
+            ! (ap (λ p → ! p ∙ idp) (ap-∘-∘-!-∙-rid f right (cin j) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp)
+              (H (fst (nat δ i) (fun (F # i) a))))) ∙
+            long-path-red {f = f ∘ right ∘ cin j ∘ fst (nat δ j)} {g = f ∘ right ∘ cin j ∘ fst (nat δ j)} idp idp idp
+              (ap f (ap right (! (ap (cin j) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp)) ∙ H (fst (nat δ i) (fun (F # i) a))))) idp ∙
+            ap (λ q → q)
+              (ap-cp-revR f (right ∘ cin j ∘ fst (nat δ j)) idp
+              (ap right (! (ap (cin j) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp)) ∙ H (fst (nat δ i) (fun (F # i) a)))) ∙
+              ap (λ p → ap f p ∙ idp)
+                (ap (λ p → ! (ap right (! (ap (cin j) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp)) ∙ p)) ∙ idp)
+                  (apCommSq2 (λ x → cin j (fst (G <#> g) x)) h H τ₁₀) ∙
+                !-!-!-∘-∘-∘-rid (cin j) (fst (G <#> g)) h right τ₁₀ τ₁₃ idp idp (H (fun (G # i) a)) ∙ idp)) ∙
+            ap-∘-∙-∙ f (right ∘ h) τ₁₀ (! (ap right (H (fun (G # i) a))) ∙ ap (right ∘ cin j) τ₁₃ ∙ idp)
+              ==
+            !-!-∙-pth (ap (λ x → f (right (cin j x))) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp))
+              (ap f (ap right (H (fst (nat δ i) (fun (F # i) a))))) ∙
+            ap (λ p → p ∙ ap (λ x → f (right (cin j x))) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp) ∙ idp)
+              (hmtpy-nat-! (λ x → ap f (ap right (H x))) τ₁₀) ∙
+            long-path-red-V (λ x → f (right (cin j x))) (fst (G <#> g))
+              (fst (nat δ j)) (ap (λ x → f (right (h x))) τ₁₀) τ₁₀
+              (! (ap f (ap right (H (fun (G # i) a))))) τ₁₃ idp idp idp ∙
+            ap (_∙_ (ap (λ x → f (right (h x))) τ₁₀)) (ap-cp-revR f (λ x → right (cin j x)) τ₁₃ (ap right (H (fun (G # i) a))) ∙ idp)}
+          (NatSq2-Λ-coher-aux3 τ₁₀ τ₁₃)
+          (cin i) (cglue g)
 
       NatSq2-Λ-coher-aux : (τ₁₀ : fst (nat δ i) (fun (F # i) a) == fun (G # i) a)
         (τ₁₃ : fst (G <#> g) (fun (G # i) a) == fst (nat δ j) (fst (F <#> g) (fun (F # i) a)))
         {σ₁ : fst (G <#> g) (fst (nat δ i) (fun (F # i) a)) == fst (nat δ j) (fst (F <#> g) (fun (F # i) a))}
         (τ₁₄ : σ₁ == ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp) →
-        ! (ap (λ p → ! p ∙ idp) (ap-∘-∘-!-∙-rid f right (cin j) σ₁
-          (cglue g (fst (nat δ i) (fun (F # i) a))))) ∙
+        ! (ap (λ p → ! p ∙ idp) (ap-∘-∘-!-∙-rid f right (cin j) σ₁ (cglue g (fst (nat δ i) (fun (F # i) a))))) ∙
         long-path-red {f = f ∘ right ∘ cin j ∘ fst (nat δ j)} {g = f ∘ right ∘ cin j ∘ fst (nat δ j)} idp idp idp
           (ap f (ap right (! (ap (cin j) σ₁) ∙ cglue g (fst (nat δ i) (fun (F # i) a))))) idp ∙
-        ap (λ q → q) (ap-cp-revR f (right ∘ cin j ∘ fst (nat δ j)) idp
-          (ap right (! (ap (cin j) σ₁) ∙
-          cglue g (fst (nat δ i) (fun (F # i) a)))) ∙
-          ap (λ p → ap f p ∙ idp) (ap (λ p → ! (ap right p) ∙ idp)
-          (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) τ₁₄) ∙
-          ap (λ p → ! (ap right (! (ap (cin j) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp)) ∙ p)) ∙ idp)
-          (apCommSq2 (λ x → cin j (fst (G <#> g) x)) (cin i) (cglue g) τ₁₀) ∙
-          !-!-!-∘-∘-∘-rid (cin j) (fst (G <#> g)) (cin i) right τ₁₀ τ₁₃ idp idp (cglue g (fun (G # i) a)) ∙ idp)) ∙
+        ap (λ q → q)
+          (ap-cp-revR f (right ∘ cin j ∘ fst (nat δ j)) idp
+          (ap right (! (ap (cin j) σ₁) ∙ cglue g (fst (nat δ i) (fun (F # i) a)))) ∙
+          ap (λ p → ap f p ∙ idp)
+            (ap (λ p → ! (ap right p) ∙ idp)
+              (ap (λ p → ! (ap (cin j) p) ∙ cglue g (fst (nat δ i) (fun (F # i) a))) τ₁₄) ∙
+            ap (λ p → ! (ap right (! (ap (cin j) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp)) ∙ p)) ∙ idp)
+              (apCommSq2 (λ x → cin j (fst (G <#> g) x)) (cin i) (cglue g) τ₁₀) ∙
+            !-!-!-∘-∘-∘-rid (cin j) (fst (G <#> g)) (cin i) right τ₁₀ τ₁₃ idp idp (cglue g (fun (G # i) a)) ∙ idp)) ∙
         ap-∘-∙-∙ f (right ∘ cin i) τ₁₀ (! (ap right (cglue g (fun (G # i) a))) ∙
         ap (right ∘ cin j) τ₁₃ ∙ idp)
           ==
         !-!-∙-pth (ap (λ x → f (right (cin j x))) σ₁)
           (ap f (ap right (cglue g (fst (nat δ i) (fun (F # i) a))))) ∙
-        ap (λ p → ! (ap f (ap right (cglue g (fst (nat δ i) (fun (F # i) a))))) ∙
-          ap (λ x → f (right (cin j x))) p ∙ idp) τ₁₄ ∙
+        ap (λ p → ! (ap f (ap right (cglue g (fst (nat δ i) (fun (F # i) a))))) ∙ ap (λ x → f (right (cin j x))) p ∙ idp) τ₁₄ ∙
         ap (λ p → p ∙ ap (λ x → f (right (cin j x))) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ idp) ∙ idp)
           (hmtpy-nat-! (λ x → ap f (ap right (cglue g x))) τ₁₀) ∙
-        long-path-red-V (λ x → f (right (cin j x))) (fst (G <#> g))
-          (fst (nat δ j)) (ap (λ x → f (right (cin i x))) τ₁₀) τ₁₀
+        long-path-red-V (λ x → f (right (cin j x))) (fst (G <#> g)) (fst (nat δ j))
+          (ap (λ x → f (right (cin i x))) τ₁₀) τ₁₀
           (! (ap f (ap right (cglue g (fun (G # i) a))))) τ₁₃ idp idp idp ∙
-        ap (_∙_ (ap (λ x → f (right (cin i x))) τ₁₀)) (ap-cp-revR f (λ x → right (cin j x)) τ₁₃
-          (ap right (cglue g (fun (G # i) a))) ∙ idp)
+        ap (_∙_ (ap (λ x → f (right (cin i x))) τ₁₀))
+          (ap-cp-revR f (λ x → right (cin j x)) τ₁₃ (ap right (cglue g (fun (G # i) a))) ∙ idp)
       NatSq2-Λ-coher-aux τ₁₀ τ₁₃ idp = NatSq2-Λ-coher-aux2 τ₁₀ τ₁₃
 
       NatSq2-Λ-coher : {x : ty (F # j)} (τ₅ : fst (F <#> g) (fun (F # i) a) == x) {y : ty (G # j)} (τ₆ : fst (nat δ j) x == y)
@@ -219,103 +220,72 @@ module ConstrMap19 {ℓv ℓe ℓ ℓF ℓG} {Γ : Graph ℓv ℓe} {A : Type �
         (τ₁₄ : comSq δ g (fun (F # i) a) == (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ ! τ₆ ∙ ! (ap (fst (nat δ j)) τ₅)))
         {τ₁₁ : right (cin i (fun (G # i) a)) == z}
         (τ₁ : ! (ap right (cglue g (fun (G # i) a))) ∙ ap (right ∘ cin j) τ₁₃ ∙ τ₇ == τ₁₁) → 
-        ! (ap (λ p → ! p ∙ ap (f ∘ right ∘ cin j ∘ fst (nat δ j)) τ₅ ∙
-          ap (f ∘ right ∘ cin j) τ₆ ∙ ap f τ₇ ∙ τ₈)
-          (ap-∘-∘-!-∙-rid f right (cin j) (comSq δ g (fun (F # i) a))
-          (cglue g (fst (nat δ i) (fun (F # i) a))))) ◃∙
+        ! (ap (λ p → ! p ∙ ap (f ∘ right ∘ cin j ∘ fst (nat δ j)) τ₅ ∙ ap (f ∘ right ∘ cin j) τ₆ ∙ ap f τ₇ ∙ τ₈)
+            (ap-∘-∘-!-∙-rid f right (cin j) (comSq δ g (fun (F # i) a)) (cglue g (fst (nat δ i) (fun (F # i) a))))) ◃∙
         ap (λ p → ! (p ∙ ap f (ap right (! (ap (cin j) (comSq δ g (fun (F # i) a))) ∙
-          (cglue g (fst (nat δ i) (fun (F # i) a))))) ∙ idp) ∙
-          ap (f ∘ right ∘ cin j ∘ fst (nat δ j))
-          τ₅ ∙
-          ap (f ∘ right ∘ cin j) τ₆ ∙ ap f τ₇ ∙ τ₈)
-          (hmtpy-nat-rev (λ x → idp) τ₅
-          (ap f (ap (λ x → right (cin j x)) τ₆ ∙
-          τ₇) ∙ τ₈)) ◃∙
-        ap (λ p → ! ((ap (f ∘ right ∘ cin j ∘ fst (nat δ j))
-          τ₅ ∙
-          (p ∙ ! (ap f (ap (λ x → right (cin j x)) τ₆ ∙
-          τ₇) ∙ τ₈)) ∙
-          ! (ap (f ∘ right ∘ cin j ∘ fst (nat δ j)) τ₅)) ∙
-          ap f (ap right (! (ap (cin j) (comSq δ g (fun (F # i) a))) ∙
-          (cglue g (fst (nat δ i) (fun (F # i) a))))) ∙ idp) ∙
-          ap (f ∘ right ∘ cin j ∘ fst (nat δ j)) τ₅ ∙
-          ap (f ∘ right ∘ cin j) τ₆ ∙ ap f τ₇ ∙ τ₈)
+               (cglue g (fst (nat δ i) (fun (F # i) a))))) ∙ idp) ∙
+             ap (f ∘ right ∘ cin j ∘ fst (nat δ j)) τ₅ ∙
+             ap (f ∘ right ∘ cin j) τ₆ ∙ ap f τ₇ ∙ τ₈)
+          (hmtpy-nat-rev (λ x → idp) τ₅ (ap f (ap (λ x → right (cin j x)) τ₆ ∙ τ₇) ∙ τ₈)) ◃∙
+        ap (λ p → ! ((ap (f ∘ right ∘ cin j ∘ fst (nat δ j)) τ₅ ∙ (p ∙ ! (ap f (ap (λ x → right (cin j x)) τ₆ ∙ τ₇) ∙ τ₈)) ∙
+              ! (ap (f ∘ right ∘ cin j ∘ fst (nat δ j)) τ₅)) ∙
+            ap f (ap right (! (ap (cin j) (comSq δ g (fun (F # i) a))) ∙ (cglue g (fst (nat δ i) (fun (F # i) a))))) ∙ idp) ∙
+            ap (f ∘ right ∘ cin j ∘ fst (nat δ j)) τ₅ ∙
+            ap (f ∘ right ∘ cin j) τ₆ ∙ ap f τ₇ ∙ τ₈)
           (ap-∘-∙-∙ f (right ∘ cin j) τ₆ τ₇) ◃∙
         long-path-red τ₅
           (ap (f ∘ right ∘ cin j) τ₆ ∙ ap f τ₇ ∙ τ₈)
-          (ap f (ap (λ x → right (cin j x)) τ₆ ∙
-          τ₇) ∙ τ₈)
-          (ap f (ap right (! (ap (cin j) (comSq δ g (fun (F # i) a))) ∙
-          (cglue g (fst (nat δ i) (fun (F # i) a)))))) idp ◃∙
-        ap (λ q → q) (ap-cp-revR f (right ∘ cin j ∘ fst (nat δ j)) τ₅
-          (ap right (! (ap (cin j) (comSq δ g (fun (F # i) a))) ∙
-          (cglue g (fst (nat δ i) (fun (F # i) a))))) ∙
+          (ap f (ap (λ x → right (cin j x)) τ₆ ∙ τ₇) ∙ τ₈)
+          (ap f (ap right (! (ap (cin j) (comSq δ g (fun (F # i) a))) ∙ (cglue g (fst (nat δ i) (fun (F # i) a)))))) idp ◃∙
+        ap (λ q → q)
+          (ap-cp-revR f (right ∘ cin j ∘ fst (nat δ j)) τ₅
+            (ap right (! (ap (cin j) (comSq δ g (fun (F # i) a))) ∙ (cglue g (fst (nat δ i) (fun (F # i) a))))) ∙
           ap (λ p → ap f p ∙ τ₈)
-          (ap (λ p → ! (ap right p) ∙
-           ap (λ x → right (cin j (fst (nat δ j) x))) τ₅ ∙
-           ap (λ x → right (cin j x)) τ₆ ∙ τ₇)
-          (ap (λ p → ! (ap (cin j) p) ∙ (cglue g (fst (nat δ i) (fun (F # i) a)))) τ₁₄) ∙
-           ap (λ p → ! (ap right (! (ap (cin j)  (ap (fst (G <#> g)) τ₁₀ ∙
-             τ₁₃ ∙ ! τ₆ ∙ ! (ap (fst (nat δ j)) τ₅))) ∙ p)) ∙
-             ap (λ x → right (cin j (fst (nat δ j) x))) τ₅ ∙
-             ap (λ x → right (cin j x)) τ₆ ∙ τ₇)
-             (apCommSq2 (λ x → cin j (fst (G <#> g) x)) (cin i) (cglue g) τ₁₀) ∙
-           long-red-ap-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g)) (cin i)
-             right τ₁₀ τ₁₃ τ₅
-             τ₆ (cglue g (fun (G # i) a)) τ₇ ∙
-           ap (_∙_ (ap (λ x → right (cin i x)) τ₁₀)) τ₁)) ◃∙
-           ap-∘-∙-∙ f (right ∘ cin i) τ₁₀ τ₁₁ ◃∎
+            (ap (λ p → ! (ap right p) ∙
+                ap (λ x → right (cin j (fst (nat δ j) x))) τ₅ ∙
+                ap (λ x → right (cin j x)) τ₆ ∙ τ₇)
+              (ap (λ p → ! (ap (cin j) p) ∙ (cglue g (fst (nat δ i) (fun (F # i) a)))) τ₁₄) ∙
+            ap (λ p → ! (ap right (! (ap (cin j)  (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ ! τ₆ ∙ ! (ap (fst (nat δ j)) τ₅))) ∙ p)) ∙
+              ap (λ x → right (cin j (fst (nat δ j) x))) τ₅ ∙ ap (λ x → right (cin j x)) τ₆ ∙ τ₇)
+            (apCommSq2 (λ x → cin j (fst (G <#> g) x)) (cin i) (cglue g) τ₁₀) ∙
+            long-red-ap-!-∙ (cin j) (fst (nat δ j)) (fst (G <#> g)) (cin i) right τ₁₀ τ₁₃ τ₅ τ₆ (cglue g (fun (G # i) a)) τ₇ ∙
+            ap (_∙_ (ap (λ x → right (cin i x)) τ₁₀)) τ₁)) ◃∙
+        ap-∘-∙-∙ f (right ∘ cin i) τ₁₀ τ₁₁ ◃∎
           =ₛ
         (!-!-∙-pth (ap (λ x → f (right (cin j x))) (comSq δ g (fun (F # i) a)))
           (ap f (ap right (cglue g (fst (nat δ i) (fun (F # i) a))))) ∙
         ap (λ p →
-           ! (ap f (ap right (cglue g (fst (nat δ i) (fun (F # i) a))))) ∙
-           ap (λ x → f (right (cin j x))) p ∙
-           ap (λ x → f (right (cin j (fst (nat δ j) x)))) τ₅ ∙
-           ap (λ x → f (right (cin j x))) τ₆ ∙
-           ap f τ₇ ∙ τ₈) τ₁₄ ∙
-        ap (λ p → p ∙ ap (λ x → f (right (cin j x)))
-           (ap (fst (G <#> g)) τ₁₀ ∙
-           τ₁₃ ∙
-           ! τ₆ ∙ ! (ap (fst (nat δ j)) τ₅)) ∙
-           ap (λ x → f (right (cin j (fst (nat δ j) x)))) τ₅ ∙
-           ap (λ x → f (right (cin j x))) τ₆ ∙
-           ap f τ₇ ∙ τ₈) (hmtpy-nat-! (λ x → ap f (ap right (cglue g x))) τ₁₀) ∙
+             ! (ap f (ap right (cglue g (fst (nat δ i) (fun (F # i) a))))) ∙
+             ap (λ x → f (right (cin j x))) p ∙
+             ap (λ x → f (right (cin j (fst (nat δ j) x)))) τ₅ ∙
+             ap (λ x → f (right (cin j x))) τ₆ ∙
+             ap f τ₇ ∙ τ₈)
+           τ₁₄ ∙
+        ap
+          (λ p → p ∙
+              ap (λ x → f (right (cin j x))) (ap (fst (G <#> g)) τ₁₀ ∙ τ₁₃ ∙ ! τ₆ ∙ ! (ap (fst (nat δ j)) τ₅)) ∙
+              ap (λ x → f (right (cin j (fst (nat δ j) x)))) τ₅ ∙
+              ap (λ x → f (right (cin j x))) τ₆ ∙
+              ap f τ₇ ∙ τ₈)
+            (hmtpy-nat-! (λ x → ap f (ap right (cglue g x))) τ₁₀) ∙
         long-path-red-V (λ x → f (right (cin j x))) (fst (G <#> g))
-          (fst (nat δ j)) (ap (λ x → f (right (cin i x))) τ₁₀)
-          τ₁₀ (! (ap f (ap right (cglue g (fun (G # i) a)))))
-          τ₁₃ τ₅ τ₆
-          (ap f τ₇ ∙ τ₈) ∙
+          (fst (nat δ j)) (ap (λ x → f (right (cin i x))) τ₁₀) τ₁₀
+          (! (ap f (ap right (cglue g (fun (G # i) a))))) τ₁₃ τ₅ τ₆ (ap f τ₇ ∙ τ₈) ∙
         ap (_∙_ (ap (λ x → f (right (cin i x))) τ₁₀))
-          (ap-cp-revR f (λ x → right (cin j x)) τ₁₃
-          (ap right (cglue g (fun (G # i) a))) ∙
-          ap (λ p → p ∙ τ₈) (ap (ap f) τ₁))) ◃∎
+          (ap-cp-revR f (λ x → right (cin j x)) τ₁₃ (ap right (cglue g (fun (G # i) a))) ∙
+            ap (λ p → p ∙ τ₈) (ap (ap f) τ₁))) ◃∎
       NatSq2-Λ-coher idp idp idp idp τ₁₀ τ₁₃ τ₁₄ idp = =ₛ-in (NatSq2-Λ-coher-aux τ₁₀ τ₁₃ τ₁₄)
-{-
-  τ₁ = E₁ (snd (G <#> g) a) (! (glue (cin j a))) ∙
-       ! (ap (λ p → ! (ap right (! (ap (cin j) (snd (G <#> g) a)) ∙ cglue g (fun (G # i) a))) ∙
-        ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))) ∙
-        E₃ (λ x → ! (glue x)) (cglue g a) (ψ₂-βr g a) (λ x → idp) ∙
-        ∙-unit-r (! (glue (cin i a)))
-  τ₅ = snd (F <#> g) a
-  τ₆ = snd (nat δ j) a
-  τ₇ = ! (glue (cin j a))
-  τ₈ = fₚ a
-  τ₁₀ = snd (nat δ i) a
-  τ₁₁ = ! (glue (cin i a))
-  τ₁₃ = snd (G <#> g) a
-  τ₁₄ = comSq-coher δ g a
--}
 
     CosColim-NatSq2 : CosCocEq F T (Map-to-Lim-map F (f , fₚ) K-diag) (Diag-to-Lim-map (PostComp ColCoC (f , fₚ)))
     W CosColim-NatSq2 i x = idp
     u CosColim-NatSq2 i a = ap-∘-∙-∙ f (right ∘ cin i) (snd (nat δ i) a) (! (glue (cin i a)))
-    Λ CosColim-NatSq2 {i} {j} g = (λ x → ap-∘-∘-!-∙-rid f right (cin j) (comSq δ g x) (cglue g (fst (nat δ i) x))) ,
-      λ a → NatSq2-Λ-coher g a (snd (F <#> g) a) (snd (nat δ j) a) (! (glue (cin j a))) (fₚ a) (snd (nat δ i) a)
-        (snd (G <#> g) a) (comSq-coher δ g a)
+    Λ CosColim-NatSq2 {i} {j} g =
+      (λ x → ap-∘-∘-!-∙-rid f right (cin j) (comSq δ g x) (cglue g (fst (nat δ i) x))) ,
+      λ a → NatSq2-Λ-coher g a (snd (F <#> g) a) (snd (nat δ j) a) (! (glue (cin j a))) (fₚ a)
+        (snd (nat δ i) a) (snd (G <#> g) a) (comSq-coher δ g a)
         (E₁ (snd (G <#> g) a) (! (glue (cin j a))) ∙
         ! (ap (λ p → ! (ap right (! (ap (cin j) (snd (G <#> g) a)) ∙ cglue g (fun (G # i) a))) ∙
-        ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))) ∙
+            ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))) ∙
         E₃ (λ x → ! (glue x)) (cglue g a) (ψ₂-βr g a) (λ x → idp) ∙
         ∙-unit-r (! (glue (cin i a))))
 

--- a/Colimit-code/Map-Nat/CosColimitPreCmp.agda
+++ b/Colimit-code/Map-Nat/CosColimitPreCmp.agda
@@ -2,7 +2,6 @@
 
 open import lib.Basics
 open import lib.types.Pushout
-open import lib.types.Span
 open import Coslice
 open import Diagram
 open import Cocone

--- a/Colimit-code/Map-Nat/CosColimitPstCmp.agda
+++ b/Colimit-code/Map-Nat/CosColimitPstCmp.agda
@@ -2,7 +2,6 @@
 
 open import lib.Basics
 open import lib.types.Pushout
-open import lib.types.Span
 open import Helper-paths
 open import FTID-Cos
 open import Coslice
@@ -21,7 +20,8 @@ module _ {ℓ₁ ℓ₂ ℓ₃} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type �
   ap-∘-rid : {x y : A} (p : x == y) → ap h (ap f p) ∙ idp == ap (h ∘ f) p
   ap-∘-rid idp = idp
 
-module _ {ℓv ℓe ℓ ℓd ℓc₁ ℓc₂} {Γ : Graph ℓv ℓe} {A : Type ℓ} (F : CosDiag ℓd ℓ A Γ) {T : Coslice ℓc₁ ℓ A} {U : Coslice ℓc₂ ℓ A} (φ : < A > T *→ U) where
+module _ {ℓv ℓe ℓ ℓd ℓc₁ ℓc₂} {Γ : Graph ℓv ℓe} {A : Type ℓ} (F : CosDiag ℓd ℓ A Γ) {T : Coslice ℓc₁ ℓ A} {U : Coslice ℓc₂ ℓ A}
+  (φ : < A > T *→ U) where
 
   open MapsCos A
 
@@ -30,74 +30,62 @@ module _ {ℓv ℓe ℓ ℓd ℓc₁ ℓc₂} {Γ : Graph ℓv ℓe} {A : Type �
   open Maps F
 
   φ₁ = fst φ
-
   φ₂ = snd φ
 
   Map-to-Lim-map : CosCocone A F T →  CosCocone A F U
   comp (Map-to-Lim-map (comp₁ & comTri₁)) = λ i → φ ∘* comp₁ i
-  comTri (Map-to-Lim-map (comp₁ & comTri₁)) {j} {i} = λ g → (λ x → ap φ₁ (fst (comTri₁ g) x)) ,
-    λ a →  ap-cp-revR φ₁ (fst (comp₁ j)) (snd (F <#> g) a) {r = snd (comp₁ j) a} {s = snd φ a} (fst (comTri₁ g) (fun (F # i) a)) ∙ ap (λ p → ap φ₁ p ∙ φ₂ a) (snd (comTri₁ g) a)
+  comTri (Map-to-Lim-map (comp₁ & comTri₁)) {j} {i} =
+    λ g → (λ x → ap φ₁ (fst (comTri₁ g) x)) ,
+    λ a →
+      ap-cp-revR φ₁ (fst (comp₁ j)) (snd (F <#> g) a) {r = snd (comp₁ j) a} {s = snd φ a} (fst (comTri₁ g) (fun (F # i) a)) ∙
+      ap (λ p → ap φ₁ p ∙ φ₂ a) (snd (comTri₁ g) a)
 
   module _ (f : P → ty T) (fₚ : (a : A) → f (left a) == fun T a) where
 
-    NatSq-1-Λ-aux : {i j : Obj Γ} (g : Hom Γ i j) (a : A) →
-      {x z : P} {y : ty (F # j)} (p₁ : right (cin j (fst (F <#> g) (fun (F # i) a))) == x) (p₂ : fst (F <#> g) (fun (F # i) a) == y) (p₃ : right (cin j y) == z)
-      {u : ty T} (p₄ : f z == u) {v : ty U} (p₅ : φ₁ u == v)
-      → ! (ap (λ x → φ₁ (f x)) p₁) ∙
+    NatSq-1-Λ-aux : {i j : Obj Γ} (g : Hom Γ i j) (a : A) {x z : P} {y : ty (F # j)}
+      (p₁ : right (cin j (fst (F <#> g) (fun (F # i) a))) == x)
+      (p₂ : fst (F <#> g) (fun (F # i) a) == y) (p₃ : right (cin j y) == z)
+      {u : ty T} (p₄ : f z == u) {v : ty U} (p₅ : φ₁ u == v) →
+      ! (ap (λ x → φ₁ (f x)) p₁) ∙
       ap (λ x → φ₁ (f (right (cin j x)))) p₂ ∙
       ap (λ x → φ₁ (f x)) p₃ ∙
       ap φ₁ p₄ ∙ p₅
-      =-=
+        =-=
       ! (ap φ₁ (ap f p₁)) ∙
       ap (λ v → φ₁ (f (right (cin j v)))) p₂ ∙
       ap φ₁ (ap f p₃ ∙ p₄) ∙ p₅
     NatSq-1-Λ-aux g a idp idp idp p₄ p₅ = idp ◃∎ 
 
-    NatSq-1-Λ-red : {i j : Obj Γ} (g : Hom Γ i j) (a : A) {x z : P} {y : ty (F # j)} (p₁ : right (cin j (fst (F <#> g) (fun (F # i) a))) == x)
-      (p₂ : fst (F <#> g) (fun (F # i) a) == y) (p₃ : right (cin j y) == z) {u : ty T} (p₄ : f z == u) {v : ty U} (p₅ : φ₁ u == v)
-      → ! (ap (λ p → ! p ∙ ap (φ₁ ∘ f ∘ right ∘ cin j) p₂ ∙
-          ap (φ₁ ∘ f) p₃ ∙
-          ap φ₁ p₄ ∙ p₅)
-          (ap-∘-rid φ₁ f p₁)) ◃∙
-        ap (λ p →  ! (p ∙ ap φ₁ (ap f p₁) ∙ idp) ∙
-          ap (φ₁ ∘ f ∘ right ∘ cin j) p₂ ∙
-          ap (φ₁ ∘ f) p₃ ∙
-          ap φ₁ p₄ ∙ p₅)
-          (hmtpy-nat-rev {f = φ₁ ∘ f ∘ right ∘ cin j} (λ x → idp) p₂
-          (ap φ₁ (ap f p₃ ∙ p₄) ∙ p₅)) ◃∙
-        ap (λ p →  (! ((ap (λ z → (φ₁ ∘ f ∘ right ∘ cin j) z) p₂ ∙
-          (p ∙ ! (ap φ₁ (ap f p₃ ∙ p₄) ∙ p₅)) ∙
+    NatSq-1-Λ-red : {i j : Obj Γ} (g : Hom Γ i j) (a : A) {x z : P} {y : ty (F # j)}
+      (p₁ : right (cin j (fst (F <#> g) (fun (F # i) a))) == x)
+      (p₂ : fst (F <#> g) (fun (F # i) a) == y) (p₃ : right (cin j y) == z) {u : ty T}
+      (p₄ : f z == u) {v : ty U} (p₅ : φ₁ u == v)  →
+      ! (ap (λ p → ! p ∙ ap (φ₁ ∘ f ∘ right ∘ cin j) p₂ ∙ ap (φ₁ ∘ f) p₃ ∙ ap φ₁ p₄ ∙ p₅) (ap-∘-rid φ₁ f p₁)) ◃∙
+      ap (λ p →  ! (p ∙ ap φ₁ (ap f p₁) ∙ idp) ∙ ap (φ₁ ∘ f ∘ right ∘ cin j) p₂ ∙ ap (φ₁ ∘ f) p₃ ∙ ap φ₁ p₄ ∙ p₅)
+        (hmtpy-nat-rev {f = φ₁ ∘ f ∘ right ∘ cin j} (λ x → idp) p₂  (ap φ₁ (ap f p₃ ∙ p₄) ∙ p₅)) ◃∙
+      ap (λ p →  (! ((ap (λ z → (φ₁ ∘ f ∘ right ∘ cin j) z) p₂ ∙ (p ∙ ! (ap φ₁ (ap f p₃ ∙ p₄) ∙ p₅)) ∙
           ! (ap (φ₁ ∘ f ∘ right ∘ cin j) p₂)) ∙
-          ap φ₁ (ap f p₁) ∙ idp) ∙
-          ap (φ₁ ∘ f ∘ right ∘ cin j) p₂ ∙
+          ap φ₁ (ap f p₁) ∙ idp) ∙ ap (φ₁ ∘ f ∘ right ∘ cin j) p₂ ∙
           ap (φ₁ ∘ f) p₃ ∙ ap φ₁ p₄ ∙ p₅))
-          (ap-∘-∙-∙ φ₁ f p₃ p₄)  ◃∙
-        long-path-red p₂
-          (ap (φ₁ ∘ f) p₃ ∙
-          ap φ₁ p₄ ∙ p₅)
-          (ap φ₁ (ap f p₃ ∙ p₄) ∙ p₅)
-          (ap φ₁ (ap f p₁)) idp ◃∎
+        (ap-∘-∙-∙ φ₁ f p₃ p₄)  ◃∙
+      long-path-red p₂ (ap (φ₁ ∘ f) p₃ ∙ ap φ₁ p₄ ∙ p₅) (ap φ₁ (ap f p₃ ∙ p₄) ∙ p₅) (ap φ₁ (ap f p₁)) idp ◃∎
         =ₛ
-        ↯ (NatSq-1-Λ-aux g a p₁ p₂ p₃ p₄ p₅) ◃∎
+      ↯ (NatSq-1-Λ-aux g a p₁ p₂ p₃ p₄ p₅) ◃∎
     NatSq-1-Λ-red g a idp idp idp idp idp = =ₛ-in idp 
 
     NatSq-1-Λ-red2 : {i j : Obj Γ} (g : Hom Γ i j) (a : A) {x : P} {y : ty (F # j)}
-      (p₁ : right (cin j (fst (F <#> g) (fun (F # i) a))) == x) (p₂ : fst (F <#> g) (fun (F # i) a) == y) (p₃ : right (cin j y) == left a)
-      {σ : x == left a} (τ : ! p₁ ∙ ap (right ∘ cin j) p₂ ∙ p₃ == σ)
-      →
+      (p₁ : right (cin j (fst (F <#> g) (fun (F # i) a))) == x)
+      (p₂ : fst (F <#> g) (fun (F # i) a) == y) (p₃ : right (cin j y) == left a)
+      {σ : x == left a} (τ : ! p₁ ∙ ap (right ∘ cin j) p₂ ∙ p₃ == σ) →
       ↯ (NatSq-1-Λ-aux g a p₁ p₂ p₃ (fₚ a) (φ₂ a)) ◃∙
       ap (λ q → q)
-        (ap-cp-revR φ₁ (f ∘ right ∘ cin j) p₂
-          (ap f p₁) ∙
-          ap (λ p → ap φ₁ p ∙ φ₂ a) (ap-cp-revR f (right ∘ cin j) p₂
-            p₁ ∙
-          ap (λ p → p ∙ fₚ a) (ap (ap f) τ))) ◃∙
+        (ap-cp-revR φ₁ (f ∘ right ∘ cin j) p₂ (ap f p₁) ∙
+        ap (λ p → ap φ₁ p ∙ φ₂ a) (ap-cp-revR f (right ∘ cin j) p₂ p₁ ∙
+        ap (λ p → p ∙ fₚ a) (ap (ap f) τ))) ◃∙
       ap-∘-∙-∙ φ₁ f σ (fₚ a) ◃∎
-      =ₛ
-      (ap-cp-revR (φ₁ ∘ f) (right ∘ cin j)
-        p₂ p₁ ∙
-        ap (λ p → p ∙ ap (fst φ) (fₚ a) ∙ φ₂ a)
-          (ap (ap (φ₁ ∘ f)) τ)) ◃∎
+        =ₛ
+      (ap-cp-revR (φ₁ ∘ f) (right ∘ cin j) p₂ p₁ ∙
+      ap (λ p → p ∙ ap (fst φ) (fₚ a) ∙ φ₂ a) (ap (ap (φ₁ ∘ f)) τ)) ◃∎
     NatSq-1-Λ-red2 {i} {j} g a idp idp p₃ idp = =ₛ-in (lemma p₃ (fₚ a))
       where
         lemma : {z : P} (p : right (cin j (fst (F <#> g) (fun (F # i) a))) == z) (c : f z == fun T a)
@@ -111,77 +99,75 @@ module _ {ℓv ℓe ℓ ℓd ℓc₁ ℓc₂} {Γ : Graph ℓv ℓe} {A : Type �
       where
         lemma : (a : A) → 
           ! (ap (λ p → ! p ∙  ap (φ₁ ∘ f ∘ fst (comp ColCoC j)) (snd (F <#> g) a) ∙
-            ap (φ₁ ∘ f) (snd (comp ColCoC j) a) ∙     snd (φ ∘* f , fₚ) a)
-            (ap-∘-rid φ₁ f (ap right (cglue g (fun (F # i) a))))) ◃∙
+                ap (φ₁ ∘ f) (snd (comp ColCoC j) a) ∙ snd (φ ∘* f , fₚ) a)
+              (ap-∘-rid φ₁ f (ap right (cglue g (fun (F # i) a))))) ◃∙
           ap (λ p → ! (p ∙ ap φ₁ (ap f (fst (comTri ColCoC g) (fun (F # i) a))) ∙ idp) ∙
-            ap (φ₁ ∘ f ∘ fst (comp ColCoC j)) (snd (F <#> g) a) ∙
-            ap (φ₁ ∘ f) (snd (comp ColCoC j) a) ∙
-            snd (φ ∘* f , fₚ) a)
+              ap (φ₁ ∘ f ∘ fst (comp ColCoC j)) (snd (F <#> g) a) ∙
+              ap (φ₁ ∘ f) (snd (comp ColCoC j) a) ∙
+              snd (φ ∘* f , fₚ) a)
             (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a)
-            (snd (φ ∘* f ∘ fst (comp ColCoC j) , (λ a₁ → ap f (snd (comp ColCoC j) a₁) ∙ fₚ a₁))  a)) ◃∙
+              (snd (φ ∘* f ∘ fst (comp ColCoC j) , (λ a₁ → ap f (snd (comp ColCoC j) a₁) ∙ fₚ a₁))  a)) ◃∙
           ap (λ p → ! ((ap (φ₁ ∘ f ∘ fst (comp ColCoC j)) (snd (F <#> g) a) ∙
-            (p ∙ ! (snd (φ ∘* f ∘ fst (comp ColCoC j) , (λ a₁ → ap f (snd (comp ColCoC j) a₁) ∙ fₚ a₁)) a)) ∙
-            ! (ap (fst (φ ∘* f ∘ fst (comp ColCoC j) , (λ a₁ → ap f (snd (comp ColCoC j) a₁) ∙ fₚ a₁))) (snd (F <#> g) a))) ∙
-            ap φ₁ (ap f (fst (comTri ColCoC g) (fun (F # i) a))) ∙ idp) ∙
-            ap (φ₁ ∘ f ∘ fst (comp ColCoC j)) (snd (F <#> g) a) ∙
-            ap (φ₁ ∘ f) (snd (comp ColCoC j) a) ∙
-            snd (φ ∘* f , fₚ) a) (ap-∘-∙-∙ φ₁ f (! (glue (cin j a))) (fₚ a)) ◃∙
-          long-path-red (snd (F <#> g) a) (ap (φ₁ ∘ f) (! (glue (cin j a))) ∙
-            ap (fst φ) (fₚ a) ∙ snd φ a) (ap (fst φ) (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ snd φ a)
-            (ap φ₁ (ap f (ap right (cglue g (fun (F # i) a))))) idp ◃∙ -- here
-          ap (λ q → q) (ap-cp-revR φ₁ (f ∘ fst (comp ColCoC j)) (snd (F <#> g) a)
-            (ap f (fst (comTri ColCoC g) (fun (F # i) a))) ∙
-            ap (λ p → ap φ₁ p ∙ φ₂ a)
-            (ap-cp-revR f (fst (comp ColCoC j)) (snd (F <#> g) a)
-            (fst (comTri ColCoC g) (fun (F # i) a)) ∙
+              (p ∙ ! (snd (φ ∘* f ∘ fst (comp ColCoC j) , (λ a₁ → ap f (snd (comp ColCoC j) a₁) ∙ fₚ a₁)) a)) ∙
+              ! (ap (fst (φ ∘* f ∘ fst (comp ColCoC j) , (λ a₁ → ap f (snd (comp ColCoC j) a₁) ∙ fₚ a₁))) (snd (F <#> g) a))) ∙
+              ap φ₁ (ap f (fst (comTri ColCoC g) (fun (F # i) a))) ∙ idp) ∙
+              ap (φ₁ ∘ f ∘ fst (comp ColCoC j)) (snd (F <#> g) a) ∙
+              ap (φ₁ ∘ f) (snd (comp ColCoC j) a) ∙ snd (φ ∘* f , fₚ) a)
+            (ap-∘-∙-∙ φ₁ f (! (glue (cin j a))) (fₚ a)) ◃∙
+          long-path-red (snd (F <#> g) a)
+            (ap (φ₁ ∘ f) (! (glue (cin j a))) ∙ ap (fst φ) (fₚ a) ∙ snd φ a)
+            (ap (fst φ) (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ snd φ a)
+            (ap φ₁ (ap f (ap right (cglue g (fun (F # i) a))))) idp ◃∙
+          ap (λ q → q)
+            (ap-cp-revR φ₁ (f ∘ fst (comp ColCoC j)) (snd (F <#> g) a)
+              (ap f (fst (comTri ColCoC g) (fun (F # i) a))) ∙
+              ap (λ p → ap φ₁ p ∙ φ₂ a)
+            (ap-cp-revR f (fst (comp ColCoC j)) (snd (F <#> g) a) (fst (comTri ColCoC g) (fun (F # i) a)) ∙
             ap (λ p → p ∙ fₚ a) (ap (ap f) (snd (comTri ColCoC g) a)))) ◃∙
           ap-∘-∙-∙ φ₁ f (! (glue (cin i a))) (fₚ a) ◃∎
             =ₛ
-          (ap-cp-revR (φ₁ ∘ f) (fst (comp ColCoC j))
-            (snd (F <#> g) a) (fst (comTri ColCoC g) (fun (F # i) a)) ∙
-            ap (λ p → p ∙ snd (φ ∘* f , fₚ) a)
-            (ap (ap (φ₁ ∘ f)) (snd (comTri ColCoC g) a))) ◃∎
+          (ap-cp-revR (φ₁ ∘ f) (fst (comp ColCoC j)) (snd (F <#> g) a) (fst (comTri ColCoC g) (fun (F # i) a)) ∙
+          ap (λ p → p ∙ snd (φ ∘* f , fₚ) a) (ap (ap (φ₁ ∘ f)) (snd (comTri ColCoC g) a))) ◃∎
         lemma a =
           ! (ap (λ p → ! p ∙  ap (φ₁ ∘ f ∘ fst (comp ColCoC j)) (snd (F <#> g) a) ∙
-            ap (φ₁ ∘ f) (snd (comp ColCoC j) a) ∙     snd (φ ∘* f , fₚ) a)
-            (ap-∘-rid φ₁ f (ap right (cglue g (fun (F # i) a))))) ◃∙
+                ap (φ₁ ∘ f) (snd (comp ColCoC j) a) ∙ snd (φ ∘* f , fₚ) a)
+              (ap-∘-rid φ₁ f (ap right (cglue g (fun (F # i) a))))) ◃∙
           ap (λ p → ! (p ∙ ap φ₁ (ap f (fst (comTri ColCoC g) (fun (F # i) a))) ∙ idp) ∙
-            ap (φ₁ ∘ f ∘ fst (comp ColCoC j)) (snd (F <#> g) a) ∙
-            ap (φ₁ ∘ f) (snd (comp ColCoC j) a) ∙
-            snd (φ ∘* f , fₚ) a)
+              ap (φ₁ ∘ f ∘ fst (comp ColCoC j)) (snd (F <#> g) a) ∙
+              ap (φ₁ ∘ f) (snd (comp ColCoC j) a) ∙
+              snd (φ ∘* f , fₚ) a)
             (hmtpy-nat-rev (λ x → idp) (snd (F <#> g) a)
-            (snd (φ ∘* f ∘ fst (comp ColCoC j) , (λ a₁ → ap f (snd (comp ColCoC j) a₁) ∙ fₚ a₁))  a)) ◃∙
+              (snd (φ ∘* f ∘ fst (comp ColCoC j) , (λ a₁ → ap f (snd (comp ColCoC j) a₁) ∙ fₚ a₁))  a)) ◃∙
           ap (λ p → ! ((ap (φ₁ ∘ f ∘ fst (comp ColCoC j)) (snd (F <#> g) a) ∙
-            (p ∙ ! (snd (φ ∘* f ∘ fst (comp ColCoC j) , (λ a₁ → ap f (snd (comp ColCoC j) a₁) ∙ fₚ a₁)) a)) ∙
-            ! (ap (fst (φ ∘* f ∘ fst (comp ColCoC j) , (λ a₁ → ap f (snd (comp ColCoC j) a₁) ∙ fₚ a₁))) (snd (F <#> g) a))) ∙
-            ap φ₁ (ap f (fst (comTri ColCoC g) (fun (F # i) a))) ∙ idp) ∙
-            ap (φ₁ ∘ f ∘ fst (comp ColCoC j)) (snd (F <#> g) a) ∙
-            ap (φ₁ ∘ f) (snd (comp ColCoC j) a) ∙
-            snd (φ ∘* f , fₚ) a) (ap-∘-∙-∙ φ₁ f (! (glue (cin j a))) (fₚ a)) ◃∙
-          long-path-red (snd (F <#> g) a) (ap (φ₁ ∘ f) (! (glue (cin j a))) ∙
-            ap (fst φ) (fₚ a) ∙ snd φ a) (ap (fst φ) (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ snd φ a)
+              (p ∙ ! (snd (φ ∘* f ∘ fst (comp ColCoC j) , (λ a₁ → ap f (snd (comp ColCoC j) a₁) ∙ fₚ a₁)) a)) ∙
+              ! (ap (fst (φ ∘* f ∘ fst (comp ColCoC j) , (λ a₁ → ap f (snd (comp ColCoC j) a₁) ∙ fₚ a₁))) (snd (F <#> g) a))) ∙
+              ap φ₁ (ap f (fst (comTri ColCoC g) (fun (F # i) a))) ∙ idp) ∙
+              ap (φ₁ ∘ f ∘ fst (comp ColCoC j)) (snd (F <#> g) a) ∙
+              ap (φ₁ ∘ f) (snd (comp ColCoC j) a) ∙ snd (φ ∘* f , fₚ) a)
+            (ap-∘-∙-∙ φ₁ f (! (glue (cin j a))) (fₚ a)) ◃∙
+          long-path-red (snd (F <#> g) a)
+            (ap (φ₁ ∘ f) (! (glue (cin j a))) ∙ ap (fst φ) (fₚ a) ∙ snd φ a)
+            (ap (fst φ) (ap f (! (glue (cin j a))) ∙ fₚ a) ∙ snd φ a)
             (ap φ₁ (ap f (ap right (cglue g (fun (F # i) a))))) idp ◃∙
-          ap (λ q → q) (ap-cp-revR φ₁ (f ∘ fst (comp ColCoC j)) (snd (F <#> g) a)
-            (ap f (fst (comTri ColCoC g) (fun (F # i) a))) ∙
-            ap (λ p → ap φ₁ p ∙ φ₂ a)
-            (ap-cp-revR f (fst (comp ColCoC j)) (snd (F <#> g) a)
-            (fst (comTri ColCoC g) (fun (F # i) a)) ∙
+          ap (λ q → q)
+            (ap-cp-revR φ₁ (f ∘ fst (comp ColCoC j)) (snd (F <#> g) a)
+              (ap f (fst (comTri ColCoC g) (fun (F # i) a))) ∙
+              ap (λ p → ap φ₁ p ∙ φ₂ a)
+            (ap-cp-revR f (fst (comp ColCoC j)) (snd (F <#> g) a) (fst (comTri ColCoC g) (fun (F # i) a)) ∙
             ap (λ p → p ∙ fₚ a) (ap (ap f) (snd (comTri ColCoC g) a)))) ◃∙
           ap-∘-∙-∙ φ₁ f (! (glue (cin i a))) (fₚ a) ◃∎
             =ₛ⟨ 0 & 4 & NatSq-1-Λ-red g a (ap right (cglue g (fun (F # i) a))) (snd (F <#> g) a) (! (glue (cin j a))) (fₚ a) (φ₂ a) ⟩
           ↯ (NatSq-1-Λ-aux g a (ap right (cglue g (fun (F # i) a))) (snd (F <#> g) a) (! (glue (cin j a))) (fₚ a) (φ₂ a)) ◃∙ 
-          ap (λ q → q) (ap-cp-revR φ₁ (f ∘ fst (comp ColCoC j)) (snd (F <#> g) a)
-            (ap f (fst (comTri ColCoC g) (fun (F # i) a))) ∙
+          ap (λ q → q)
+            (ap-cp-revR φ₁ (f ∘ fst (comp ColCoC j)) (snd (F <#> g) a)
+              (ap f (fst (comTri ColCoC g) (fun (F # i) a))) ∙
             ap (λ p → ap φ₁ p ∙ φ₂ a)
-            (ap-cp-revR f (fst (comp ColCoC j)) (snd (F <#> g) a)
-            (fst (comTri ColCoC g) (fun (F # i) a)) ∙
-            ap (λ p → p ∙ fₚ a) (ap (ap f) (snd (comTri ColCoC g) a)))) ◃∙
+              (ap-cp-revR f (fst (comp ColCoC j)) (snd (F <#> g) a) (fst (comTri ColCoC g) (fun (F # i) a)) ∙
+              ap (λ p → p ∙ fₚ a) (ap (ap f) (snd (comTri ColCoC g) a)))) ◃∙
           ap-∘-∙-∙ φ₁ f (! (glue (cin i a))) (fₚ a) ◃∎
             =ₛ⟨ NatSq-1-Λ-red2 g a (ap right (cglue g (fun (F # i) a))) (snd (F <#> g) a) (! (glue (cin j a))) (snd (comTri ColCoC g) a) ⟩          
-          (ap-cp-revR (φ₁ ∘ f) (fst (comp ColCoC j))
-            (snd (F <#> g) a) (fst (comTri ColCoC g) (fun (F # i) a)) ∙
-            ap (λ p → p ∙ snd (φ ∘* f , fₚ) a)
-            (ap (ap (φ₁ ∘ f)) (snd (comTri ColCoC g) a))) ◃∎ ∎ₛ
+          (ap-cp-revR (φ₁ ∘ f) (fst (comp ColCoC j)) (snd (F <#> g) a) (fst (comTri ColCoC g) (fun (F # i) a)) ∙
+          ap (λ p → p ∙ snd (φ ∘* f , fₚ) a) (ap (ap (φ₁ ∘ f)) (snd (comTri ColCoC g) a))) ◃∎ ∎ₛ
 
     CosColim-NatSq1-eq : Map-to-Lim-map (PostComp ColCoC (f , fₚ)) == PostComp ColCoC (φ ∘* (f , fₚ))
     CosColim-NatSq1-eq = CosCocEq-ind F U (Map-to-Lim-map (PostComp ColCoC (f , fₚ))) (CosColim-NatSq1)

--- a/Colimit-code/Map-Nat/CosColimitPstCmp.agda
+++ b/Colimit-code/Map-Nat/CosColimitPstCmp.agda
@@ -81,12 +81,6 @@ module _ {ℓv ℓe ℓ ℓd ℓc₁ ℓc₂} {Γ : Graph ℓv ℓe} {A : Type �
         ↯ (NatSq-1-Λ-aux g a p₁ p₂ p₃ p₄ p₅) ◃∎
     NatSq-1-Λ-red g a idp idp idp idp idp = =ₛ-in idp 
 
--- p₁ = (ap right (cglue g (fun (F # i) a)))
--- p₂ = (snd (F <#> g) a)
--- p₃ = (! (glue (cin j a)))
--- p₄ = (fₚ a)
--- p₅ = φ₂ a
-
     NatSq-1-Λ-red2 : {i j : Obj Γ} (g : Hom Γ i j) (a : A) {x : P} {y : ty (F # j)}
       (p₁ : right (cin j (fst (F <#> g) (fun (F # i) a))) == x) (p₂ : fst (F <#> g) (fun (F # i) a) == y) (p₃ : right (cin j y) == left a)
       {σ : x == left a} (τ : ! p₁ ∙ ap (right ∘ cin j) p₂ ∙ p₃ == σ)
@@ -109,8 +103,6 @@ module _ {ℓv ℓe ℓ ℓd ℓc₁ ℓc₂} {Γ : Graph ℓv ℓe} {A : Type �
         lemma : {z : P} (p : right (cin j (fst (F <#> g) (fun (F # i) a))) == z) (c : f z == fun T a)
           → ↯ (NatSq-1-Λ-aux g a idp idp p c (φ₂ a)) ∙ ap-∘-∙-∙ φ₁ f p c == idp
         lemma idp c = idp
-
--- τ = (snd (comTri ColCoC g) a)
 
     CosColim-NatSq1 : CosCocEq F U (Map-to-Lim-map (PostComp ColCoC (f , fₚ))) (PostComp ColCoC (φ ∘* (f , fₚ)))
     W CosColim-NatSq1 = λ i x → idp

--- a/Colimit-code/R-L-R/CC-Equiv-RLR-0.agda
+++ b/Colimit-code/R-L-R/CC-Equiv-RLR-0.agda
@@ -2,7 +2,6 @@
 
 open import lib.Basics
 open import lib.types.Pushout
-open import lib.types.Span
 open import Coslice
 open import Diagram
 open import Colim
@@ -25,25 +24,30 @@ module ConstrE2 {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type ℓ} 
   LRfun = PostComp ColCoC (recCosCoc K)
 
   CompEq : (i : Obj Γ) (a : A) →  snd (comp LRfun i) a =-= snd (comp K i) a
-  CompEq i a = ap (fst (recCosCoc K)) (! (glue (cin i a))) ∙ idp
-                 =⟪ ap-inv-rid (fst (recCosCoc K)) (glue (cin i a))⟫
-               ! (ap (fst (recCosCoc K)) (glue (cin i a)))
-                 =⟪ ap ! (FPrecc-βr K (cin i a)) ⟫
-               ! (! (snd (comp K i) a))
-                 =⟪ !-! (snd (comp K i) a) ⟫
-               snd (comp K i) a ∎∎
+  CompEq i a =
+    ap (fst (recCosCoc K)) (! (glue (cin i a))) ∙ idp
+      =⟪ ap-inv-rid (fst (recCosCoc K)) (glue (cin i a))⟫
+    ! (ap (fst (recCosCoc K)) (glue (cin i a)))
+      =⟪ ap ! (FPrecc-βr K (cin i a)) ⟫
+    ! (! (snd (comp K i) a))
+      =⟪ !-! (snd (comp K i) a) ⟫
+    snd (comp K i) a ∎∎
 
-  FunHomEq : {i j : Obj Γ} (g : Hom Γ i j) (x : ty (F # i)) → ap (fst (recCosCoc K)) (ap right (cglue g x)) ∙ idp =-= fst (comTri K g) x
-  FunHomEq g x = ap (fst (recCosCoc K)) (ap right (cglue g x)) ∙ idp
-                   =⟪ ap-inv-cmp-rid right (fst (recCosCoc K)) (cglue g x) ⟫
-                 ap (reccForg K) (cglue g x)
-                   =⟪ recc-βr K g x ⟫
-                 fst (comTri K g) x ∎∎
+  FunHomEq : {i j : Obj Γ} (g : Hom Γ i j) (x : ty (F # i))
+    → ap (fst (recCosCoc K)) (ap right (cglue g x)) ∙ idp =-= fst (comTri K g) x
+  FunHomEq g x =
+    ap (fst (recCosCoc K)) (ap right (cglue g x)) ∙ idp
+      =⟪ ap-inv-cmp-rid right (fst (recCosCoc K)) (cglue g x) ⟫
+    ap (reccForg K) (cglue g x)
+      =⟪ recc-βr K g x ⟫
+    fst (comTri K g) x ∎∎
 
   abstract
-
     FPrecc-transf : (i j : Obj Γ) (g : Hom Γ i j) (a : A)
-      → ap-inv-rid (fst (recCosCoc K)) (glue (cin i a)) ◃∙ ap ! (FPrecc-βr K (cin i a)) ◃∎ =ₛ
+      →
+      ap-inv-rid (fst (recCosCoc K)) (glue (cin i a)) ◃∙
+      ap ! (FPrecc-βr K (cin i a)) ◃∎
+        =ₛ
       ! (apd-tr (λ z → ap (fst (recCosCoc K)) (! (glue z)) ∙ idp) (cglue g a)) ◃∙
       ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a))
         (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
@@ -51,9 +55,12 @@ module ConstrE2 {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type ℓ} 
       ap-seq ! (η (comp K) (comTri K) i j g a)
     FPrecc-transf i j g a =
       ap-inv-rid (fst (recCosCoc K)) (glue (cin i a)) ◃∙ ap ! (FPrecc-βr K (cin i a)) ◃∎
-        =ₛ⟨ =ₛ-in (apd-tr-coher (λ z → ap (fst (recCosCoc K)) (! (glue z)) ∙ idp)
-          (λ z → ! (σ (comp K) (comTri K) z)) (cglue g a)
-          (λ z →  ap-inv-rid (fst (recCosCoc K)) (glue z) ∙ ap ! (FPrecc-βr K z))) ⟩
+        =ₛ⟨
+          =ₛ-in
+            (apd-tr-coher (λ z → ap (fst (recCosCoc K)) (! (glue z)) ∙ idp)
+              (λ z → ! (σ (comp K) (comTri K) z))
+              (cglue g a)
+              (λ z → ap-inv-rid (fst (recCosCoc K)) (glue z) ∙ ap ! (FPrecc-βr K z))) ⟩
       ! (apd-tr (λ z → ap (fst (recCosCoc K)) (! (glue z)) ∙ idp) (cglue g a)) ◃∙
       ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a))
         (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
@@ -82,27 +89,39 @@ module ConstrE2 {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type ℓ} 
     Ξ-inst =
       ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
         (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (↯ (CompEq j a)) ◃∙
+      ap (λ p →
+        ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (↯ (CompEq j a)) ◃∙
       long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
       ap (λ p → p) (snd (comTri LRfun g) a) ◃∙
       CompEq i a
 
     Ξ-RW1 =
       Ξ-inst
-        =ₛ⟨ 1 & 1 & ap-seq-∙ (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (CompEq j a) ⟩
+        =ₛ⟨ 1 & 1 &
+          ap-seq-∙
+            (λ p →
+              ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+                fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+            (CompEq j a) ⟩
       ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
         (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a))) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap ! (FPrecc-βr K (cin j a))) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (!-! (snd (comp K j) a)) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a))) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (ap ! (FPrecc-βr K (cin j a))) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (!-! (snd (comp K j) a)) ◃∙
       long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
       ap (λ p → p) (snd (comTri LRfun g) a) ◃∙
       CompEq i a ∎ₛ
@@ -110,30 +129,42 @@ module ConstrE2 {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type ℓ} 
     Ξ-RW2 =
       ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
         (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a))) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap ! (FPrecc-βr K (cin j a))) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (!-! (snd (comp K j) a)) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a))) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (ap ! (FPrecc-βr K (cin j a))) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (!-! (snd (comp K j) a)) ◃∙
       long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
       ap (λ p → p) (snd (comTri LRfun g) a) ◃∙
       CompEq i a
         =ₑ⟨ 5 & 1 &  (snd (comTri LRfun g) a ◃∎)  % =ₛ-in ((ap-idf (snd (comTri LRfun g) a))) ⟩
       ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
         (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a))) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap ! (FPrecc-βr K (cin j a))) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (!-! (snd (comp K j) a)) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a))) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (ap ! (FPrecc-βr K (cin j a))) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (!-! (snd (comp K j) a)) ◃∙
       long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
       snd (comTri LRfun g) a ◃∙
       CompEq i a ∎ₛ
@@ -141,39 +172,53 @@ module ConstrE2 {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type ℓ} 
     Ξ-RW3 =
       ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
         (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a))) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap ! (FPrecc-βr K (cin j a))) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (!-! (snd (comp K j) a)) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a))) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (ap ! (FPrecc-βr K (cin j a))) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (!-! (snd (comp K j) a)) ◃∙
       long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
       snd (comTri LRfun g) a ◃∙
       CompEq i a
-        =ₑ⟨ 6 & 2 & (↯ (! (apd-tr (λ z → ap (fst (recCosCoc K)) (! (glue z)) ∙ idp) (cglue g a)) ◃∙
-                      ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a))
-                    (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
-                    transp-inv-comm (fun T ∘ [id]) (reccForg K ∘ ψ) (cglue g a) (! (snd (comp K j) a)) ◃∙
-                    ap-seq ! (η (comp K) (comTri K) i j g a)) ◃∎) % =ₛ-in (=ₛ-out (FPrecc-transf i j g a)) ⟩
+        =ₑ⟨ 6 & 2 &
+          (↯ (! (apd-tr (λ z → ap (fst (recCosCoc K)) (! (glue z)) ∙ idp) (cglue g a)) ◃∙
+          ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a))
+            (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
+          transp-inv-comm (fun T ∘ [id]) (reccForg K ∘ ψ) (cglue g a) (! (snd (comp K j) a)) ◃∙
+          ap-seq ! (η (comp K) (comTri K) i j g a)) ◃∎)
+          % =ₛ-in (=ₛ-out (FPrecc-transf i j g a)) ⟩
       ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
         (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a))) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap ! (FPrecc-βr K (cin j a))) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (!-! (snd (comp K j) a)) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a))) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (ap ! (FPrecc-βr K (cin j a))) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (!-! (snd (comp K j) a)) ◃∙
       long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
       snd (comTri LRfun g) a ◃∙
       ↯ (! (apd-tr (λ z → ap (fst (recCosCoc K)) (! (glue z)) ∙ idp) (cglue g a)) ◃∙
         ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a))
-        (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
+          (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
         transp-inv-comm (fun T ∘ [id]) (reccForg K ∘ ψ) (cglue g a) (! (snd (comp K j) a)) ◃∙
         ap-seq ! (η (comp K) (comTri K) i j g a)) ◃∙
       !-! (snd (comp K i) a) ◃∎ ∎ₛ
@@ -181,141 +226,192 @@ module ConstrE2 {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type ℓ} 
     Ξ-RW4 =
       ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
         (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a))) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap ! (FPrecc-βr K (cin j a))) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (!-! (snd (comp K j) a)) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a))) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (ap ! (FPrecc-βr K (cin j a))) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (!-! (snd (comp K j) a)) ◃∙
       long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
       snd (comTri LRfun g) a ◃∙
       ↯ (! (apd-tr (λ z → ap (fst (recCosCoc K)) (! (glue z)) ∙ idp) (cglue g a)) ◃∙
-      ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a))
-        (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
-      transp-inv-comm (fun T ∘ [id]) (reccForg K ∘ ψ) (cglue g a) (! (snd (comp K j) a)) ◃∙
-      ap-seq ! (η (comp K) (comTri K) i j g a)) ◃∙
+        ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a))
+          (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
+        transp-inv-comm (fun T ∘ [id]) (reccForg K ∘ ψ) (cglue g a) (! (snd (comp K j) a)) ◃∙
+        ap-seq ! (η (comp K) (comTri K) i j g a)) ◃∙
       !-! (snd (comp K i) a) ◃∎
-        =ₑ⟨ 6 & 1 & (! (apd-tr (λ z → ap (fst (recCosCoc K)) (! (glue z)) ∙ idp) (cglue g a)) ◃∙
-      ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a)) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
-      transp-inv-comm (fun T ∘ [id]) (reccForg K ∘ ψ) (cglue g a) (! (snd (comp K j) a)) ◃∙
-      ap ! (H₁ (cglue g a) (! (snd (comp K j) a)) (ψ-βr g a)) ◃∙
-      ap ! (H₂ (snd (F <#> g) a) (snd (comp K j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
-      ap ! (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙
-        (snd (comp K j) a))) (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
-      ap ! (ap ! (snd (comTri K g) a)) ◃∎) % =ₛ-in idp ⟩
+        =ₑ⟨ 6 & 1 &
+          (! (apd-tr (λ z → ap (fst (recCosCoc K)) (! (glue z)) ∙ idp) (cglue g a)) ◃∙
+          ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a))
+            (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
+          transp-inv-comm (fun T ∘ [id]) (reccForg K ∘ ψ) (cglue g a) (! (snd (comp K j) a)) ◃∙
+          ap ! (H₁ (cglue g a) (! (snd (comp K j) a)) (ψ-βr g a)) ◃∙
+          ap ! (H₂ (snd (F <#> g) a) (snd (comp K j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
+          ap !
+            (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
+              (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
+          ap ! (ap ! (snd (comTri K g) a)) ◃∎)
+          % =ₛ-in idp ⟩
       ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
         (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a))) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap ! (FPrecc-βr K (cin j a))) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (!-! (snd (comp K j) a)) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a))) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (ap ! (FPrecc-βr K (cin j a))) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (!-! (snd (comp K j) a)) ◃∙
       long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
       snd (comTri LRfun g) a ◃∙
       ! (apd-tr (λ z → ap (fst (recCosCoc K)) (! (glue z)) ∙ idp) (cglue g a)) ◃∙
-      ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a)) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
+      ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a))
+        (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
       transp-inv-comm (fun T ∘ [id]) (reccForg K ∘ ψ) (cglue g a) (! (snd (comp K j) a)) ◃∙
       ap ! (H₁ (cglue g a) (! (snd (comp K j) a)) (ψ-βr g a)) ◃∙
       ap ! (H₂ (snd (F <#> g) a) (snd (comp K j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
-      ap ! (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙
-        (snd (comp K j) a))) (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
+      ap !
+        (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
+          (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
       ap ! (ap ! (snd (comTri K g) a)) ◃∙
       !-! (snd (comp K i) a) ◃∎ ∎ₛ
 
     Ξ-RW5 =
-      ap (λ p → ! (p ∙ fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+      ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
         (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a))) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap ! (FPrecc-βr K (cin j a))) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (!-! (snd (comp K j) a)) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a))) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (ap ! (FPrecc-βr K (cin j a))) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (!-! (snd (comp K j) a)) ◃∙
       long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
       snd (comTri LRfun g) a ◃∙
       ! (apd-tr (λ z → ap (fst (recCosCoc K)) (! (glue z)) ∙ idp) (cglue g a)) ◃∙
-      ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a)) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
+      ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a))
+        (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
       transp-inv-comm (fun T ∘ [id]) (reccForg K ∘ ψ) (cglue g a) (! (snd (comp K j) a)) ◃∙
       ap ! (H₁ (cglue g a) (! (snd (comp K j) a)) (ψ-βr g a)) ◃∙
       ap ! (H₂ (snd (F <#> g) a) (snd (comp K j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
-      ap ! (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙
-        (snd (comp K j) a))) (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
+      ap !
+        (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
+          (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
       ap ! (ap ! (snd (comTri K g) a)) ◃∙
       !-! (snd (comp K i) a) ◃∎
-        =ₑ⟨ 5 & 1 & (ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
-      ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (↯ (ϵ g g a))) ◃∎)  % =ₛ-in idp ⟩
+        =ₑ⟨ 5 & 1 &
+          (ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
+          ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (↯ (ϵ g g a))) ◃∎)
+          % =ₛ-in idp ⟩
       ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
         (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a))) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap ! (FPrecc-βr K (cin j a))) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (!-! (snd (comp K j) a)) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a))) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (ap ! (FPrecc-βr K (cin j a))) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (!-! (snd (comp K j) a)) ◃∙
       long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
       ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
       ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (↯ (ϵ g g a))) ◃∙
       ! (apd-tr (λ z → ap (fst (recCosCoc K)) (! (glue z)) ∙ idp) (cglue g a)) ◃∙
-      ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a)) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
+      ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a))
+        (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
       transp-inv-comm (fun T ∘ [id]) (reccForg K ∘ ψ) (cglue g a) (! (snd (comp K j) a)) ◃∙
       ap ! (H₁ (cglue g a) (! (snd (comp K j) a)) (ψ-βr g a)) ◃∙
       ap ! (H₂ (snd (F <#> g) a) (snd (comp K j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
-      ap ! (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙
-        (snd (comp K j) a))) (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
+      ap !
+        (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
+          (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
       ap ! (ap ! (snd (comTri K g) a)) ◃∙
       !-! (snd (comp K i) a) ◃∎ ∎ₛ
 
     Ξ-RW6 =       
       ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
         (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a))) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap ! (FPrecc-βr K (cin j a))) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (!-! (snd (comp K j) a)) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a))) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (ap ! (FPrecc-βr K (cin j a))) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (!-! (snd (comp K j) a)) ◃∙
       long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
       ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
       ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (↯ (ϵ g g a))) ◃∙
       ! (apd-tr (λ z → ap (fst (recCosCoc K)) (! (glue z)) ∙ idp) (cglue g a)) ◃∙
-      ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a)) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
+      ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a))
+        (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
       transp-inv-comm (fun T ∘ [id]) (reccForg K ∘ ψ) (cglue g a) (! (snd (comp K j) a)) ◃∙
       ap ! (H₁ (cglue g a) (! (snd (comp K j) a)) (ψ-βr g a)) ◃∙
       ap ! (H₂ (snd (F <#> g) a) (snd (comp K j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
-      ap ! (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙
-        (snd (comp K j) a))) (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
+      ap !
+        (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
+          (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
       ap ! (ap ! (snd (comTri K g) a)) ◃∙
       !-! (snd (comp K i) a) ◃∎
-        =ₛ⟨ 6 & 1 & =ₛ-in (ap (ap (λ p → p ∙ (snd (recCosCoc K) a))) (=ₛ-out (ap-seq-∙ (ap (fst (recCosCoc K))) (ϵ g g a)))) ∙ₛ ap-seq-∙ (λ p → p ∙
-          (snd (recCosCoc K) a)) (ap-seq (ap (fst (recCosCoc K))) (ϵ g g a)) ⟩
+        =ₛ⟨ 6 & 1 &
+          =ₛ-in
+            (ap (ap (λ p → p ∙ (snd (recCosCoc K) a))) (=ₛ-out (ap-seq-∙ (ap (fst (recCosCoc K))) (ϵ g g a)))) ∙ₛ
+            ap-seq-∙ (λ p → p ∙ (snd (recCosCoc K) a)) (ap-seq (ap (fst (recCosCoc K))) (ϵ g g a)) ⟩
       ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
-        (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a)
-        (snd (comp LRfun j) a)) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a))) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap ! (FPrecc-βr K (cin j a))) ◃∙
-      ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-        fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-        ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (!-! (snd (comp K j) a)) ◃∙
+        (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a))) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (ap ! (FPrecc-βr K (cin j a))) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (!-! (snd (comp K j) a)) ◃∙
       long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
       ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
       ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₁ (snd (F <#> g) a) (! (glue (cin j a))))) ◃∙
@@ -324,11 +420,54 @@ module ConstrE2 {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type ℓ} 
       ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₃ (λ z → ! (glue z)) (cglue g a) (ψ-βr g a) (λ z → idp))) ◃∙
       ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (∙-unit-r (! (glue (cin i a))))) ◃∙ 
       ! (apd-tr (λ z → ap (fst (recCosCoc K)) (! (glue z)) ∙ idp) (cglue g a)) ◃∙
-      ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a)) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
+      ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a))
+        (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
       transp-inv-comm (fun T ∘ [id]) (reccForg K ∘ ψ) (cglue g a) (! (snd (comp K j) a)) ◃∙
       ap ! (H₁ (cglue g a) (! (snd (comp K j) a)) (ψ-βr g a)) ◃∙
       ap ! (H₂ (snd (F <#> g) a) (snd (comp K j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
-      ap ! (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙
-        (snd (comp K j) a))) (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
+      ap !
+        (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
+          (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
       ap ! (ap ! (snd (comTri K g) a)) ◃∙
       !-! (snd (comp K i) a) ◃∎ ∎ₛ
+
+    abstract
+      Ξ-rewrite :
+        Ξ-inst
+          =ₛ
+        ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+          (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
+        ap (λ p →
+            ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+            fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+            ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+          (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a))) ◃∙
+        ap (λ p →
+            ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+            fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+            ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+          (ap ! (FPrecc-βr K (cin j a))) ◃∙
+        ap (λ p →
+            ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+            fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+            ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+          (!-! (snd (comp K j) a)) ◃∙
+        long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
+        ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
+        ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₁ (snd (F <#> g) a) (! (glue (cin j a))))) ◃∙
+        ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K)))
+          (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
+        ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₃ (λ z → ! (glue z)) (cglue g a) (ψ-βr g a) (λ z → idp))) ◃∙
+        ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (∙-unit-r (! (glue (cin i a))))) ◃∙ 
+        ! (apd-tr (λ z → ap (fst (recCosCoc K)) (! (glue z)) ∙ idp) (cglue g a)) ◃∙
+        ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a))
+          (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
+        transp-inv-comm (fun T ∘ [id]) (reccForg K ∘ ψ) (cglue g a) (! (snd (comp K j) a)) ◃∙
+        ap ! (H₁ (cglue g a) (! (snd (comp K j) a)) (ψ-βr g a)) ◃∙
+        ap ! (H₂ (snd (F <#> g) a) (snd (comp K j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
+        ap !
+          (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
+            (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
+        ap ! (ap ! (snd (comTri K g) a)) ◃∙
+        !-! (snd (comp K i) a) ◃∎
+      Ξ-rewrite = Ξ-RW1 ∙ₛ (Ξ-RW2 ∙ₛ (Ξ-RW3 ∙ₛ (Ξ-RW4 ∙ₛ (Ξ-RW5 ∙ₛ Ξ-RW6))))

--- a/Colimit-code/R-L-R/CC-Equiv-RLR-1.agda
+++ b/Colimit-code/R-L-R/CC-Equiv-RLR-1.agda
@@ -2,7 +2,6 @@
 
 open import lib.Basics
 open import lib.types.Pushout
-open import lib.types.Span
 open import Coslice
 open import Diagram
 open import Colim
@@ -17,7 +16,7 @@ module CC-Equiv-RLR-1 where
 module _ {ℓ₁ ℓ₂ ℓ₃} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type ℓ₃} (e : A → B) (f : C → A) where
 
   Ξ-coher1-trip : {y z : C} (q : y == z) {x : A} (p : f y == x) {w : C} (r : z == w)  
-    →  ap e (! p ∙ ap f q ∙ ap f r) ∙ idp == (ap e (! p) ∙ ap (e ∘ f) q) ∙ ap (e ∘ f) r
+    → ap e (! p ∙ ap f q ∙ ap f r) ∙ idp == (ap e (! p) ∙ ap (e ∘ f) q) ∙ ap (e ∘ f) r
   Ξ-coher1-trip idp idp idp = idp 
 
   ap-∙-cmp2 : {x : A} {y z : C} (p : x == f y) (q : y == z)
@@ -44,9 +43,8 @@ module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄} {A : Type ℓ₁} {B : Type ℓ₂} {C : 
   Ξ-helper1-delay idp p₂ p₄ p₃ = Ξ-coher1-trip e k p₃ p₂ p₄      
 
   Ξ-helper2-delay : {a₁ a₂ : A} (p₁ : a₂ == a₁) {z₁ z₂ : E} (p₃ : z₁ == z₂) (p₂ : e (f a₂) == e (k z₁))  
-    → ap e (! (ap f p₁)) ∙ ! (! p₂) ∙ ap (e ∘ k) p₃ ==
-    ! (! (ap (e ∘ k) p₃) ∙ ! p₂ ∙ ap (e ∘ f) p₁)
-  Ξ-helper2-delay idp p₃ p₂ = Ξ-coher2 p₂ (ap (e ∘ k) p₃) --  
+    → ap e (! (ap f p₁)) ∙ ! (! p₂) ∙ ap (e ∘ k) p₃ == ! (! (ap (e ∘ k) p₃) ∙ ! p₂ ∙ ap (e ∘ f) p₁)
+  Ξ-helper2-delay idp p₃ p₂ = Ξ-coher2 p₂ (ap (e ∘ k) p₃)
 
 module ConstrE2Cont {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type ℓ} (F : CosDiag ℓd ℓ A Γ) (T : Coslice ℓc ℓ A) (K : CosCocone A F T) where
 
@@ -57,40 +55,9 @@ module ConstrE2Cont {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type �
     open Equiv2a i j g a public
 
     abstract
-
-      Ξ-rewrite :
-        Ξ-inst =ₛ
-        ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a)
-          (snd (comp LRfun j) a)) ◃∙
-        ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a))) ◃∙
-        ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap ! (FPrecc-βr K (cin j a))) ◃∙
-        ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (!-! (snd (comp K j) a)) ◃∙
-        long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
-        ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
-        ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₁ (snd (F <#> g) a) (! (glue (cin j a))))) ◃∙
-        ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K)))
-          (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
-        ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₃ (λ z → ! (glue z)) (cglue g a) (ψ-βr g a) (λ z → idp))) ◃∙
-        ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (∙-unit-r (! (glue (cin i a))))) ◃∙
-        ! (apd-tr (λ z → ap (fst (recCosCoc K)) (! (glue z)) ∙ idp) (cglue g a)) ◃∙
-        ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a)) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
-        transp-inv-comm (fun T ∘ [id]) (reccForg K ∘ ψ) (cglue g a) (! (snd (comp K j) a)) ◃∙
-        ap ! (H₁ (cglue g a) (! (snd (comp K j) a)) (ψ-βr g a)) ◃∙
-        ap ! (H₂ (snd (F <#> g) a) (snd (comp K j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
-        ap ! (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙
-          (snd (comp K j) a))) (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
-        ap ! (ap ! (snd (comTri K g) a)) ◃∙
-        !-! (snd (comp K i) a) ◃∎
-      Ξ-rewrite = Ξ-RW1 ∙ₛ (Ξ-RW2 ∙ₛ (Ξ-RW3 ∙ₛ (Ξ-RW4 ∙ₛ (Ξ-RW5 ∙ₛ Ξ-RW6))))
-
       Ξ-rewrite-refine : {x : Colim (ConsDiag Γ A)} (q : cin j a == x) {U : ψ (cin j a) == ψ x} (E : ap ψ q == U)
-        → ap (λ p → p ∙ idp) (ap (ap (fst (recCosCoc K))) (E₃ {f = left} {h = [id]} {u = right} (λ z → ! (glue z)) q E (λ z → idp))) ◃∙
+        →
+        ap (λ p → p ∙ idp) (ap (ap (fst (recCosCoc K))) (E₃ {f = left} {h = [id]} {u = right} (λ z → ! (glue z)) q E (λ z → idp))) ◃∙
         ap (λ p → p ∙ idp) (ap (ap (fst (recCosCoc K))) (∙-unit-r (! (glue x)))) ◃∙
         ! (apd-tr (λ z → ap (fst (recCosCoc K)) (! (glue z)) ∙ idp) q) ◃∎
           =ₛ
@@ -101,58 +68,79 @@ module ConstrE2Cont {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type �
       Ξ-rewrite-refine idp idp = =ₛ-in (lemma (glue (cin j a)))
         where
           lemma : {y : P} (G : left a == y)
-            → ap (λ p → p ∙ idp) (ap (ap (fst (recCosCoc K))) (∙-unit-r (! G))) ∙ idp
+            →
+            ap (λ p → p ∙ idp) (ap (ap (fst (recCosCoc K))) (∙-unit-r (! G))) ∙ idp
               ==
             ∙-unit-r (ap (fst (recCosCoc K)) ((! G) ∙ idp)) ∙
             ap-∙-cmp2 (fst (recCosCoc K)) left (! G) idp ∙ idp
           lemma idp = idp
 
     abstract
-
       Ξ-rewrite2 :
         Ξ-inst =ₛ
-        ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        ap (λ p →
+            ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
           (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
-        ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙      
-          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
-            ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (!-! (snd (comp K j) a)) ◃∙
-          long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
+        ap (λ p →
+            ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+            fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+            ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+          (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
+        ap (λ p →
+            ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+            fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+          (!-! (snd (comp K j) a)) ◃∙
+        long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
         ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
         ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₁ (snd (F <#> g) a) (! (glue (cin j a))))) ◃∙
-        ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙
-          cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙                                         
+        ap (λ p → p ∙ (snd (recCosCoc K) a))
+          (ap (ap (fst (recCosCoc K)))
+            (! (ap (λ p →
+                 ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙
+                 ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
         ap (λ p → p ∙ idp) (ap (ap (fst (recCosCoc K))) (E₃ {f = left} {h = [id]} {u = right} (λ z → ! (glue z)) (cglue g a) (ψ-βr g a) (λ z → idp))) ◃∙
         ∙-unit-r (ap (fst (recCosCoc K)) (! (glue (cin i a)) ∙ idp)) ◃∙
         ap-∙-cmp2 (fst (recCosCoc K)) left (! (glue (cin i a))) idp ◃∙
         ! (apd-tr (λ z → ap (fst (recCosCoc K)) (! (glue z)) ∙ idp) (cglue g a)) ◃∙
-        ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a)) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
+        ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a))
+          (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
         transp-inv-comm (fun T ∘ [id]) (reccForg K ∘ ψ) (cglue g a) (! (snd (comp K j) a)) ◃∙
         ap ! (H₁ (cglue g a) (! (snd (comp K j) a)) (ψ-βr g a)) ◃∙
         ap ! (H₂ (snd (F <#> g) a) (snd (comp K j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
-        ap ! (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
+        ap !
+          (ap (λ p →
+                p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
           (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
         ap ! (ap ! (snd (comTri K g) a)) ◃∙
         !-! (snd (comp K i) a) ◃∎
-      Ξ-rewrite2 = Ξ-inst
+      Ξ-rewrite2 =
+        Ξ-inst
           =ₛ⟨ Ξ-rewrite ⟩
-        ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a)
-          (snd (comp LRfun j) a)) ◃∙
-        ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a))) ◃∙
-        ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap ! (FPrecc-βr K (cin j a))) ◃∙
-        ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (!-! (snd (comp K j) a)) ◃∙
+        ap (λ p →
+             ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+             ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+           (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
+        ap (λ p →
+            ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+            fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+            ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+          (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a))) ◃∙
+        ap (λ p →
+            ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+            fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+            ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+          (ap ! (FPrecc-βr K (cin j a))) ◃∙
+        ap (λ p →
+            ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+            fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+            ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+          (!-! (snd (comp K j) a)) ◃∙
         long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
         ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
         ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₁ (snd (F <#> g) a) (! (glue (cin j a))))) ◃∙
-        ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K)))
-          (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
+        ap (λ p → p ∙ (snd (recCosCoc K) a))
+          (ap (ap (fst (recCosCoc K)))
+            (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
         ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₃ (λ z → ! (glue z)) (cglue g a) (ψ-βr g a) (λ z → idp))) ◃∙
         ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (∙-unit-r (! (glue (cin i a))))) ◃∙
         ! (apd-tr (λ z → ap (fst (recCosCoc K)) (! (glue z)) ∙ idp) (cglue g a)) ◃∙
@@ -160,27 +148,37 @@ module ConstrE2Cont {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type �
         transp-inv-comm (fun T ∘ [id]) (reccForg K ∘ ψ) (cglue g a) (! (snd (comp K j) a)) ◃∙
         ap ! (H₁ (cglue g a) (! (snd (comp K j) a)) (ψ-βr g a)) ◃∙
         ap ! (H₂ (snd (F <#> g) a) (snd (comp K j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
-        ap ! (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
-          (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
+        ap !
+          (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
+            (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
         ap ! (ap ! (snd (comTri K g) a)) ◃∙
         !-! (snd (comp K i) a) ◃∎
           =ₛ⟨ 8 & 3 & Ξ-rewrite-refine (cglue g a) (ψ-βr g a) ⟩
-        ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a)
-          (snd (comp LRfun j) a)) ◃∙
-        ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a))) ◃∙
-        ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap ! (FPrecc-βr K (cin j a))) ◃∙
-        ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (!-! (snd (comp K j) a)) ◃∙
+        ap (λ p →
+             ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+             ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+           (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
+        ap (λ p →
+            ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+            fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+            ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+          (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a))) ◃∙
+        ap (λ p →
+            ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+            fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+            ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+          (ap ! (FPrecc-βr K (cin j a))) ◃∙
+        ap (λ p →
+            ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+            fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+            ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+          (!-! (snd (comp K j) a)) ◃∙
         long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
         ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
         ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₁ (snd (F <#> g) a) (! (glue (cin j a))))) ◃∙
-        ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K)))
-          (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
+        ap (λ p → p ∙ (snd (recCosCoc K) a))
+          (ap (ap (fst (recCosCoc K)))
+            (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
         ap (λ p → p ∙ idp) (ap (ap (fst (recCosCoc K))) (E₃ {f = left} {h = [id]} {u = right} (λ z → ! (glue z)) (cglue g a) (ψ-βr g a) (λ z → idp))) ◃∙
         ∙-unit-r (ap (fst (recCosCoc K)) (! (glue (cin i a)) ∙ idp)) ◃∙
         ap-∙-cmp2 (fst (recCosCoc K)) left (! (glue (cin i a))) idp ◃∙
@@ -189,26 +187,36 @@ module ConstrE2Cont {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type �
         transp-inv-comm (fun T ∘ [id]) (reccForg K ∘ ψ) (cglue g a) (! (snd (comp K j) a)) ◃∙
         ap ! (H₁ (cglue g a) (! (snd (comp K j) a)) (ψ-βr g a)) ◃∙
         ap ! (H₂ (snd (F <#> g) a) (snd (comp K j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
-        ap ! (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
-          (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
+        ap !
+          (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
+            (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
         ap ! (ap ! (snd (comTri K g) a)) ◃∙
         !-! (snd (comp K i) a) ◃∎
-          =ₛ₁⟨ 1 & 2 & ∙-ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-              fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K))
-              (glue (cin j a))) (ap ! (FPrecc-βr K (cin j a))) ⟩
-        ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
-          (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a)       
-          (snd (comp LRfun j) a)) ◃∙
-        ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙      
-          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
-          ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (!-! (snd (comp K j) a)) ◃∙
+          =ₛ₁⟨ 1 & 2 &
+               ∙-ap
+                 (λ p →
+                   ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+                   fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+                 (ap-inv-rid (fst (recCosCoc K))
+                 (glue (cin j a))) (ap ! (FPrecc-βr K (cin j a))) ⟩
+        ap (λ p →
+             ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+           (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
+        ap (λ p →
+             ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+             fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+             ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+           (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
+          ap (λ p →
+               ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+               fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+             (!-! (snd (comp K j) a)) ◃∙
         long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
         ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
         ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₁ (snd (F <#> g) a) (! (glue (cin j a))))) ◃∙
-        ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K)))
-          (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
+        ap (λ p → p ∙ (snd (recCosCoc K) a))
+          (ap (ap (fst (recCosCoc K)))
+            (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
         ap (λ p → p ∙ idp) (ap (ap (fst (recCosCoc K))) (E₃ {f = left} {h = [id]} {u = right} (λ z → ! (glue z)) (cglue g a) (ψ-βr g a) (λ z → idp))) ◃∙
         ∙-unit-r (ap (fst (recCosCoc K)) (! (glue (cin i a)) ∙ idp)) ◃∙
         ap-∙-cmp2 (fst (recCosCoc K)) left (! (glue (cin i a))) idp ◃∙
@@ -216,19 +224,22 @@ module ConstrE2Cont {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type �
         ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a)) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
         transp-inv-comm (fun T ∘ [id]) (reccForg K ∘ ψ) (cglue g a) (! (snd (comp K j) a)) ◃∙
         ap ! (H₁ (cglue g a) (! (snd (comp K j) a)) (ψ-βr g a)) ◃∙
-          ap ! (H₂ (snd (F <#> g) a) (snd (comp K j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
-          ap ! (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
-          (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
+        ap ! (H₂ (snd (F <#> g) a) (snd (comp K j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
+        ap !
+          (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
+            (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
         ap ! (ap ! (snd (comTri K g) a)) ◃∙
         !-! (snd (comp K i) a) ◃∎ ∎ₛ
 
-
     Ξ-Red0 : {x : Colim (ConsDiag Γ A)} (q : cin j a == x) (Q : a == [id] x) (U : ψ (cin j a) == ψ x) (R : fst (comp K j) (fun (F # j) a) == fun T a)
       (L : a == a) (M : left a == right (ψ (cin j a)))  (t : ap (fst (recCosCoc K)) (! M) ∙ ap (fun T) L == ! (! R))
-      → ap (fst (recCosCoc K)) (! (ap right U) ∙ (! M) ∙ ap left L ∙ ap left Q) ∙ idp =-= ! (! (ap (fun T) Q) ∙ ! R ∙ ap (recc (comp K) (comTri K)) U)
+      →
+      ap (fst (recCosCoc K)) (! (ap right U) ∙ (! M) ∙ ap left L ∙ ap left Q) ∙ idp
+        =-=
+      ! (! (ap (fun T) Q) ∙ ! R ∙ ap (recc (comp K) (comTri K)) U)
     Ξ-Red0 q Q U R L M t =
       ap (fst (recCosCoc K)) (! (ap right U) ∙ (! M) ∙ ap left L ∙ ap left Q) ∙ idp
-        =⟪  Ξ-helper1-delay right (fst (recCosCoc K)) left U M Q L ⟫
+        =⟪ Ξ-helper1-delay right (fst (recCosCoc K)) left U M Q L ⟫
       ap (fst (recCosCoc K)) (! (ap right U)) ∙ (ap (fst (recCosCoc K)) (! M) ∙ ap (fun T) L) ∙ ap (fun T) Q
         =⟪ ap (λ p → ap (fst (recCosCoc K)) (! (ap right U)) ∙ p ∙ ap (fun T) Q) t ⟫
       ap (fst (recCosCoc K)) (! (ap right U)) ∙ ! (! R) ∙ ap (fun T) Q
@@ -236,10 +247,10 @@ module ConstrE2Cont {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type �
       ! (! (ap (fun T) Q) ∙ ! R ∙ ap (recc (comp K) (comTri K)) U) ∎∎ 
 
     abstract
-
       Ξ-RedEq0 : {x : Colim (ConsDiag Γ A)} (q : cin j a == x) (U : ψ (cin j a) == ψ x) (E : ap ψ q == U) (R : fst (comp K j) (fun (F # j) a) == fun T a)
         (L : (z : Colim (ConsDiag Γ A)) → [id] z == [id] z) (t : ap (fst (recCosCoc K)) (! (glue (cin j a))) ∙ ap (fun T) (L (cin j a)) == ! (! R))
-        → ap (λ p → p ∙ idp) (ap (ap (fst (recCosCoc K))) (E₃ {f = left} {h = [id]} (λ z → ! (glue z)) q E (λ z → ap left (L z)))) ◃∙
+        →
+        ap (λ p → p ∙ idp) (ap (ap (fst (recCosCoc K))) (E₃ {f = left} {h = [id]} (λ z → ! (glue z)) q E (λ z → ap left (L z)))) ◃∙
         ∙-unit-r (ap (fst (recCosCoc K)) (! (glue x) ∙ ap left (L x))) ◃∙
         ap-∙-cmp2 (fst (recCosCoc K)) left (! (glue x)) (L x) ◃∙
         ! (apd-tr (λ z → ap (fst (recCosCoc K)) (! (glue z)) ∙ ap (fun T) (L z)) q) ◃∙
@@ -252,11 +263,13 @@ module ConstrE2Cont {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type �
         where
           lemma : {y : P} (G : left a == y) {z : A} (Λ : a == z) 
             (r : fst (recCosCoc K) y == fun T z) (τ : ap (fst (recCosCoc K)) (! G) ∙ ap (fun T) Λ == ! (! r)) 
-            → ap (λ p → p ∙ idp) (ap (ap (fst (recCosCoc K))) (ap (_∙_ (! G)) (∙-unit-r (ap left Λ)))) ∙
-              ∙-unit-r (ap (fst (recCosCoc K)) ((! G) ∙ (ap left Λ))) ∙
-              ap-∙-cmp2 (fst (recCosCoc K)) left (! G) Λ ∙
-              ap (λ z → z) τ ∙
-              ap ! (! (∙-unit-r (! r))) ==
+            →
+            ap (λ p → p ∙ idp) (ap (ap (fst (recCosCoc K))) (ap (_∙_ (! G)) (∙-unit-r (ap left Λ)))) ∙
+            ∙-unit-r (ap (fst (recCosCoc K)) ((! G) ∙ (ap left Λ))) ∙
+            ap-∙-cmp2 (fst (recCosCoc K)) left (! G) Λ ∙
+            ap (λ z → z) τ ∙
+            ap ! (! (∙-unit-r (! r)))
+              ==
             Ξ-coher1-trip (fst (recCosCoc K)) left Λ G idp ∙
             ap (λ p → p ∙ idp) τ ∙
             Ξ-coher2 r idp
@@ -269,14 +282,17 @@ module ConstrE2Cont {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type �
     Ξ-Red1 : (Q : a == a) (R : fst (comp K j) (fun (F # j) a) == fun T a) (t : ap (fst (recCosCoc K)) (! (glue (cin j a))) ∙ ap (fun T) Q == ! (! R))
       (C : fst (comp K j) (fst (F <#> g) (fun (F # i) a)) == fst (comp K i) (fun (F # i) a)) (c : ap (recc (comp K) (comTri K)) (cglue g (fun (F # i) a)) == C)
       (W : fst (comp K i) (fun (F # i) a) == fun T a) (s : ! C ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ R == W)
-      → ap (fst (recCosCoc K)) (! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ (cglue g (fun (F # i) a)))) ∙ ! (glue (cin j a)) ∙ ap left Q ∙ ap left Q) ∙ idp
-        =-= ! (! (ap (fun T) Q) ∙ ! W)
+      →
+      ap (fst (recCosCoc K)) (! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ (cglue g (fun (F # i) a)))) ∙ ! (glue (cin j a)) ∙ ap left Q ∙ ap left Q) ∙ idp
+        =-=
+      ! (! (ap (fun T) Q) ∙ ! W)
     Ξ-Red1 Q R t C c W s =
       ap (fst (recCosCoc K)) (! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ (cglue g (fun (F # i) a)))) ∙ ! (glue (cin j a)) ∙ ap left Q ∙ ap left Q) ∙ idp
         =⟪ long-path-red2 right (fst (recCosCoc K)) (cin j) left (snd (F <#> g) a) (cglue g (fun (F # i) a)) (glue (cin j a)) Q  ⟫
-      (! (ap (recc (comp K) (comTri K)) (cglue g (fun (F # i) a))) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙
-        (ap (fst (recCosCoc K)) (! (glue (cin j a))) ∙ ap (fun T) Q)) ∙
-        ap (fun T) Q
+      (! (ap (recc (comp K) (comTri K)) (cglue g (fun (F # i) a))) ∙
+      ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙
+      (ap (fst (recCosCoc K)) (! (glue (cin j a))) ∙ ap (fun T) Q)) ∙
+      ap (fun T) Q
         =⟪ ap (λ p → (! p ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ (ap (fst (recCosCoc K)) (! (glue (cin j a))) ∙ ap (fun T) Q)) ∙ ap (fun T) Q) c ⟫   
       (! C ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ (ap (fst (recCosCoc K)) (! (glue (cin j a))) ∙ ap (fun T) Q)) ∙ ap (fun T) Q
         =⟪ ap (λ p → (! C ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ p) ∙ ap (fun T) Q) t ⟫           
@@ -290,14 +306,14 @@ module ConstrE2Cont {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type �
       ∎∎
 
     abstract
-
       Ξ-RedEq1 : (Q : a == a) (I : ap [id] (cglue g a) == Q) (R : fst (comp K j) (fun (F # j) a) == fun T a)
         (t : ap (fst (recCosCoc K)) (! (glue (cin j a))) ∙ ap (fun T) Q == ! (! R))
         (C : fst (comp K j) (fst (F <#> g) (fun (F # i) a)) == fst (comp K i) (fun (F # i) a)) (c : ap (recc (comp K) (comTri K)) (cglue g (fun (F # i) a)) == C)
         (W : fst (comp K i) (fun (F # i) a) == fun T a) (s : ! C ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ R == W)
         →
-        ap (λ p → p ∙ idp) (ap (ap (fst (recCosCoc K))) (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙
-          ! (glue (cin j a)) ∙ ap left Q ∙ p) (ap (ap left) I)))) ◃∙
+        ap (λ p → p ∙ idp)
+          (ap (ap (fst (recCosCoc K)))
+            (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ ap left Q ∙ p) (ap (ap left) I)))) ◃∙
         ↯ (Ξ-Red0 (cglue g a) (ap [id] (cglue g a)) (! (ap (cin j) (snd (F <#> g) a)) ∙ (cglue g (fun (F # i) a))) R Q (glue (cin j a)) t) ◃∙
         ap ! (H₂ (snd (F <#> g) a) R (cglue g (fun (F # i) a)) c) ◃∙
         ap ! (ap (λ p → p ∙ ! (! C ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ R)) (ap (λ p → ! (ap (fun T) p)) I)) ◃∙
@@ -307,7 +323,8 @@ module ConstrE2Cont {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type �
       Ξ-RedEq1 Q idp R t C idp W idp = =ₛ-in (lemma (cglue g (fun (F # i) a)))
         where
           lemma : {y : Colim (DiagForg A Γ F)} (κ : cin j (fst (F <#> g) (fun (F # i) a)) == y)
-            → (Ξ-helper1-delay right (fst (recCosCoc K)) left (! (ap (cin j) (snd (F <#> g) a)) ∙ κ) (glue (cin j a)) (ap [id] (cglue g a)) (ap [id] (cglue g a)) ∙
+            →
+            (Ξ-helper1-delay right (fst (recCosCoc K)) left (! (ap (cin j) (snd (F <#> g) a)) ∙ κ) (glue (cin j a)) (ap [id] (cglue g a)) (ap [id] (cglue g a)) ∙
             ap (λ p →  ap (fst (recCosCoc K)) (! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ κ))) ∙ p ∙ ap (fun T) (ap [id] (cglue g a))) t ∙
             Ξ-helper2-delay right (fst (recCosCoc K)) left (! (ap (cin j) (snd (F <#> g) a)) ∙ κ) (ap [id] (cglue g a)) R) ∙
             ap ! (H₂ {u = recc (comp K) (comTri K)} {g = cin j} (snd (F <#> g) a) R κ idp) ∙
@@ -320,19 +337,22 @@ module ConstrE2Cont {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type �
           lemma idp = lemma2 (snd (F <#> g) a)
             where
               lemma2 : {w : ty (F # j)} (Z : w == fun (F # j) a)
-                → (Ξ-helper1-delay right (fst (recCosCoc K)) left (! (ap (cin j) Z) ∙ idp) (glue (cin j a)) (ap [id] (cglue g a)) (ap [id] (cglue g a)) ∙
+                →
+                (Ξ-helper1-delay right (fst (recCosCoc K)) left (! (ap (cin j) Z) ∙ idp) (glue (cin j a)) (ap [id] (cglue g a)) (ap [id] (cglue g a)) ∙
                 ap (λ p →  ap (fst (recCosCoc K)) (! (ap right (! (ap (cin j) Z) ∙ idp))) ∙ p ∙ ap (fun T) (ap [id] (cglue g a))) t ∙
                 Ξ-helper2-delay right (fst (recCosCoc K)) left (! (ap (cin j) Z) ∙ idp) (ap [id] (cglue g a)) R) ∙
                 ap ! (H₂ Z R idp idp) ∙ idp
                   ==
                 long-path-red2 right (fst (recCosCoc K)) (cin j) left Z idp (glue (cin j a)) (ap [id] (cglue g a)) ∙
-                ap (λ p → (ap (fst (comp K j)) Z ∙ p) ∙ ap (fun T) (ap [id] (cglue g a))) t ∙ ap (λ p → (ap (fst (comp K j)) Z ∙ p) ∙
-                  ap (fun T) (ap [id] (cglue g a))) (!-! R) ∙
+                ap (λ p → (ap (fst (comp K j)) Z ∙ p) ∙ ap (fun T) (ap [id] (cglue g a))) t ∙
+                ap (λ p → (ap (fst (comp K j)) Z ∙ p) ∙ ap (fun T) (ap [id] (cglue g a))) (!-! R) ∙
                 ap-dbl-inv-∙-del (fun T) (ap [id] (cglue g a)) (ap (fst (comp K j)) Z ∙ R)
               lemma2 idp = lemma3 (glue (cin j a)) R t
                 where
-                  lemma3 : {y : P} (G : left a == y) (r : fst (recCosCoc K) y == fun T a) (τ : ap (fst (recCosCoc K)) (! G) ∙ ap (fun T) (ap [id] (cglue g a)) == ! (! r))
-                    → (Ξ-coher1-trip (fst (recCosCoc K)) left (ap [id] (cglue g a)) G (ap [id] (cglue g a)) ∙ -- Ξ-coher1-trip e k p₃ p₂ p₄
+                  lemma3 : {y : P} (G : left a == y) (r : fst (recCosCoc K) y == fun T a)
+                    (τ : ap (fst (recCosCoc K)) (! G) ∙ ap (fun T) (ap [id] (cglue g a)) == ! (! r))
+                    →
+                    (Ξ-coher1-trip (fst (recCosCoc K)) left (ap [id] (cglue g a)) G (ap [id] (cglue g a)) ∙
                     ap (λ p → p ∙ ap (fun T) (ap [id] (cglue g a))) τ ∙
                     Ξ-coher2 r (ap (fun T) (ap [id] (cglue g a)))) ∙
                     ap ! (ap (λ p → ! (ap (fun T) (ap [id] (cglue g a))) ∙ p) (∙-unit-r (! r))) ∙ idp
@@ -344,7 +364,8 @@ module ConstrE2Cont {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type �
                   lemma3 idp r τ = lemma4 (ap [id] (cglue g a)) r τ (ap [id] (cglue g a))
                     where
                       lemma4 : {y : A} (Q₁ : a == y) (r' : fun T a == fun T y) (τ' : ap (fun T) Q₁ == ! (! r')) {z : A} (Q₂ : y == z)
-                        → (Ξ-coher1-trip (fst (recCosCoc K)) left Q₁ idp Q₂ ∙
+                        →
+                        (Ξ-coher1-trip (fst (recCosCoc K)) left Q₁ idp Q₂ ∙
                         ap (λ p → p ∙ ap (fun T) Q₂) τ' ∙
                         Ξ-coher2 r' (ap (fun T) Q₂)) ∙
                         ap ! (ap (_∙_ (! (ap (fun T) Q₂))) (∙-unit-r (! r'))) ∙
@@ -357,10 +378,12 @@ module ConstrE2Cont {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type �
                       lemma4 idp r' τ' idp = lemma5 r' τ'
                         where
                           lemma5 : {y : ty T} (𝕣 : y == fun T a) {c : y == fun T a} (u : c == ! (! 𝕣))
-                            → (ap (λ p → p ∙ idp) u ∙ Ξ-coher2 𝕣 idp) ∙
+                            →
+                            (ap (λ p → p ∙ idp) u ∙ Ξ-coher2 𝕣 idp) ∙
                             ap ! (ap (λ q → q) (∙-unit-r (! 𝕣))) ∙ idp
                               ==
                             ap (λ p → p ∙ idp) u ∙
-                            ap (λ p → p ∙ idp) (!-! 𝕣) ∙ ap-dbl-inv-∙-del (fun T) idp 𝕣
+                            ap (λ p → p ∙ idp) (!-! 𝕣) ∙
+                            ap-dbl-inv-∙-del (fun T) idp 𝕣
                           lemma5 idp idp = idp
 

--- a/Colimit-code/R-L-R/CC-Equiv-RLR-2.agda
+++ b/Colimit-code/R-L-R/CC-Equiv-RLR-2.agda
@@ -2,7 +2,6 @@
 
 open import lib.Basics
 open import lib.types.Pushout
-open import lib.types.Span
 open import Coslice
 open import Diagram
 open import Colim
@@ -30,17 +29,29 @@ module _ {ℓ} {A : Type ℓ} where
   helper-coher-rid r idp = =ₛ-in idp 
 
   coher-rid-trip : {x : A} (r : x == x) (τ : idp == ! (! r))
-    → ap (λ p → ! (((p ∙ idp) ∙ idp) ∙ idp) ∙ r) τ ◃∙ ap (λ p → ! (((p ∙ idp) ∙ idp) ∙ idp) ∙ r) (!-! r) ◃∙ db-neg-rid-db r idp ◃∙
-      ap (λ p → p ∙ idp) τ ◃∙ ap (λ p → p ∙ idp) (!-! r) ◃∎
-      =ₛ ! (∙-unit-r r) ◃∎
+    →
+    ap (λ p → ! (((p ∙ idp) ∙ idp) ∙ idp) ∙ r) τ ◃∙
+    ap (λ p → ! (((p ∙ idp) ∙ idp) ∙ idp) ∙ r) (!-! r) ◃∙
+    db-neg-rid-db r idp ◃∙
+    ap (λ p → p ∙ idp) τ ◃∙ ap (λ p → p ∙ idp) (!-! r) ◃∎
+      =ₛ
+    ! (∙-unit-r r) ◃∎
   coher-rid-trip r τ =
-    ap (λ p → ! (((p ∙ idp) ∙ idp) ∙ idp) ∙ r) τ ◃∙ ap (λ p → ! (((p ∙ idp) ∙ idp) ∙ idp) ∙ r) (!-! r) ◃∙ db-neg-rid-db r idp ◃∙
-      ap (λ p → p ∙ idp) τ ◃∙ ap (λ p → p ∙ idp) (!-! r) ◃∎
+    ap (λ p → ! (((p ∙ idp) ∙ idp) ∙ idp) ∙ r) τ ◃∙
+    ap (λ p → ! (((p ∙ idp) ∙ idp) ∙ idp) ∙ r) (!-! r) ◃∙
+    db-neg-rid-db r idp ◃∙
+    ap (λ p → p ∙ idp) τ ◃∙
+    ap (λ p → p ∙ idp) (!-! r) ◃∎
       =ₛ₁⟨ 0 & 2 & ∙-ap (λ p → ! (((p ∙ idp) ∙ idp) ∙ idp) ∙ r) τ (!-! r) ⟩
-    ap (λ p → ! (((p ∙ idp) ∙ idp) ∙ idp) ∙ r) (τ ∙ !-! r) ◃∙ db-neg-rid-db r idp ◃∙ ap (λ p → p ∙ idp) τ ◃∙ ap (λ p → p ∙ idp) (!-! r) ◃∎
-      =ₛ₁⟨ 2 & 2 & ∙-ap (λ p → p ∙ idp) τ (!-! r) ⟩ 
-    ap (λ p → ! (((p ∙ idp) ∙ idp) ∙ idp) ∙ r) (τ ∙ !-! r) ◃∙ db-neg-rid-db r idp ◃∙ ap (λ p → p ∙ idp) (τ ∙ !-! r) ◃∎
-        =ₛ⟨  helper-coher-rid r (τ ∙ !-! r) ⟩
+    ap (λ p → ! (((p ∙ idp) ∙ idp) ∙ idp) ∙ r) (τ ∙ !-! r) ◃∙
+    db-neg-rid-db r idp ◃∙
+    ap (λ p → p ∙ idp) τ ◃∙
+    ap (λ p → p ∙ idp) (!-! r) ◃∎
+      =ₛ₁⟨ 2 & 2 & ∙-ap (λ p → p ∙ idp) τ (!-! r) ⟩
+    ap (λ p → ! (((p ∙ idp) ∙ idp) ∙ idp) ∙ r) (τ ∙ !-! r) ◃∙
+    db-neg-rid-db r idp ◃∙
+    ap (λ p → p ∙ idp) (τ ∙ !-! r) ◃∎
+      =ₛ⟨  helper-coher-rid r (τ ∙ !-! r) ⟩
     ! (∙-unit-r r) ◃∎ ∎ₛ
 
 module ConstrE2Cont2 {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type ℓ} (F : CosDiag ℓd ℓ A Γ) (T : Coslice ℓc ℓ A) (K : CosCocone A F T) where
@@ -51,26 +62,31 @@ module ConstrE2Cont2 {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type 
 
     open Equiv2b i j g a
 
-    Ξ-Red2 : {R : fst (comp K j) (fun (F # j) a) == fun T a} {C : fst (comp K j) (fst (F <#> g) (fun (F # i) a)) == fst (comp K i) (fun (F # i) a)}
+    Ξ-Red2 : {R : fst (comp K j) (fun (F # j) a) == fun T a}
+      {C : fst (comp K j) (fst (F <#> g) (fun (F # i) a)) == fst (comp K i) (fun (F # i) a)}
       (W : fst (comp K i) (fun (F # i) a) == fun T a) (s : ! C ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ R == W)
       → ! C ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ R =-= ! (! W)
     Ξ-Red2 W s = s ◃∙ ! (!-! W) ◃∎
 
     abstract
-
       Ξ-Red2Eq :  (R : fst (comp K j) (fun (F # j) a) == fun T a) (t : ap (fst (recCosCoc K)) (! (glue (cin j a))) ∙ idp == ! (! R))
-        {C : fst (comp K j) (fst (F <#> g) (fun (F # i) a)) == fst (comp K i) (fun (F # i) a)} (c : ap (recc (comp K) (comTri K)) (cglue g (fun (F # i) a)) == C)
+        {C : fst (comp K j) (fst (F <#> g) (fun (F # i) a)) == fst (comp K i) (fun (F # i) a)}
+        (c : ap (recc (comp K) (comTri K)) (cglue g (fun (F # i) a)) == C)
         {W : fst (comp K i) (fun (F # i) a) == fun T a} (s : ! C ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ R == W) 
         →
         ! (ap (λ p → ! p ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ R) (ap-inv-cmp-rid right (fst (recCosCoc K)) (cglue g (fun (F # i) a)) ∙ c)) ◃∙
-        ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ R) (hmtpy-nat-rev (λ z → idp)
-          (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
-        ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-          ap (fst (comp K j)) (snd (F <#> g) a) ∙ R) t ◃∙
-        ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-          fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-          ap (fst (comp K j)) (snd (F <#> g) a) ∙ R) (!-! R) ◃∙
+        ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ R)
+          (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
+        ap (λ p →
+             ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙
+               ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙ fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+             ap (fst (comp K j)) (snd (F <#> g) a) ∙ R)
+           t ◃∙
+        ap (λ p →
+             ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+               fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+             ap (fst (comp K j)) (snd (F <#> g) a) ∙ R)
+           (!-! R) ◃∙
         long-path-red (snd (F <#> g) a) R (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
         ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
         ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₁ (snd (F <#> g) a) (! (glue (cin j a))))) ◃∙
@@ -80,15 +96,20 @@ module ConstrE2Cont2 {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type 
       Ξ-Red2Eq R t idp idp = =ₛ-in (lemma (cglue g (fun (F # i) a)))
         where
           lemma : {y : Colim (DiagForg A Γ F)} (κ : cin j (fst (F <#> g) (fun (F # i) a)) == y)
-            → ! (ap (λ p → ! p ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ R) (ap-inv-cmp-rid right (fst (recCosCoc K)) κ ∙ idp)) ∙
-            ap (λ p → ! (p ∙ ap (fst (recCosCoc K)) (ap right κ) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ R) (hmtpy-nat-rev (λ z → idp)
-              (snd (F <#> g) a) (snd (comp LRfun j) a)) ∙
-            ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-              ap (fst (recCosCoc K)) (ap right κ) ∙ idp) ∙
-              ap (fst (comp K j)) (snd (F <#> g) a) ∙ R) t ∙
-            ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-              ap (fst (recCosCoc K)) (ap right κ) ∙ idp) ∙
-              ap (fst (comp K j)) (snd (F <#> g) a) ∙ R) (!-! R) ∙
+            →
+            ! (ap (λ p → ! p ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ R) (ap-inv-cmp-rid right (fst (recCosCoc K)) κ ∙ idp)) ∙
+            ap (λ p → ! (p ∙ ap (fst (recCosCoc K)) (ap right κ) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ R)
+              (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ∙
+            ap (λ p →
+                 ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+                   ap (fst (recCosCoc K)) (ap right κ) ∙ idp) ∙
+                 ap (fst (comp K j)) (snd (F <#> g) a) ∙ R)
+               t ∙
+            ap (λ p →
+                 ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+                   ap (fst (recCosCoc K)) (ap right κ) ∙ idp) ∙
+                 ap (fst (comp K j)) (snd (F <#> g) a) ∙ R)
+               (!-! R) ∙
             long-path-red (snd (F <#> g) a) R (ap (fst (recCosCoc K)) (! (glue (cin j a))) ∙ idp) (ap (fst (recCosCoc K)) (ap right κ)) idp ∙
             ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a) (ap right κ) ∙
             ap (λ p → p ∙ snd (recCosCoc K) a) (ap (ap (fst (recCosCoc K))) (E₁ (snd (F <#> g) a) (! (glue (cin j a))))) ∙
@@ -101,11 +122,13 @@ module ConstrE2Cont2 {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type 
           lemma idp = lemma2 (snd (F <#> g) a)
             where
               lemma2 : {w : ty (F # j)} (Z : w == fun (F # j) a)
-                → ap (λ p → ! (p ∙ idp) ∙ ap (fst (comp K j)) Z ∙ R) (hmtpy-nat-rev (λ z → idp) Z (snd (comp LRfun j) a)) ∙
-                ap (λ p → ! ((ap (fst (comp K j)) Z ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) Z)) ∙ idp) ∙
-                  ap (fst (comp K j)) Z ∙ R) t ∙
-                ap (λ p → ! ((ap (fst (comp K j)) Z ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) Z)) ∙ idp) ∙
-                  ap (fst (comp K j)) Z ∙ R) (!-! R) ∙
+                →
+                ap (λ p → ! (p ∙ idp) ∙ ap (fst (comp K j)) Z ∙ R) (hmtpy-nat-rev (λ z → idp) Z (snd (comp LRfun j) a)) ∙
+                ap (λ p →
+                     ! ((ap (fst (comp K j)) Z ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) Z)) ∙ idp) ∙
+                     ap (fst (comp K j)) Z ∙ R) t ∙
+                     ap (λ p → ! ((ap (fst (comp K j)) Z ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) Z)) ∙ idp) ∙ ap (fst (comp K j)) Z ∙ R)
+                   (!-! R) ∙
                 long-path-red Z R (ap (fst (recCosCoc K)) (! (glue (cin j a))) ∙ idp) idp idp ∙
                 ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) Z idp ∙
                 ap (λ p → p ∙ snd (recCosCoc K) a) (ap (ap (fst (recCosCoc K))) (E₁ Z (! (glue (cin j a))))) ∙
@@ -117,7 +140,8 @@ module ConstrE2Cont2 {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type 
                 ! (!-! (ap (fst (comp K j)) Z ∙ R))
               lemma2 idp = =ₛ-out (lemma3a ∙ₛ lemma3b (glue (cin j a)) R t)
                 where
-                  lemma3a : ap (λ p → ! (p ∙ idp) ∙ R) (hmtpy-nat-rev {f = fst (comp K j)} (λ z → idp) idp (ap (fst (recCosCoc K)) (! (glue (cin j a))) ∙ idp)) ◃∙
+                  lemma3a :
+                    ap (λ p → ! (p ∙ idp) ∙ R) (hmtpy-nat-rev {f = fst (comp K j)} (λ z → idp) idp (ap (fst (recCosCoc K)) (! (glue (cin j a))) ∙ idp)) ◃∙
                     ap (λ p → ! (((p ∙ ! (ap (fst (recCosCoc K)) (! (glue (cin j a))) ∙ idp)) ∙ idp) ∙ idp) ∙ R) t ◃∙
                     ap (λ p → ! (((p ∙ ! (ap (fst (recCosCoc K)) (! (glue (cin j a))) ∙ idp)) ∙ idp) ∙ idp) ∙ R) (!-! R) ◃∙
                     long-path-red {f = fst (comp K j)} {g = fst (comp K j)} idp R (ap (fst (recCosCoc K)) (! (glue (cin j a))) ∙ idp) idp idp ◃∙
@@ -156,8 +180,10 @@ module ConstrE2Cont2 {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type 
                     ap (λ p → p ∙ idp) (!-! R) ◃∙
                     ap-dbl-inv-∙-del (fun T) idp R ◃∎ ∎ₛ
 
-                  lemma3b : {y : P} (G : y == right (ψ (cin j a))) (r : fst (comp K j) (fun (F # j) a) == (fst (recCosCoc K)) y) (τ : ap (fst (recCosCoc K)) (! G) ∙ idp == ! (! r))
-                    → ap (λ p → ! (p ∙ idp) ∙ r) (hmtpy-nat-rev {f = fst (comp K j)} (λ z → idp) idp (ap (fst (recCosCoc K)) (! G) ∙ idp)) ◃∙
+                  lemma3b : {y : P} (G : y == right (ψ (cin j a))) (r : fst (comp K j) (fun (F # j) a) == (fst (recCosCoc K)) y)
+                    (τ : ap (fst (recCosCoc K)) (! G) ∙ idp == ! (! r))
+                    →
+                    ap (λ p → ! (p ∙ idp) ∙ r) (hmtpy-nat-rev {f = fst (comp K j)} (λ z → idp) idp (ap (fst (recCosCoc K)) (! G) ∙ idp)) ◃∙
                     ap (λ p → ! (((p ∙ ! (ap (fst (recCosCoc K)) (! G) ∙ idp)) ∙ idp) ∙ idp) ∙ r) τ ◃∙
                     ap (λ p → ! (((p ∙ ! (ap (fst (recCosCoc K)) (! G) ∙ idp)) ∙ idp) ∙ idp) ∙ r) (!-! r) ◃∙
                     long-path-red {f = fst (comp K j)} {g = fst (comp K j)} idp r (ap (fst (recCosCoc K)) (! G) ∙ idp) idp idp ◃∙
@@ -170,7 +196,8 @@ module ConstrE2Cont2 {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type 
                     ! (!-! r) ◃∎
                   lemma3b idp r τ = =ₛ-in (=ₛ-out (lemma4a ∙ₛ lemma4b r))
                     where
-                      lemma4a : ap (λ p → ! (((p ∙ idp) ∙ idp) ∙ idp) ∙ r) τ ◃∙
+                      lemma4a :
+                        ap (λ p → ! (((p ∙ idp) ∙ idp) ∙ idp) ∙ r) τ ◃∙
                         ap (λ p → ! (((p ∙ idp) ∙ idp) ∙ idp) ∙ r) (!-! r) ◃∙
                         db-neg-rid-db r idp ◃∙
                         ap (λ p → p ∙ idp) τ ◃∙
@@ -179,18 +206,20 @@ module ConstrE2Cont2 {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type 
                           =ₛ
                         ! (∙-unit-r r) ◃∙
                         (∙-unit-r r ∙ ! (!-! r)) ◃∎
-                      lemma4a = ap (λ p → ! (((p ∙ idp) ∙ idp) ∙ idp) ∙ r) τ ◃∙
+                      lemma4a =
+                        ap (λ p → ! (((p ∙ idp) ∙ idp) ∙ idp) ∙ r) τ ◃∙
                         ap (λ p → ! (((p ∙ idp) ∙ idp) ∙ idp) ∙ r) (!-! r) ◃∙
                         db-neg-rid-db r idp ◃∙
                         ap (λ p → p ∙ idp) τ ◃∙
                         ap (λ p → p ∙ idp) (!-! r) ◃∙
                         (∙-unit-r r ∙ ! (!-! r)) ◃∎
-                          =ₛ⟨ 0 & 5 & coher-rid-trip r τ  ⟩
+                          =ₛ⟨ 0 & 5 & coher-rid-trip r τ ⟩
                         ! (∙-unit-r r) ◃∙
                         (∙-unit-r r ∙ ! (!-! r)) ◃∎ ∎ₛ
                       
                       lemma4b : {y : ty T} (r' : y == fst (comp K j) (fun (F # j) a))
-                        → ! (∙-unit-r r') ◃∙
+                        →
+                        ! (∙-unit-r r') ◃∙
                         (∙-unit-r r' ∙ ! (!-! r')) ◃∎
                           =ₛ
                         ! (!-! r') ◃∎
@@ -198,110 +227,138 @@ module ConstrE2Cont2 {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type 
 
 
     Λ-eq0 =
-             ! (ap (λ p → ! p ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (↯ (FunHomEq g (fun (F # i) a)))) ◃∙ Ξ-inst
-               =ₑ⟨ 1 & 7 & (ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
-                   (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a)
-                 (snd (comp LRfun j) a)) ◃∙
-             ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙ fst
-               (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-               ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
-             ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+      ! (ap (λ p → ! p ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (↯ (FunHomEq g (fun (F # i) a)))) ◃∙ Ξ-inst
+        =ₑ⟨ 1 & 7 &
+          (ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+            (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
+          ap (λ p →
+               ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
                fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-               ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (!-! (snd (comp K j) a)) ◃∙
-             long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
-             ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
-             ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₁ (snd (F <#> g) a) (! (glue (cin j a))))) ◃∙
-             ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K)))
-               (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
-             ap (λ p → p ∙ idp) (ap (ap (fst (recCosCoc K))) (E₃ {f = left} {h = [id]} {u = right} (λ z → ! (glue z)) (cglue g a) (ψ-βr g a) (λ z → idp))) ◃∙
-             ∙-unit-r (ap (fst (recCosCoc K)) (! (glue (cin i a)) ∙ idp)) ◃∙
-             ap-∙-cmp2 (fst (recCosCoc K)) left (! (glue (cin i a))) idp ◃∙
-             ! (apd-tr (λ z → ap (fst (recCosCoc K)) (! (glue z)) ∙ idp) (cglue g a)) ◃∙
-             ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a)) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
-             transp-inv-comm (fun T ∘ [id]) (reccForg K ∘ ψ) (cglue g a) (! (snd (comp K j) a)) ◃∙
-             ap ! (H₁ (cglue g a) (! (snd (comp K j) a)) (ψ-βr g a)) ◃∙
-             ap ! (H₂ (snd (F <#> g) a) (snd (comp K j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
-             ap ! (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
-               (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
-             ap ! (ap ! (snd (comTri K g) a)) ◃∙
-             !-! (snd (comp K i) a) ◃∎)  % Ξ-rewrite2  ⟩
-             ! (ap (λ p → ! p ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (↯ (FunHomEq g (fun (F # i) a)))) ◃∙
-             ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
-               (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
-             ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+               ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+             (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
+          ap (λ p →
+               ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
                fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-               ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
-             ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-               fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-               ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (!-! (snd (comp K j) a)) ◃∙
-             long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
-             ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
-             ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₁ (snd (F <#> g) a) (! (glue (cin j a))))) ◃∙
-               ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K)))
-             (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
-             ap (λ p → p ∙ idp) (ap (ap (fst (recCosCoc K))) (E₃ {f = left} {h = [id]} {u = right} (λ z → ! (glue z)) (cglue g a) (ψ-βr g a) (λ z → idp))) ◃∙
-             ∙-unit-r (ap (fst (recCosCoc K)) (! (glue (cin i a)) ∙ idp)) ◃∙
-             ap-∙-cmp2 (fst (recCosCoc K)) left (! (glue (cin i a))) idp ◃∙
-             ! (apd-tr (λ z → ap (fst (recCosCoc K)) (! (glue z)) ∙ idp) (cglue g a)) ◃∙
-             ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a)) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
-             transp-inv-comm (fun T ∘ [id]) (reccForg K ∘ ψ) (cglue g a) (! (snd (comp K j) a)) ◃∙
-             ap ! (H₁ (cglue g a) (! (snd (comp K j) a)) (ψ-βr g a)) ◃∙
-             ap ! (H₂ (snd (F <#> g) a) (snd (comp K j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
-             ap ! (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
-               (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
-             ap ! (ap ! (snd (comTri K g) a)) ◃∙
-             !-! (snd (comp K i) a) ◃∎ ∎ₛ
+               ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+             (!-! (snd (comp K j) a)) ◃∙
+          long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
+          ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
+          ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₁ (snd (F <#> g) a) (! (glue (cin j a))))) ◃∙
+          ap (λ p → p ∙ (snd (recCosCoc K) a))
+            (ap (ap (fst (recCosCoc K)))
+              (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
+          ap (λ p → p ∙ idp) (ap (ap (fst (recCosCoc K))) (E₃ {f = left} {h = [id]} {u = right} (λ z → ! (glue z)) (cglue g a) (ψ-βr g a) (λ z → idp))) ◃∙
+          ∙-unit-r (ap (fst (recCosCoc K)) (! (glue (cin i a)) ∙ idp)) ◃∙
+          ap-∙-cmp2 (fst (recCosCoc K)) left (! (glue (cin i a))) idp ◃∙
+          ! (apd-tr (λ z → ap (fst (recCosCoc K)) (! (glue z)) ∙ idp) (cglue g a)) ◃∙
+          ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a)) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
+          transp-inv-comm (fun T ∘ [id]) (reccForg K ∘ ψ) (cglue g a) (! (snd (comp K j) a)) ◃∙
+          ap ! (H₁ (cglue g a) (! (snd (comp K j) a)) (ψ-βr g a)) ◃∙
+          ap ! (H₂ (snd (F <#> g) a) (snd (comp K j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
+          ap !
+            (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
+              (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
+          ap ! (ap ! (snd (comTri K g) a)) ◃∙
+          !-! (snd (comp K i) a) ◃∎)
+          % Ξ-rewrite2 ⟩
+      ! (ap (λ p → ! p ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (↯ (FunHomEq g (fun (F # i) a)))) ◃∙
+      ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
+      ap (λ p →
+           ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+           fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+           ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+         (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
+      ap (λ p →
+           ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+           fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+           ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+         (!-! (snd (comp K j) a)) ◃∙
+      long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
+      ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
+      ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₁ (snd (F <#> g) a) (! (glue (cin j a))))) ◃∙
+      ap (λ p → p ∙ (snd (recCosCoc K) a))
+        (ap (ap (fst (recCosCoc K)))
+          (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
+      ap (λ p → p ∙ idp) (ap (ap (fst (recCosCoc K))) (E₃ {f = left} {h = [id]} {u = right} (λ z → ! (glue z)) (cglue g a) (ψ-βr g a) (λ z → idp))) ◃∙
+      ∙-unit-r (ap (fst (recCosCoc K)) (! (glue (cin i a)) ∙ idp)) ◃∙
+      ap-∙-cmp2 (fst (recCosCoc K)) left (! (glue (cin i a))) idp ◃∙
+      ! (apd-tr (λ z → ap (fst (recCosCoc K)) (! (glue z)) ∙ idp) (cglue g a)) ◃∙
+      ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a)) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
+      transp-inv-comm (fun T ∘ [id]) (reccForg K ∘ ψ) (cglue g a) (! (snd (comp K j) a)) ◃∙
+      ap ! (H₁ (cglue g a) (! (snd (comp K j) a)) (ψ-βr g a)) ◃∙
+      ap ! (H₂ (snd (F <#> g) a) (snd (comp K j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
+      ap !
+        (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
+          (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
+      ap ! (ap ! (snd (comTri K g) a)) ◃∙
+      !-! (snd (comp K i) a) ◃∎ ∎ₛ
 
     Λ-eq1 =
-             ! (ap (λ p → ! p ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (↯ (FunHomEq g (fun (F # i) a)))) ◃∙
-             ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (hmtpy-nat-rev (λ z → idp)
-               (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
-             ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙ fst (comTri LRfun g)
-               (fun (F # i) a) ∙ idp) ∙
-               ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
-             ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-               fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-               ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (!-! (snd (comp K j) a)) ◃∙
-             long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
-             ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
-             ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₁ (snd (F <#> g) a) (! (glue (cin j a))))) ◃∙
-             ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K)))
-               (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
-             ap (λ p → p ∙ idp) (ap (ap (fst (recCosCoc K))) (E₃ {f = left} {h = [id]} {u = right} (λ z → ! (glue z)) (cglue g a) (ψ-βr g a) (λ z → idp))) ◃∙
-             ∙-unit-r (ap (fst (recCosCoc K)) (! (glue (cin i a)) ∙ idp)) ◃∙
-             ap-∙-cmp2 (fst (recCosCoc K)) left (! (glue (cin i a))) idp ◃∙
-             ! (apd-tr (λ z → ap (fst (recCosCoc K)) (! (glue z)) ∙ idp) (cglue g a)) ◃∙
-             ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a)) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
-             transp-inv-comm (fun T ∘ [id]) (reccForg K ∘ ψ) (cglue g a) (! (snd (comp K j) a)) ◃∙
-             ap ! (H₁ (cglue g a) (! (snd (comp K j) a)) (ψ-βr g a)) ◃∙
-             ap ! (H₂ (snd (F <#> g) a) (snd (comp K j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
-             ap ! (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
-               (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
-             ap ! (ap ! (snd (comTri K g) a)) ◃∙
-             !-! (snd (comp K i) a) ◃∎
-               =ₑ⟨ 8 & 7 & (↯ (Ξ-Red0 (cglue g a) (ap [id] (cglue g a)) (! (ap (cin j) (snd (F <#> g) a)) ∙ (cglue g (fun (F # i) a)))
-                 (snd (comp K j) a) idp (glue (cin j a)) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))))) ◃∎  %
-                   =ₛ-in (=ₛ-out (Ξ-RedEq0 (cglue g a) (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a)) (ψ-βr g a) (snd (comp K j) a) (λ z → idp)
-                     (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))))) ⟩
-             ! (ap (λ p → ! p ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (↯ (FunHomEq g (fun (F # i) a)))) ◃∙
-             ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
-               (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
-             ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-               fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-               ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
-             ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-               fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-               ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (!-! (snd (comp K j) a)) ◃∙
-             long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
-             ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
-             ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₁ (snd (F <#> g) a) (! (glue (cin j a))))) ◃∙
-             ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K)))
-               (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
-             ↯ (Ξ-Red0 (cglue g a) (ap [id] (cglue g a)) (! (ap (cin j) (snd (F <#> g) a)) ∙ (cglue g (fun (F # i) a)))
-               (snd (comp K j) a) idp (glue (cin j a)) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a)))) ◃∙
-             ap ! (H₂ (snd (F <#> g) a) (snd (comp K j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
-             ap ! (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
-               (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
-             ap ! (ap ! (snd (comTri K g) a)) ◃∙
-             !-! (snd (comp K i) a) ◃∎ ∎ₛ
+      ! (ap (λ p → ! p ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (↯ (FunHomEq g (fun (F # i) a)))) ◃∙
+      ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
+      ap (λ p →
+           ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+             fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+           ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+         (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
+      ap (λ p →
+           ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+             fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+           ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+         (!-! (snd (comp K j) a)) ◃∙
+      long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
+      ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
+      ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₁ (snd (F <#> g) a) (! (glue (cin j a))))) ◃∙
+      ap (λ p → p ∙ (snd (recCosCoc K) a))
+        (ap (ap (fst (recCosCoc K)))
+          (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
+      ap (λ p → p ∙ idp) (ap (ap (fst (recCosCoc K))) (E₃ {f = left} {h = [id]} {u = right} (λ z → ! (glue z)) (cglue g a) (ψ-βr g a) (λ z → idp))) ◃∙
+      ∙-unit-r (ap (fst (recCosCoc K)) (! (glue (cin i a)) ∙ idp)) ◃∙
+      ap-∙-cmp2 (fst (recCosCoc K)) left (! (glue (cin i a))) idp ◃∙
+      ! (apd-tr (λ z → ap (fst (recCosCoc K)) (! (glue z)) ∙ idp) (cglue g a)) ◃∙
+      ap (transport (λ z → reccForg K (ψ z) == fun T ([id] z)) (cglue g a)) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
+      transp-inv-comm (fun T ∘ [id]) (reccForg K ∘ ψ) (cglue g a) (! (snd (comp K j) a)) ◃∙
+      ap ! (H₁ (cglue g a) (! (snd (comp K j) a)) (ψ-βr g a)) ◃∙
+      ap ! (H₂ (snd (F <#> g) a) (snd (comp K j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
+      ap !
+        (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
+          (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
+      ap ! (ap ! (snd (comTri K g) a)) ◃∙
+      !-! (snd (comp K i) a) ◃∎
+        =ₑ⟨ 8 & 7 &
+          (↯ (Ξ-Red0 (cglue g a) (ap [id] (cglue g a)) (! (ap (cin j) (snd (F <#> g) a)) ∙ (cglue g (fun (F # i) a)))
+               (snd (comp K j) a) idp (glue (cin j a)) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))))) ◃∎
+          % =ₛ-in
+              (=ₛ-out
+                (Ξ-RedEq0 (cglue g a) (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a)) (ψ-βr g a) (snd (comp K j) a) (λ z → idp)
+                  (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))))) ⟩
+      ! (ap (λ p → ! p ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (↯ (FunHomEq g (fun (F # i) a)))) ◃∙
+      ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
+      ap (λ p →
+           ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+             fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+           ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+         (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
+      ap (λ p →
+           ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+             fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+           ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+         (!-! (snd (comp K j) a)) ◃∙
+      long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
+      ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
+      ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₁ (snd (F <#> g) a) (! (glue (cin j a))))) ◃∙
+      ap (λ p → p ∙ (snd (recCosCoc K) a))
+        (ap (ap (fst (recCosCoc K)))
+          (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
+      ↯ (Ξ-Red0 (cglue g a) (ap [id] (cglue g a)) (! (ap (cin j) (snd (F <#> g) a)) ∙ (cglue g (fun (F # i) a)))
+          (snd (comp K j) a) idp (glue (cin j a)) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a)))) ◃∙
+      ap ! (H₂ (snd (F <#> g) a) (snd (comp K j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
+      ap !
+        (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
+          (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
+      ap ! (ap ! (snd (comTri K g) a)) ◃∙
+      !-! (snd (comp K i) a) ◃∎ ∎ₛ
 

--- a/Colimit-code/R-L-R/CC-Equiv-RLR-3.agda
+++ b/Colimit-code/R-L-R/CC-Equiv-RLR-3.agda
@@ -2,7 +2,6 @@
 
 open import lib.Basics
 open import lib.types.Pushout
-open import lib.types.Span
 open import Coslice
 open import Diagram
 open import Colim
@@ -26,120 +25,155 @@ module ConstrE2Cont3 {ℓv ℓe ℓ ℓd ℓc} {Γ : Graph ℓv ℓe} {A : Type 
     open Equiv2c i j g a
 
     Λ-eq2-pre =
-             ! (ap (λ p → ! p ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (↯ (FunHomEq g (fun (F # i) a)))) ◃∙
-             ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
-               (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
-             ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-               fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-               ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
-             ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-               fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-               ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (!-! (snd (comp K j) a)) ◃∙
-             long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
-             ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
-             ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₁ (snd (F <#> g) a) (! (glue (cin j a))))) ◃∙
-             ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K)))
-               (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
-             ↯ (Ξ-Red0 (cglue g a) (ap [id] (cglue g a)) (! (ap (cin j) (snd (F <#> g) a)) ∙ (cglue g (fun (F # i) a)))
-               (snd (comp K j) a) idp (glue (cin j a)) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a)))) ◃∙
-             ap ! (H₂ (snd (F <#> g) a) (snd (comp K j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
-             ap ! (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
-               (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
-             ap ! (ap ! (snd (comTri K g) a)) ◃∙
-             !-! (snd (comp K i) a) ◃∎
-               =ₛ₁⟨ 11 & 1 & ap (ap !) (! (ap-idf (ap ! (snd (comTri K g) a)))) ⟩
-             ! (ap (λ p → ! p ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (↯ (FunHomEq g (fun (F # i) a)))) ◃∙
-             ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
-               (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
-             ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-               fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-               ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
-             ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-               fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-               ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (!-! (snd (comp K j) a)) ◃∙
-             long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
-             ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
-             ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₁ (snd (F <#> g) a) (! (glue (cin j a))))) ◃∙
-             ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K)))
-               (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
-             ↯ (Ξ-Red0 (cglue g a) (ap [id] (cglue g a)) (! (ap (cin j) (snd (F <#> g) a)) ∙ (cglue g (fun (F # i) a)))
-               (snd (comp K j) a) idp (glue (cin j a)) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a)))) ◃∙
-             ap ! (H₂ (snd (F <#> g) a) (snd (comp K j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
-             ap ! (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
-               (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
-             ap ! (ap (λ z → z) (ap ! (snd (comTri K g) a))) ◃∙
-             !-! (snd (comp K i) a) ◃∎ ∎ₛ
+      ! (ap (λ p → ! p ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (↯ (FunHomEq g (fun (F # i) a)))) ◃∙
+      ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
+      ap (λ p →
+           ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+             fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+           ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+         (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
+      ap (λ p →
+           ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+             fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+           ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+         (!-! (snd (comp K j) a)) ◃∙
+      long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
+      ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
+      ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₁ (snd (F <#> g) a) (! (glue (cin j a))))) ◃∙
+      ap (λ p → p ∙ (snd (recCosCoc K) a))
+        (ap (ap (fst (recCosCoc K)))
+          (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
+      ↯ (Ξ-Red0 (cglue g a) (ap [id] (cglue g a)) (! (ap (cin j) (snd (F <#> g) a)) ∙ (cglue g (fun (F # i) a)))
+          (snd (comp K j) a) idp (glue (cin j a)) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a)))) ◃∙
+      ap ! (H₂ (snd (F <#> g) a) (snd (comp K j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
+      ap !
+        (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
+          (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
+      ap ! (ap ! (snd (comTri K g) a)) ◃∙
+      !-! (snd (comp K i) a) ◃∎
+        =ₛ₁⟨ 11 & 1 & ap (ap !) (! (ap-idf (ap ! (snd (comTri K g) a)))) ⟩
+      ! (ap (λ p → ! p ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (↯ (FunHomEq g (fun (F # i) a)))) ◃∙
+      ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
+      ap (λ p →
+          ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+            fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+          ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
+      ap (λ p →
+           ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+             fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+           ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+         (!-! (snd (comp K j) a)) ◃∙
+      long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
+      ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
+      ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₁ (snd (F <#> g) a) (! (glue (cin j a))))) ◃∙
+      ap (λ p → p ∙ (snd (recCosCoc K) a))
+        (ap (ap (fst (recCosCoc K)))
+          (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
+      ↯ (Ξ-Red0 (cglue g a) (ap [id] (cglue g a)) (! (ap (cin j) (snd (F <#> g) a)) ∙ (cglue g (fun (F # i) a)))
+          (snd (comp K j) a) idp (glue (cin j a)) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a)))) ◃∙
+      ap ! (H₂ (snd (F <#> g) a) (snd (comp K j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
+      ap !
+        (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
+          (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
+      ap ! (ap (λ z → z) (ap ! (snd (comTri K g) a))) ◃∙
+      !-! (snd (comp K i) a) ◃∎ ∎ₛ
 
     Λ-eq2 =
-             ! (ap (λ p → ! p ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (↯ (FunHomEq g (fun (F # i) a)))) ◃∙
-             ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
-               (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
-             ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-               fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-               ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
-             ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-               fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-               ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (!-! (snd (comp K j) a)) ◃∙
-             long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
-             ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
-             ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₁ (snd (F <#> g) a) (! (glue (cin j a))))) ◃∙
-             ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K)))
-               (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
-             ↯ (Ξ-Red0 (cglue g a) (ap [id] (cglue g a)) (! (ap (cin j) (snd (F <#> g) a)) ∙ (cglue g (fun (F # i) a)))
-               (snd (comp K j) a) idp (glue (cin j a)) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a)))) ◃∙
-             ap ! (H₂ (snd (F <#> g) a) (snd (comp K j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
-             ap ! (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
-               (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
-             ap ! (ap (λ z → z) (ap ! (snd (comTri K g) a))) ◃∙
-             !-! (snd (comp K i) a) ◃∎
-               =ₑ⟨ 7 & 5 & (Ξ-Red1 idp (snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a)))
-                 (fst (comTri K g) (fun (F # i) a)) (recc-βr K g (fun (F # i) a)) (snd (comp K i) a) (snd (comTri K g) a))  % Ξ-RedEq1 idp (id-βr g a) (snd (comp K j) a)
-                   (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) (fst (comTri K g) (fun (F # i) a)) (recc-βr K g (fun (F # i) a))
-                     (snd (comp K i) a) (snd (comTri K g) a)  ⟩
-             ! (ap (λ p → ! p ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (↯ (FunHomEq g (fun (F # i) a)))) ◃∙
-             ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
-               (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
-             ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-               fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-               ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
-             ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-               fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-               ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (!-! (snd (comp K j) a)) ◃∙
-             long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
-             ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
-             ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₁ (snd (F <#> g) a) (! (glue (cin j a))))) ◃∙
-             (Ξ-Red1 idp (snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a)))
-               (fst (comTri K g) (fun (F # i) a)) (recc-βr K g (fun (F # i) a)) (snd (comp K i) a) (snd (comTri K g) a) ∙∙
-             !-! (snd (comp K i) a) ◃∎) ∎ₛ
+      ! (ap (λ p → ! p ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (↯ (FunHomEq g (fun (F # i) a)))) ◃∙
+      ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
+      ap (λ p →
+           ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+             fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+           ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+         (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
+      ap (λ p →
+           ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+             fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+           ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+         (!-! (snd (comp K j) a)) ◃∙
+      long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
+      ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
+      ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₁ (snd (F <#> g) a) (! (glue (cin j a))))) ◃∙
+      ap (λ p → p ∙ (snd (recCosCoc K) a))
+        (ap (ap (fst (recCosCoc K)))
+          (! (ap (λ p → ! (ap right (! (ap (cin j) (snd (F <#> g) a)) ∙ cglue g (fun (F # i) a))) ∙ ! (glue (cin j a)) ∙ p) (ap (ap left) (id-βr g a))))) ◃∙
+      ↯ (Ξ-Red0 (cglue g a) (ap [id] (cglue g a)) (! (ap (cin j) (snd (F <#> g) a)) ∙ (cglue g (fun (F # i) a)))
+          (snd (comp K j) a) idp (glue (cin j a)) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a)))) ◃∙
+      ap ! (H₂ (snd (F <#> g) a) (snd (comp K j) a) (cglue g (fun (F # i) a)) (recc-βr K g (fun (F # i) a))) ◃∙
+      ap !
+        (ap (λ p → p ∙ ! (! (fst (comTri K g) (fun (F # i) a)) ∙ ap (recc (comp K) (comTri K) ∘ cin j) (snd (F <#> g) a) ∙ (snd (comp K j) a)))
+          (ap (λ p → ! (ap (fun T) p)) (id-βr g a))) ◃∙
+      ap ! (ap (λ z → z) (ap ! (snd (comTri K g) a))) ◃∙
+      !-! (snd (comp K i) a) ◃∎
+        =ₑ⟨ 7 & 5 &
+          (Ξ-Red1 idp (snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a)))
+            (fst (comTri K g) (fun (F # i) a)) (recc-βr K g (fun (F # i) a)) (snd (comp K i) a) (snd (comTri K g) a))
+          %
+          Ξ-RedEq1 idp (id-βr g a) (snd (comp K j) a)          
+            (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) (fst (comTri K g) (fun (F # i) a)) (recc-βr K g (fun (F # i) a))
+              (snd (comp K i) a) (snd (comTri K g) a)  ⟩
+      ! (ap (λ p → ! p ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (↯ (FunHomEq g (fun (F # i) a)))) ◃∙
+      ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
+      ap (λ p →
+           ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+             fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+           ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+         (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
+      ap (λ p →
+           ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+             fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+           ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+         (!-! (snd (comp K j) a)) ◃∙
+      long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
+      ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
+      ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₁ (snd (F <#> g) a) (! (glue (cin j a))))) ◃∙
+      (Ξ-Red1 idp (snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a)))
+        (fst (comTri K g) (fun (F # i) a)) (recc-βr K g (fun (F # i) a)) (snd (comp K i) a) (snd (comTri K g) a) ∙∙
+      !-! (snd (comp K i) a) ◃∎) ∎ₛ
 
     Λ-eq3 =
-             ! (ap (λ p → ! p ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (↯ (FunHomEq g (fun (F # i) a)))) ◃∙
-             ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
-               (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
-             ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-               fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-               ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
-             ap (λ p → ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
-               fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
-               ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (!-! (snd (comp K j) a)) ◃∙
-             long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
-             ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
-             ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₁ (snd (F <#> g) a) (! (glue (cin j a))))) ◃∙
-             (Ξ-Red1 idp (snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a)))
-               (fst (comTri K g) (fun (F # i) a)) (recc-βr K g (fun (F # i) a)) (snd (comp K i) a) (snd (comTri K g) a) ∙∙
-             !-! (snd (comp K i) a) ◃∎)
-               =ₑ⟨ 0 & 13 & ((snd (comTri K g) a) ◃∙ ! (!-! (snd (comp K i) a)) ◃∎) % Ξ-Red2Eq (snd (comp K j) a)
-                 (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) (recc-βr K g (fun (F # i) a)) (snd (comTri K g) a) ⟩
-             (snd (comTri K g) a) ◃∙
-             ! (!-! (snd (comp K i) a)) ◃∙
-             !-! (snd (comp K i) a) ◃∎ ∎ₛ
+      ! (ap (λ p → ! p ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (↯ (FunHomEq g (fun (F # i) a)))) ◃∙
+      ap (λ p → ! (p ∙  fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+        (hmtpy-nat-rev (λ z → idp) (snd (F <#> g) a) (snd (comp LRfun j) a)) ◃∙
+      ap (λ p →
+           ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+             fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+           ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+         (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) ◃∙
+      ap (λ p →
+           ! ((ap (fst (comp K j)) (snd (F <#> g) a) ∙ (p ∙ ! (snd (comp LRfun j) a)) ∙ ! (ap (fst (comp LRfun j)) (snd (F <#> g) a))) ∙
+             fst (comTri LRfun g) (fun (F # i) a) ∙ idp) ∙
+           ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a)
+         (!-! (snd (comp K j) a)) ◃∙
+      long-path-red (snd (F <#> g) a) (snd (comp K j) a) (snd (comp LRfun j) a) (fst (comTri LRfun g) (fun (F # i) a)) idp ◃∙
+      ap-cp-revR (fst (recCosCoc K)) (fst (comp ColCoC j)) (snd (F <#> g) a)  (fst (comTri ColCoC g) (fun (F # i) a)) ◃∙
+      ap (λ p → p ∙ (snd (recCosCoc K) a)) (ap (ap (fst (recCosCoc K))) (E₁ (snd (F <#> g) a) (! (glue (cin j a))))) ◃∙
+      (Ξ-Red1 idp (snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a)))
+        (fst (comTri K g) (fun (F # i) a)) (recc-βr K g (fun (F # i) a)) (snd (comp K i) a) (snd (comTri K g) a) ∙∙
+      !-! (snd (comp K i) a) ◃∎)
+        =ₑ⟨ 0 & 13 & ((snd (comTri K g) a) ◃∙ ! (!-! (snd (comp K i) a)) ◃∎)
+          %
+          Ξ-Red2Eq
+            (snd (comp K j) a) (ap-inv-rid (fst (recCosCoc K)) (glue (cin j a)) ∙ ap ! (FPrecc-βr K (cin j a))) (recc-βr K g (fun (F # i) a)) (snd (comTri K g) a) ⟩
+      (snd (comTri K g) a) ◃∙
+      ! (!-! (snd (comp K i) a)) ◃∙
+      !-! (snd (comp K i) a) ◃∎ ∎ₛ
 
-    Λ-eq4 =  (snd (comTri K g) a) ◃∙
-             ! (!-! (snd (comp K i) a)) ◃∙
-             !-! (snd (comp K i) a) ◃∎
-               =ₛ⟨ =ₛ-in (ap (λ p → (snd (comTri K g) a) ∙ p) (!-inv-l (!-! (snd (comp K i) a))) ∙ ∙-unit-r (snd (comTri K g) a)) ⟩
-             snd (comTri K g) a ◃∎ ∎ₛ
+    Λ-eq4 =
+      snd (comTri K g) a ◃∙
+      ! (!-! (snd (comp K i) a)) ◃∙
+      !-! (snd (comp K i) a) ◃∎
+        =ₛ⟨ =ₛ-in (ap (λ p → (snd (comTri K g) a) ∙ p) (!-inv-l (!-! (snd (comp K i) a))) ∙ ∙-unit-r (snd (comTri K g) a)) ⟩
+      snd (comTri K g) a ◃∎ ∎ₛ
 
-    Λ-eq : ! (ap (λ p → ! p ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (↯ (FunHomEq g (fun (F # i) a)))) ◃∙ Ξ-inst
-      =ₛ snd (comTri K g) a ◃∎
-    Λ-eq = Λ-eq0 ∙ₛ (Λ-eq1 ∙ₛ (Λ-eq2-pre ∙ₛ (Λ-eq2 ∙ₛ (Λ-eq3 ∙ₛ Λ-eq4))))
+    abstract
+      Λ-eq :
+        ! (ap (λ p → ! p ∙ ap (fst (comp K j)) (snd (F <#> g) a) ∙ snd (comp K j) a) (↯ (FunHomEq g (fun (F # i) a)))) ◃∙ Ξ-inst
+          =ₛ
+        snd (comTri K g) a ◃∎
+      Λ-eq = Λ-eq0 ∙ₛ (Λ-eq1 ∙ₛ (Λ-eq2-pre ∙ₛ (Λ-eq2 ∙ₛ (Λ-eq3 ∙ₛ Λ-eq4))))

--- a/Colimit-code/R-L-R/CC-Equiv-RLR-4.agda
+++ b/Colimit-code/R-L-R/CC-Equiv-RLR-4.agda
@@ -1,8 +1,6 @@
 {-# OPTIONS --without-K --rewriting  #-}
 
 open import lib.Basics
-open import lib.types.Pushout
-open import lib.types.Span
 open import Coslice
 open import Diagram
 open import Colim

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,46 +50,13 @@ RUN /dist/agda --library-file=/dist/libraries ./theorems/homotopy/SuspAdjointLoo
 
 WORKDIR /build/Colimit-code
 RUN /dist/agda --library-file=/dist/libraries ./Trunc-Cos/TruncAdj.agda
-
-RUN /dist/agda --library-file=/dist/libraries ./R-L-R/CC-Equiv-RLR-0.agda
-RUN /dist/agda --library-file=/dist/libraries ./R-L-R/CC-Equiv-RLR-1.agda
-RUN /dist/agda --library-file=/dist/libraries ./R-L-R/CC-Equiv-RLR-2.agda
-RUN /dist/agda --library-file=/dist/libraries ./R-L-R/CC-Equiv-RLR-3.agda
-RUN /dist/agda --library-file=/dist/libraries ./R-L-R/CC-Equiv-RLR-4.agda
-RUN /dist/agda --library-file=/dist/libraries ./L-R-L/CC-Equiv-LRL-0.agda
-RUN /dist/agda --library-file=/dist/libraries ./L-R-L/CC-Equiv-LRL-1.agda
-RUN /dist/agda --library-file=/dist/libraries ./L-R-L/CC-Equiv-LRL-2.agda
-RUN /dist/agda --library-file=/dist/libraries ./L-R-L/CC-Equiv-LRL-3.agda
-RUN /dist/agda --library-file=/dist/libraries ./L-R-L/CC-Equiv-LRL-4.agda
-RUN /dist/agda --library-file=/dist/libraries ./L-R-L/CC-Equiv-LRL-5.agda
-RUN /dist/agda --library-file=/dist/libraries ./L-R-L/CC-Equiv-LRL-6.agda
-RUN /dist/agda --library-file=/dist/libraries ./L-R-L/CC-Equiv-LRL-7.agda
-RUN /dist/agda --library-file=/dist/libraries ./Map-Nat/CosColimitMap00.agda
-RUN /dist/agda --library-file=/dist/libraries ./Map-Nat/CosColimitMap01.agda
-RUN /dist/agda --library-file=/dist/libraries ./Map-Nat/CosColimitMap02.agda
-RUN /dist/agda --library-file=/dist/libraries ./Map-Nat/CosColimitMap03.agda
-RUN /dist/agda --library-file=/dist/libraries ./Map-Nat/CosColimitMap04.agda
-RUN /dist/agda --library-file=/dist/libraries ./Map-Nat/CosColimitMap05.agda
-RUN /dist/agda --library-file=/dist/libraries ./Map-Nat/CosColimitMap06.agda
-RUN /dist/agda --library-file=/dist/libraries ./Map-Nat/CosColimitMap07.agda
-RUN /dist/agda --library-file=/dist/libraries ./Map-Nat/CosColimitMap08.agda
-RUN /dist/agda --library-file=/dist/libraries ./Map-Nat/CosColimitMap09.agda
-RUN /dist/agda --library-file=/dist/libraries ./Map-Nat/CosColimitMap10.agda
-RUN /dist/agda --library-file=/dist/libraries ./Map-Nat/CosColimitMap11.agda
-RUN /dist/agda --library-file=/dist/libraries ./Map-Nat/CosColimitMap12.agda
-RUN /dist/agda --library-file=/dist/libraries ./Map-Nat/CosColimitMap13.agda
-RUN /dist/agda --library-file=/dist/libraries ./Map-Nat/CosColimitMap14.agda
-RUN /dist/agda --library-file=/dist/libraries ./Map-Nat/CosColimitMap15.agda
-RUN /dist/agda --library-file=/dist/libraries ./Map-Nat/CosColimitMap16.agda
-RUN /dist/agda --library-file=/dist/libraries ./Map-Nat/CosColimitMap17.agda
-RUN /dist/agda --library-file=/dist/libraries ./Map-Nat/CosColimitMap18.agda
 RUN /dist/agda --library-file=/dist/libraries ./Main-Theorem/CosColim-Adjunction.agda
 
 WORKDIR /build/Pullback-stability
 RUN /dist/agda --library-file=/dist/libraries ./Stability.agda
 
 ####################################################################################################
-# Execute shell script to create html files
+# Execute shell script to create html files for colimit code
 ####################################################################################################
 
 WORKDIR /build

--- a/HoTT-Agda/core/lib/Base.agda
+++ b/HoTT-Agda/core/lib/Base.agda
@@ -75,7 +75,7 @@ Path = _==_
 
 {- Paulin-Mohring J rule
 
-At the time I’m writing this (July 2013), the identity type is somehow broken in
+At the time of writing this (July 2013), the identity type is somehow broken in
 Agda dev, it behaves more or less as the Martin-Löf identity type instead of
 behaving like the Paulin-Mohring identity type.
 So here is the Paulin-Mohring J rule -}
@@ -96,7 +96,7 @@ idp ∙ q = q
 
 {- Rewriting
 
-This is a new pragma added to Agda to help create higher inductive types.
+This is a pragma added to Agda to help create higher inductive types.
 -}
 
 infix 30 _↦_

--- a/HoTT-Agda/core/lib/PathFunctor.agda
+++ b/HoTT-Agda/core/lib/PathFunctor.agda
@@ -100,7 +100,7 @@ module _ {i j} {A : Type i} {B : Type j} (g : A → B) where
   !-ap-∙ idp r = idp
 
   ap-!-∙-ap : ∀ {k} {C : Type k} (h : C → A) {y z : C} {x : A} (q : y == z) (p : x == h y) 
-    →  ap g (! p) ∙ ap g (p ∙ ap h q) == ap g (ap h q)
+    → ap g (! p) ∙ ap g (p ∙ ap h q) == ap g (ap h q)
   ap-!-∙-ap h q idp = idp 
 
   !-ap-∙-s : {x y : A} (p : x == y) {z : A} {r : x == z} {w : B} {s : g z == w}
@@ -113,7 +113,7 @@ module _ {i j} {A : Type i} {B : Type j} (g : A → B) where
 
   !-∙-ap-∙'-!-coher : {y : A} {x : B} (p : x == g y) →
     ! (!-inv-r p) ∙ ap (_∙_ p) (! (∙'-unit-l (! p)))
-    ==
+      ==
     ap ! (! (!-inv-r p) ∙ ap (_∙_ p) (! (∙'-unit-l (! p)))) ∙
     !-∙-ap-∙'-! p idp p
   !-∙-ap-∙'-!-coher idp = idp
@@ -125,7 +125,7 @@ module _ {i j} {A : Type i} {B : Type j} (g : A → B) where
   idp-ap-!-!-∙-∙'-coher : {x y : A} (p : x == y) →
     ! (!-inv-r (ap g (! p))) ∙
     ap (_∙_ (ap g (! p))) (! (∙'-unit-l (! (ap g (! p)))))
-    ==
+      ==
     idp-ap-!-!-∙-∙' p ∙
     ! (ap (λ q → ap g (! p) ∙ ap g q ∙' ! (ap g (! p)))
       (! (!-inv-r p) ∙ ap (_∙_ p) (! (∙'-unit-l (! p))))) ∙ idp
@@ -166,9 +166,8 @@ module _ {i j k} {A : Type i} {B : Type j} {C : Type k} (g : B → C) (f : A →
   ap-∘2-ap-∙ : {x y : A} (v : x == y) → 
     ! (ap (ap g) (ap-∙ f v idp ∙ idp)) ∙
     ! (ap (λ q → q) (ap-∘ (v ∙ idp))) ∙
-    ! (! (ap (λ p → p ∙ idp) (ap-∘ v)) ∙
-      ! (ap-∙ (g ∘ f) v idp))
-    ==
+    ! (! (ap (λ p → p ∙ idp) (ap-∘ v)) ∙ ! (ap-∙ (g ∘ f) v idp))
+      ==
     ap-∙ g (ap f v) idp ∙ idp
   ap-∘2-ap-∙ idp = idp
 
@@ -177,7 +176,7 @@ module _ {i j k} {A : Type i} {B : Type j} {C : Type k} (g : B → C) (f : A →
   ap-cp-rev idp q r = idp
 
   ap-cp-revR : {x y : A} (q : x == y) {w : B} {z : C} {r : f y == w} {s : g w == z} {b : B} (p : f x == b) 
-    →  ! (ap g p) ∙ (ap (g ∘ f) q) ∙ (ap g r) ∙ s == ap g (! p ∙ ap f q ∙ r) ∙ s
+    → ! (ap g p) ∙ (ap (g ∘ f) q) ∙ (ap g r) ∙ s == ap g (! p ∙ ap f q ∙ r) ∙ s
   ap-cp-revR idp {r = r} {s = s} p = !-ap-∙-s g p {r = r} {s = s}
 
   ap-cmp-rev-s : {x y : A} (q : x == y) {z : B} {p : f x == z}
@@ -189,15 +188,17 @@ module _ {i j k} {A : Type i} {B : Type j} {C : Type k} (g : B → C) (f : A →
   inv-canc-cmp idp idp idp = idp
 
   ap-!-∘-rid-coher : {x y : A} (p : x == y)
-    → ! (ap (λ q →  (ap g (ap f p)) ∙ q) (ap-∘ (! p) ∙ ap (ap g) (ap-! f p))) ∙ idp
+    →
+    ! (ap (λ q →  (ap g (ap f p)) ∙ q) (ap-∘ (! p) ∙ ap (ap g) (ap-! f p))) ∙ idp
       ==
-      ap-!-inv g (ap f p) ∙ ! (cmp-inv-r p)
+    ap-!-inv g (ap f p) ∙ ! (cmp-inv-r p)
   ap-!-∘-rid-coher idp = idp
 
   ap-!-∘-∙-rid-coher : {x y : A} (p : x == y)
-    → ! (! (cmp-inv-r p) ∙ ! (ap (λ q → q ∙ ap (g ∘ f) (! p)) (ap-∘ p)) ∙ ! (ap-∙ (g ∘ f) p (! p))) ∙ idp
+    →
+    ! (! (cmp-inv-r p) ∙ ! (ap (λ q → q ∙ ap (g ∘ f) (! p)) (ap-∘ p)) ∙ ! (ap-∙ (g ∘ f) p (! p))) ∙ idp
       ==
-      ap (ap (g ∘ f)) (!-inv-r p) ∙ idp
+    ap (ap (g ∘ f)) (!-inv-r p) ∙ idp
   ap-!-∘-∙-rid-coher idp = idp
   
 {- ap of idf -}
@@ -384,7 +385,7 @@ module _ {i j k} {A : Type i} {B : Type j} {C : Type k} (g : B → C) (f : A →
 
   ap-∘-long : (h : A → B) (K : (z : A) → h z == f z) {x y : A} (p : x == y) →
     ap (g ∘ f) p
-    ==
+      ==
     ap g (! (K x)) ∙ ap g (K x ∙ ap f p ∙' ! (K y)) ∙' ! (ap g (! (K y)))
   ap-∘-long h K {x} idp = idp-ap-!-!-∙-∙' g (K x)
 
@@ -467,10 +468,10 @@ module _ {i} {A : Type i} where
 
 module _ {i j k} {A : Type i} {B : Type j} {C : Type k}
          (f g : A → B → C) (h : ∀ a b → f a b == g a b) where
+         
   homotopy-naturality2 : {a₀ a₁ : A} {b₀ b₁ : B} (p : a₀ == a₁) (q : b₀ == b₁)
     → ap2 f p q ◃∙ h a₁ b₁ ◃∎ =ₛ h a₀ b₀ ◃∙ ap2 g p q ◃∎
-  homotopy-naturality2 {a₀ = a} {b₀ = b} idp idp =
-    =ₛ-in (! (∙-unit-r (h a b)))
+  homotopy-naturality2 {a₀ = a} {b₀ = b} idp idp =  =ₛ-in (! (∙-unit-r (h a b)))
 
 module _ {ℓ₁ ℓ₂} {A : Type ℓ₁} {B : Type ℓ₂} (f g : A → B) (H : (x : A) → f x == g x) where
 
@@ -488,7 +489,7 @@ module _ {ℓ₁ ℓ₂} {A : Type ℓ₁} {B : Type ℓ₂} {f g : A → B} (H 
   hmtpy-nat-!-sq : {x y : A} (p : x == y) → ! (H x) ∙ ap f p == ap g p ∙ ! (H y)
   hmtpy-nat-!-sq {x = x} idp = ∙-unit-r (! (H x))
 
-  hmpty-nat-∙'-r : {x y : A} (p : x == y) →  ap f p ==  H x ∙ ap g p ∙' ! (H y)
+  hmpty-nat-∙'-r : {x y : A} (p : x == y) → ap f p ==  H x ∙ ap g p ∙' ! (H y)
   hmpty-nat-∙'-r {x} idp = ! (!-inv-r (H x)) ∙ ap (λ p → H x ∙ p) (! (∙'-unit-l (! (H x))))
 
 module _ {ℓ₁ ℓ₂} {A : Type ℓ₁} {B : Type ℓ₂} {f : A → B} where
@@ -612,12 +613,12 @@ module _ {i j} {A : Type i} {B : Type j} {f : A → B} where
 
   transp-pth-Rcmp : ∀ {k l} {C : Type k} {D : Type l} {h : C → A} {v : C → D} {u : D → B}
     {x y : C} (p : x == y) (q : u (v x) == f (h x))
-    →  transport (λ x → u (v x) == f (h x)) p q == ! (ap u (ap v p)) ∙ q ∙ (ap (f ∘ h) p)
+    → transport (λ x → u (v x) == f (h x)) p q == ! (ap u (ap v p)) ∙ q ∙ (ap (f ∘ h) p)
   transp-pth-Rcmp idp q = ! (∙-unit-r q)
 
   transp-pth-cmp-s : ∀ {k l} {C : Type k} {D : Type l} {h : C → A} {v : C → D} {u : D → B}
     {x y : C} (p : x == y) (q : u (v x) == f (h x))
-    →  transport (λ x → u (v x) == f (h x)) p q ◃∎ =ₛ (! (ap u (ap v p))) ◃∙ q ◃∙ (ap f (ap h p)) ◃∎
+    → transport (λ x → u (v x) == f (h x)) p q ◃∎ =ₛ (! (ap u (ap v p))) ◃∙ q ◃∙ (ap f (ap h p)) ◃∎
   transp-pth-cmp-s idp q = =ₛ-in (! (∙-unit-r q))
 
   transp-pth-l : {x y : A} {g : A → B} (p : x == y) (q : f x == g x)
@@ -630,17 +631,17 @@ module _ {i j} {A : Type i} {B : Type j} {f : A → B} where
 
   transp-pth-cmpR : ∀ {k l m} {C : Type k} {D : Type l} {Z : Type m} {t : C → Z} {h : Z → A} {v : C → D} {u : D → B}
     {x y : C} (p : x == y) (q : u (v x) == f (h (t x)))
-    →  transport (λ x → u (v x) == f (h (t x))) p q == (! (ap u (ap v p))) ∙ q ∙ (ap f (ap h (ap t p)))
+    → transport (λ x → u (v x) == f (h (t x))) p q == (! (ap u (ap v p))) ∙ q ∙ (ap f (ap h (ap t p)))
   transp-pth-cmpR idp q = ! (∙-unit-r q)
 
   transp-pth-cmp : ∀ {k l} {C : Type k} {D : Type l} {h : C → A} {v : C → D} {u : D → B}
     {x y : C} (p : x == y) (q : u (v x) == f (h x))
-    →  transport (λ x → u (v x) == f (h x)) p q == (! (ap u (ap v p))) ∙ q ∙ (ap f (ap h p))
+    → transport (λ x → u (v x) == f (h x)) p q == (! (ap u (ap v p))) ∙ q ∙ (ap f (ap h p))
   transp-pth-cmp idp q = ! (∙-unit-r q)
   
   transp-pth-cmp-l : ∀ {k l} {C : Type k} {D : Type l} {h : C → A} {v : C → D} {u : D → B}
     {x y : C} (p : x == y) (q : u (v x) == f (h x))
-    →  transport (λ x → u (v x) == f (h x)) p q == ((! (ap u (ap v p))) ∙ q) ∙ (ap f (ap h p))
+    → transport (λ x → u (v x) == f (h x)) p q == ((! (ap u (ap v p))) ∙ q) ∙ (ap f (ap h p))
   transp-pth-cmp-l idp q = ! (∙-unit-r q)
 
   transpRev : {x y : A} {g : A → B} (p : x == y) {q : f x == g x} {r : f y == g y}
@@ -661,7 +662,7 @@ module _ {ℓ₁ ℓ₂ ℓ₃} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type �
 module _ {i j k l} {A : Type i} {B : Type j} {f : A → B} {C : Type k} {D : Type l} {h : C → A} {v : C → D} {u : D → B} {x y : C} where 
 
   transpRevSlice : (p : x == y) (q : u (v x) == f (h x)) {r : u (v y) == f (h y)}
-    → (((! (ap u (ap v p))) ∙ q) ∙ (ap f (ap h p)) == r) →  ((! (ap f (ap h p))) ∙ ! q ∙ (ap u (ap v p)) == ! r)
+    → (((! (ap u (ap v p))) ∙ q) ∙ (ap f (ap h p)) == r) → (! (ap f (ap h p))) ∙ ! q ∙ (ap u (ap v p)) == ! r
   transpRevSlice idp q idp = ∙-unit-r (! q) ∙ ap (λ p → ! p) (! (∙-unit-r q))
 
   DecompTrRev : (p : x == y) (q : u (v x) == f (h x)) {r : u (v y) == f (h y)}

--- a/HoTT-Agda/core/lib/PathFunctor.agda
+++ b/HoTT-Agda/core/lib/PathFunctor.agda
@@ -743,13 +743,6 @@ module _ {i j} {A : Type i} {F : A → Type j} {γ : (x : A) → F x} {x y z : A
   apd-concat-arg : (p : x == y) (q : y == z) → apd-tr γ (p ∙ q) ◃∎ =ₛ apd-helper p ◃∙ apd-tr γ q ◃∎
   apd-concat-arg idp idp = =ₛ-in idp
 
-module _ {ℓ₁ ℓ₂ ℓ₃} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type ℓ₃} {g : B → A} {f : A → C}  where
-
-  Δ-red : {t u : B} (v : t == u) {c : C} (R : f (g t) == c) {d : C} (σ : f (g u) == d) {z : A} (D : g t == z)
-    {W : f z == f (g u)} (τ : W == ! (ap f (! (ap g v) ∙ D)))
-    → W ∙ σ ∙ ! (! R ∙ (ap (f ∘ g) v) ∙ σ) ==  ! (ap f D) ∙ R
-  Δ-red idp idp idp idp idp = idp
-
 {- for functions with more arguments -}
 module _ {i₀ i₁ i₂ j} {A₀ : Type i₀} {A₁ : Type i₁} {A₂ : Type i₂}
   {B : Type j} (f : A₀ → A₁ → A₂ → B) where

--- a/HoTT-Agda/core/lib/PathGroupoid.agda
+++ b/HoTT-Agda/core/lib/PathGroupoid.agda
@@ -120,7 +120,8 @@ module _ {i} {A : Type i} where
   !-inv-l-r-unit-assoc : {x y : A} (p : x == y) →
     ! (ap (λ c → p ∙ c) (!-inv-l p) ∙ ∙-unit-r p) ∙
     ! (∙-assoc p (! p) p) ∙ ap (λ c → c ∙ p) (!-inv-r p)
-    == idp
+      ==
+    idp
   !-inv-l-r-unit-assoc idp = idp
 
   assoc-tri-!-mid : {x y z w u v : A} (p₀ : x == y) (p₁ : y == z) (p₂ : w == z)
@@ -129,7 +130,8 @@ module _ {i} {A : Type i} where
   assoc-tri-!-mid idp p₁ p₂ p₃ idp = ∙'-!-∙-∙ p₁ p₂ p₃
 
   assoc-tri-!-coher : {x y : A} (p : x == y) →
-    ! (!-inv-r p) ∙ ap (_∙_ p) (! (∙'-unit-l (! p))) ==
+    ! (!-inv-r p) ∙ ap (_∙_ p) (! (∙'-unit-l (! p)))
+      ==
     ap (λ q → q ∙ idp)
       (! (!-inv-r p) ∙ ap (_∙_ p) (! (∙'-unit-l (! p)))) ∙
     ap (_∙_ (p ∙ idp ∙' ! p))
@@ -187,7 +189,7 @@ module _ {ℓ₁ ℓ₂ ℓ₃} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type �
 
 module _ {ℓ₁ ℓ₂} {A : Type ℓ₁} {B : Type ℓ₂} {f : A → B} where
 
-  fun-rid-inv1 : {x y : A} (p : x == y) →  ((ap f p ∙ idp) ∙ idp) ∙ ! (ap f p ∙ idp) == idp
+  fun-rid-inv1 : {x y : A} (p : x == y) → ((ap f p ∙ idp) ∙ idp) ∙ ! (ap f p ∙ idp) == idp
   fun-rid-inv1 idp = idp
 
   fun-rid-inv2 : {x y : A} (p : x == y) → idp == (ap f p ∙ idp) ∙ ! (ap f (p ∙ idp) ∙ idp)
@@ -444,7 +446,6 @@ module _ {i j} {A : Type i} {B : A → Type j} where
   !◃idp :{x : A} {v w : B x} (q : v == w)
     → q !◃ idp == ! q
   !◃idp idp = idp
-
 
   {-
   This is some kind of dependent horizontal composition (used in [apd∙]).

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ NOTE: We have successfully tested the following Docker container on Linux but no
    The building itself type checks the whole development. The type-checking
    is partitioned into multiple stages, for otherwise the type-checking
    could take an unacceptably long time. The entire build may take over an hour.
-   The type checking of all our Agda code takes about 31 minutes on our host Ubuntu.
+   The type-checking of all our Agda code takes about 23 minutes on our host Ubuntu.
 
 2. Generate HTML files:
 


### PR DESCRIPTION
1. This PR cleans up the Colimit-code by making the line breaks of huge terms in the equational reasoning more understandable. Previously, they were largely arbitrary. It also does a tiny bit of moving around technical lemmas, but the code itself remains the same.
2. I also shortened the Dockerfile by just running Agda on the final file, which depends on all the other files.


