### PR TITLE
rearranging main theorem

### DIFF
--- a/Colimit-code/Main-Theorem/CosColim-Adjunction.agda
+++ b/Colimit-code/Main-Theorem/CosColim-Adjunction.agda
@@ -5,7 +5,6 @@ open import lib.types.Pushout
 open import Coslice
 open import Diagram
 open import Cocone
-open import CosColim-Iso
 open import CC-Equiv-LRL-7
 open import CC-Equiv-RLR-4
 open import CosColimitMap00
@@ -16,11 +15,8 @@ open import CosColimitPreCmp
 module CosColim-Adjunction where
 
 {-
-
-  This module shows that our pushout construction satisfies the universal property of an A-colimit,
-  namely that it's left adjoint to the constant diagram functor. We construct such an adjunction
-  by presenting the expected natural isomorphism.
-
+  This module shows that our pushout construction's action on maps fits into the two
+  naturality squares satisfied by the left adjoint to the constant diagram functor.
 -}
 
 module _ {ℓv ℓe ℓ} {Γ : Graph ℓv ℓe} {A : Type ℓ} where
@@ -33,10 +29,10 @@ module _ {ℓv ℓe ℓ} {Γ : Graph ℓv ℓe} {A : Type ℓ} where
 
 -- The first naturality square, arising from post-composition with the coslice map
 
-  Iso-Nat-PostCmp : ∀ {ℓd ℓc₁ ℓc₂} (F : CosDiag ℓd ℓ A Γ) {T : Coslice ℓc₁ ℓ A} {U : Coslice ℓc₂ ℓ A}
+  AdjSq-PostCmp : ∀ {ℓd ℓc₁ ℓc₂} (F : CosDiag ℓd ℓ A Γ) {T : Coslice ℓc₁ ℓ A} {U : Coslice ℓc₂ ℓ A}
     (φ : T *→ U) (f* : (Cos (P F) left) *→ T)
     → Map-to-Lim-map F φ (PostComp (ColCoC F) f*) == PostComp (ColCoC F) (φ ∘* f*)
-  Iso-Nat-PostCmp F φ (f , fₚ) = CosColim-NatSq1-eq F φ f fₚ 
+  AdjSq-PostCmp F φ (f , fₚ) = CosColim-NatSq1-eq F φ f fₚ 
 
 -- The second naturality square, arising from pre-composition with the diagram map
 
@@ -46,6 +42,6 @@ module _ {ℓv ℓe ℓ} {Γ : Graph ℓv ℓe} {A : Type ℓ} where
 
     open ConstrMap19 δ
 
-    Iso-Nat-PreCmp : ∀ {ℓc} {T : Coslice ℓc ℓ A} (f* : (Cos P₂ left) *→ T)
+    AdjSq-PreCmp : ∀ {ℓc} {T : Coslice ℓc ℓ A} (f* : (Cos P₂ left) *→ T)
       → Diag-to-Lim-map (PostComp (ColCoC G) f*) == PostComp (ColCoC F) (f* ∘* 𝕕)
-    Iso-Nat-PreCmp f* = NatSq-PreCmp δ f*
+    AdjSq-PreCmp f* = NatSq-PreCmp δ f*

--- a/Colimit-code/Main-Theorem/CosColim-main.agda
+++ b/Colimit-code/Main-Theorem/CosColim-main.agda
@@ -1,0 +1,12 @@
+{-# OPTIONS --without-K --rewriting  #-}
+
+module CosColim-main where
+
+{-
+  This module shows that our pushout construction satisfies the universal property of an A-colimit,
+  namely that it's left adjoint to the constant diagram functor. We construct such an adjunction
+  by presenting the expected natural isomorphism. This amounts to combining two files.  
+-}
+
+open import CosColim-Iso  -- shows that the canonical post-comp map is an equivalence
+open import CosColim-Adjunction  -- shows that post-comp fits into the two naturality squares

--- a/Colimit-code/README.md
+++ b/Colimit-code/README.md
@@ -52,7 +52,7 @@ check the entire development in a reasonable amount of time.
 
 1. Install Agda 2.6.4.3.
 2. Install the stripped, modified HoTT-Agda library under `../HoTT-Agda`.
-3. Type-check the file `Main-Theorem/CosColim-Adjunction.agda`.
+3. Type-check the file `Main-Theorem/CosColim-main.agda`.
 
 ## License
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN /dist/agda --library-file=/dist/libraries ./theorems/homotopy/SuspAdjointLoo
 
 WORKDIR /build/Colimit-code
 RUN /dist/agda --library-file=/dist/libraries ./Trunc-Cos/TruncAdj.agda
-RUN /dist/agda --library-file=/dist/libraries ./Main-Theorem/CosColim-Adjunction.agda
+RUN /dist/agda --library-file=/dist/libraries ./Main-Theorem/CosColim-main.agda
 
 WORKDIR /build/Pullback-stability
 RUN /dist/agda --library-file=/dist/libraries ./Stability.agda


### PR DESCRIPTION
This PR adjusts the `Main-Theorem` folder by adding the file `CosColim-main.agda`, which imports the other two files in the folder (the two separate conditions for the main adjunction). Previously, the `CosColim-Adjunction` file imported  the`CosColim-Iso` file despite not using it.

Now, the final file to check is the new file in the folder, as in the adjusted Dockerfile.