### PR TITLE
Wild bicategorical coherence lemmas 

### DIFF
--- a/Colimit-code/Create/Tree-preserve.agda
+++ b/Colimit-code/Create/Tree-preserve.agda
@@ -65,20 +65,8 @@ module _ {ℓv ℓe ℓ} {Γ : Graph ℓv ℓe} (tr : is-tree Γ) {A : Type ℓ}
         cg-PO = cogap-map-wc (ColCoc-is-colim {ℓd = lmax ℓ ℓd} Δ)
 
       cg-PO-eqv : is-colim K → equiv-wc (Coslice-wc A (lmax ℓ ℓd)) (cg-PO K)
-      cg-PO-eqv cl = col-wc-unq {K₁ = CosCoc-to-wc {i = lmax ℓ ℓd} (ColCoC-cos Δ-F)} {K₂ = K} (pentagon-wc-Cos A {lmax ℓ ℓd})
-        (λ g f →
-          UndFun∼-to-== (*→-assoc id-cos g f) ◃∙
-          ! (UndFun∼-to-== (lunit-∘* (g ∘* f))) ◃∎
-            =ₛ₁⟨ 1 & 1 & !cos-conv (lunit-∘* (g ∘* f)) ⟩
-          UndFun∼-to-== (*→-assoc id-cos g f) ◃∙
-          UndFun∼-to-== (∼!-cos (lunit-∘* (g ∘* f))) ◃∎
-            =ₛ⟨ !ₛ (cos∘-conv (*→-assoc id-cos g f) (∼!-cos (lunit-∘* (g ∘* f)))) ⟩
-          UndFun∼-to-== (*→-assoc id-cos g f ∼∘-cos ∼!-cos (lunit-∘* (g ∘* f))) ◃∎
-            =ₛ₁⟨ ap UndFun∼-to-== (∼∼-cos∼-to-== ((λ _ → idp) , (λ a → aux (fst g) (snd f a) (snd g a)))) ⟩
-          UndFun∼-to-== (pre-∘*-∼ f (∼!-cos (lunit-∘* g))) ◃∎
-            =ₛ₁⟨ ! (ap (ap (λ m → m ∘* f)) (!cos-conv (lunit-∘* g)) ∙ whisk-cos-conv-r (∼!-cos (lunit-∘* g))) ⟩
-          ap (λ m → m ∘* f) (! (UndFun∼-to-== (lunit-∘* g))) ◃∎ ∎ₛ)
-        cl-po cl
+      cg-PO-eqv cl = col-wc-unq {K₁ = CosCoc-to-wc {i = lmax ℓ ℓd} (ColCoC-cos Δ-F)} {K₂ = K}
+        (pentagon-wc-Cos A {lmax ℓ ℓd}) (triangle-wc-Cos A {lmax ℓ ℓd}) cl-po cl
         where abstract
           aux : ∀ {ℓ₁ ℓ₂} {X : Type ℓ₁} {Y : Type ℓ₂} (k : X → Y)
             {x y : X} {z : Y} (p₁ : x == y) (p₂ : k y == z) → 

--- a/Colimit-code/Create/Tree-reflect.agda
+++ b/Colimit-code/Create/Tree-reflect.agda
@@ -40,7 +40,7 @@ module _ {ℓv ℓe ℓ} {Γ : Graph ℓv ℓe} (tr : is-tree Γ) {A : Type ℓ}
       FrgCol = Forg-coscol-pres tr {ℓd = ℓd} Δ (CosCoc-to-wc (ColCoC-cos Δ-F)) cl-po
 
       cg-eqv : equiv-wc (Type-wc (lmax ℓ ℓd)) (cogap-map-wc FrgCol (F-coc (Forg-funct-cos A {ℓd}) K))
-      cg-eqv = col-wc-unq pentagon-wc-ty (λ _ _ → =ₛ-in idp) FrgCol cl
+      cg-eqv = col-wc-unq pentagon-wc-ty triangle-wc-ty FrgCol cl
 
       cc-mor : Coc-wc-mor (F-coc (Forg-funct-cos A {ℓd}) (CosCoc-to-wc (ColCoC-cos Δ-F))) (F-coc (Forg-funct-cos A {ℓd}) K)
       cc-mor = FCol-iso.tr-coscol-abs-mor tr {ℓd = ℓd} Δ K
@@ -61,4 +61,4 @@ module _ {ℓv ℓe ℓ} {Γ : Graph ℓv ℓe} (tr : is-tree Γ) {A : Type ℓ}
       Forg-coscol-reflect = fst (eqv-pres-colim {C = Coslice-wc A (lmax ℓ ℓd)} (pentagon-wc-Cos A {lmax ℓ ℓd})
         (cg-PO K , cogap-map-wc-β {K = CosCoc-to-wc {i = lmax ℓ ℓd} (ColCoC-cos Δ-F)} cl-po {V = K})
         (iso-to-eqv-cos A {lmax ℓ ℓd} (eqv-wc-to-eqv-ty cc-eqv)))
-        cl-po 
+        cl-po

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ ARG GHC_VERSION=9.4.7
 FROM fossa/haskell-static-alpine:ghc-${GHC_VERSION} AS agda
 
 WORKDIR /build/agda
-# Agda 2.6.4
-ARG AGDA_VERSION=f42acb696e43d382639f04f869e9a99ab36a91c6
+# Agda 2.6.4.3
+ARG AGDA_VERSION=714c7d2c76c5ffda3180e95c28669259f0dc5b5c
 RUN \
   git init && \
   git remote add origin https://github.com/agda/agda.git && \

--- a/HoTT-Agda/core/lib/NType.agda
+++ b/HoTT-Agda/core/lib/NType.agda
@@ -2,7 +2,6 @@
 
 open import lib.Base
 open import lib.PathGroupoid
-open import lib.Relation
 
 module lib.NType where
 

--- a/HoTT-Agda/core/lib/PathFunctor.agda
+++ b/HoTT-Agda/core/lib/PathFunctor.agda
@@ -235,6 +235,9 @@ ap-idf idp = idp
 ap-idf-inv-l : ∀ {i} {A : Type i} {u v : A} (p : u == v) → ap (λ v → v) (! p) ∙ p == idp
 ap-idf-inv-l idp = idp
 
+!-ap-idf-l : ∀ {i} {A : Type i} {u v : A} (p : u == v) → ! (ap (λ v → v) p) ∙ p == idp
+!-ap-idf-l idp = idp
+
 ap-idf-inv-r : ∀ {i} {A : Type i} {u v : A} (p : u == v) → ap (λ v → v) p ∙ ! p == idp
 ap-idf-inv-r idp = idp
 

--- a/HoTT-Agda/core/lib/PathGroupoid.agda
+++ b/HoTT-Agda/core/lib/PathGroupoid.agda
@@ -75,7 +75,6 @@ module _ {i} {A : Type i} where
 
   !-inv'-r : {x y : A} (p : x == y) → p ∙' (! p) == idp
   !-inv'-r idp = idp
-
   {- Interactions between operations
 
   A lemma of the form [!-∙ …] gives a result of the form [! (_∙_ …) == …],
@@ -104,6 +103,9 @@ module _ {i} {A : Type i} where
 {- additional algebraic lemmas -}
 
 module _ {i} {A : Type i} where
+
+  !-inv-l-∙ : {x y z : A} (q : x == y) (p : y == z) → ! q ∙ q ∙ p == p
+  !-inv-l-∙ idp p = idp
 
   !-∙-∙'-rot : {x y z w : A} (p₀ : x == y) {p₁ : x == z} {p₂ : z == w} (p₃ : y == w)
     → ! p₁ ∙ p₀ ∙' p₃ == p₂ → p₀ == p₁ ∙ p₂ ∙' ! p₃

--- a/HoTT-Agda/core/lib/PathOver.agda
+++ b/HoTT-Agda/core/lib/PathOver.agda
@@ -380,22 +380,22 @@ module _ {i j} {A : Type i} {B : Type j} (f g : A → B) where
 
 module _ {i j} {X : Ptd i} {Y : Ptd j} where 
 
-  infixr 30 _⊙-comp_
-  _⊙-comp_ : (f g : X ⊙→ Y) → Type (lmax i j)
-  _⊙-comp_ f g = Σ (fst f ∼ fst g) λ H → ! (H (pt X)) ∙ snd f == snd g
+  infixr 30 _⊙-crd∼_
+  _⊙-crd∼_ : (f g : X ⊙→ Y) → Type (lmax i j)
+  _⊙-crd∼_ f g = Σ (fst f ∼ fst g) λ H → ! (H (pt X)) ∙ snd f == snd g
 
   comp-⊙∼ : {f g : X ⊙→ Y} (H : f ⊙∼ g) → ! (fst H (pt X)) ∙ snd f == snd g
   comp-⊙∼ {f = f} H = ! (transp-cst=idf-l (fst H (pt X)) (snd f)) ∙ to-transp (snd H)
 
-  ⊙-to-comp : {f g : X ⊙→ Y} → f ⊙∼ g → f ⊙-comp g
+  ⊙-to-comp : {f g : X ⊙→ Y} → f ⊙∼ g → f ⊙-crd∼ g
   ⊙-to-comp H = fst H , comp-⊙∼ H  
 
-  comp-to-⊙ : {f g : X ⊙→ Y} → f ⊙-comp g → f ⊙∼ g
+  comp-to-⊙ : {f g : X ⊙→ Y} → f ⊙-crd∼ g → f ⊙∼ g
   fst (comp-to-⊙ H) = fst H
   snd (comp-to-⊙ {f} H) =
     from-transp (_== pt Y) (fst H (pt X)) (transp-cst=idf-l (fst H (pt X)) (snd f) ∙ snd H)
 
-  ⊙id-to-comp : {f g : X ⊙→ Y} (p : f == g) → f ⊙-comp g
+  ⊙id-to-comp : {f g : X ⊙→ Y} (p : f == g) → f ⊙-crd∼ g
   fst (⊙id-to-comp idp) = λ x → idp
   snd (⊙id-to-comp idp) = idp
 

--- a/HoTT-Agda/core/lib/PathOver.agda
+++ b/HoTT-Agda/core/lib/PathOver.agda
@@ -380,6 +380,7 @@ module _ {i j} {A : Type i} {B : Type j} (f g : A → B) where
 
 module _ {i j} {X : Ptd i} {Y : Ptd j} where 
 
+  -- "crd" stands for "coordinate"
   infixr 30 _⊙-crd∼_
   _⊙-crd∼_ : (f g : X ⊙→ Y) → Type (lmax i j)
   _⊙-crd∼_ f g = Σ (fst f ∼ fst g) λ H → ! (H (pt X)) ∙ snd f == snd g

--- a/HoTT-Agda/core/lib/PathOver.agda
+++ b/HoTT-Agda/core/lib/PathOver.agda
@@ -387,17 +387,17 @@ module _ {i j} {X : Ptd i} {Y : Ptd j} where
   comp-⊙∼ : {f g : X ⊙→ Y} (H : f ⊙∼ g) → ! (fst H (pt X)) ∙ snd f == snd g
   comp-⊙∼ {f = f} H = ! (transp-cst=idf-l (fst H (pt X)) (snd f)) ∙ to-transp (snd H)
 
-  ⊙-to-comp : {f g : X ⊙→ Y} → f ⊙∼ g → f ⊙-crd∼ g
-  ⊙-to-comp H = fst H , comp-⊙∼ H  
+  ⊙-to-crd : {f g : X ⊙→ Y} → f ⊙∼ g → f ⊙-crd∼ g
+  ⊙-to-crd H = fst H , comp-⊙∼ H  
 
   comp-to-⊙ : {f g : X ⊙→ Y} → f ⊙-crd∼ g → f ⊙∼ g
   fst (comp-to-⊙ H) = fst H
   snd (comp-to-⊙ {f} H) =
     from-transp (_== pt Y) (fst H (pt X)) (transp-cst=idf-l (fst H (pt X)) (snd f) ∙ snd H)
 
-  ⊙id-to-comp : {f g : X ⊙→ Y} (p : f == g) → f ⊙-crd∼ g
-  fst (⊙id-to-comp idp) = λ x → idp
-  snd (⊙id-to-comp idp) = idp
+  ⊙id-to-crd : {f g : X ⊙→ Y} (p : f == g) → f ⊙-crd∼ g
+  fst (⊙id-to-crd idp) = λ x → idp
+  snd (⊙id-to-crd idp) = idp
 
 {- Various other lemmas -}
 

--- a/HoTT-Agda/core/lib/types/Colim.agda
+++ b/HoTT-Agda/core/lib/types/Colim.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --confluence-check --rewriting #-}
+{-# OPTIONS --without-K  --rewriting --confluence-check #-}
 
 open import lib.Basics
 open import lib.Equivalence2

--- a/HoTT-Agda/core/lib/types/Pointed.agda
+++ b/HoTT-Agda/core/lib/types/Pointed.agda
@@ -57,10 +57,10 @@ module lib.types.Pointed where
 
 module _ {i j k} {X : Ptd i} {Y : Ptd j} {Z : Ptd k} where 
 
-  ⊙∘-assoc-comp : ∀ {l} {W : Ptd l} (h : Z ⊙→ W) (g : Y ⊙→ Z) (f : X ⊙→ Y)
+  ⊙∘-assoc-crd : ∀ {l} {W : Ptd l} (h : Z ⊙→ W) (g : Y ⊙→ Z) (f : X ⊙→ Y)
     → ((h ⊙∘ g) ⊙∘ f) ⊙-crd∼ (h ⊙∘ (g ⊙∘ f))
-  fst (⊙∘-assoc-comp (h , hpt) (g , gpt) (f , fpt)) = λ x → idp
-  snd (⊙∘-assoc-comp (h , hpt) (g , gpt) (f , fpt)) =
+  fst (⊙∘-assoc-crd (h , hpt) (g , gpt) (f , fpt)) = λ x → idp
+  snd (⊙∘-assoc-crd (h , hpt) (g , gpt) (f , fpt)) =
     ! (∙-assoc (ap (h ∘ g) fpt) (ap h gpt) hpt) ∙
     ap (λ p → p ∙ hpt) (ap (λ p → p ∙ ap h gpt) (ap-∘ h g fpt)) ∙
     ap (λ p → p ∙ hpt) (∙-ap h (ap g fpt) gpt)

--- a/HoTT-Agda/core/lib/types/Pointed.agda
+++ b/HoTT-Agda/core/lib/types/Pointed.agda
@@ -58,7 +58,7 @@ module lib.types.Pointed where
 module _ {i j k} {X : Ptd i} {Y : Ptd j} {Z : Ptd k} where 
 
   ⊙∘-assoc-comp : ∀ {l} {W : Ptd l} (h : Z ⊙→ W) (g : Y ⊙→ Z) (f : X ⊙→ Y)
-    → ((h ⊙∘ g) ⊙∘ f) ⊙-comp (h ⊙∘ (g ⊙∘ f))
+    → ((h ⊙∘ g) ⊙∘ f) ⊙-crd∼ (h ⊙∘ (g ⊙∘ f))
   fst (⊙∘-assoc-comp (h , hpt) (g , gpt) (f , fpt)) = λ x → idp
   snd (⊙∘-assoc-comp (h , hpt) (g , gpt) (f , fpt)) =
     ! (∙-assoc (ap (h ∘ g) fpt) (ap h gpt) hpt) ∙
@@ -67,14 +67,14 @@ module _ {i j k} {X : Ptd i} {Y : Ptd j} {Z : Ptd k} where
 
 -- pre- and post-comp on (unfolded) homotopies of pointed maps
 
-  ⊙∘-post : {f₁ f₂ : X ⊙→ Y} (g : Y ⊙→ Z) (H : f₁ ⊙-comp f₂) → g ⊙∘ f₁ ⊙-comp g ⊙∘ f₂
+  ⊙∘-post : {f₁ f₂ : X ⊙→ Y} (g : Y ⊙→ Z) (H : f₁ ⊙-crd∼ f₂) → g ⊙∘ f₁ ⊙-crd∼ g ⊙∘ f₂
   fst (⊙∘-post g H) = λ x → ap (fst g) (fst H x)
   snd (⊙∘-post {f₁} g H) =
     ! (∙-assoc (! (ap (fst g) (fst H (pt X)))) (ap (fst g) (snd f₁)) (snd g)) ∙
     ap (λ p → p ∙ snd g) (!-ap-∙ (fst g) (fst H (pt X)) (snd f₁)) ∙
     ap (λ p → p ∙ snd g) (ap (ap (fst g)) (snd H))
 
-  ⊙∘-pre : {f₁ f₂ : X ⊙→ Y} (g : Z ⊙→ X) (H : f₁ ⊙-comp f₂) → f₁ ⊙∘ g ⊙-comp f₂ ⊙∘ g
+  ⊙∘-pre : {f₁ f₂ : X ⊙→ Y} (g : Z ⊙→ X) (H : f₁ ⊙-crd∼ f₂) → f₁ ⊙∘ g ⊙-crd∼ f₂ ⊙∘ g
   fst (⊙∘-pre g H) = λ x → fst H (fst g x)
   snd (⊙∘-pre {f₁} {f₂} g H) =
     ! (∙-assoc (! (fst H (fst g (pt Z)))) (ap (fst f₁) (snd g)) (snd f₁)) ∙
@@ -87,7 +87,7 @@ module _ {i j k} {X : Ptd i} {Y : Ptd j} {Z : Ptd k} where
 module _ {i j} {X : Ptd i} {Y : Ptd j} {f₁ f₂ f₃ : X ⊙→ Y} where 
 
   infixr 15 _∙⊙∼_
-  _∙⊙∼_ : f₁ ⊙-comp f₂ → f₂ ⊙-comp f₃ → f₁ ⊙-comp f₃
+  _∙⊙∼_ : f₁ ⊙-crd∼ f₂ → f₂ ⊙-crd∼ f₃ → f₁ ⊙-crd∼ f₃
   fst (H₁ ∙⊙∼ H₂) = λ x → fst H₁ x ∙ fst H₂ x 
   snd (H₁ ∙⊙∼ H₂) =
     ap (λ p → ! (p ∙ fst H₂ (pt X)) ∙ snd f₁) (tri-exch (snd H₁)) ∙ 
@@ -96,11 +96,11 @@ module _ {i j} {X : Ptd i} {Y : Ptd j} {f₁ f₂ f₃ : X ⊙→ Y} where
 
 module _ {i j} {X : Ptd i} {Y : Ptd j} (f : X ⊙→ Y) where
 
-  ⊙∘-lunit : f ⊙-comp ⊙idf Y ⊙∘ f
+  ⊙∘-lunit : f ⊙-crd∼ ⊙idf Y ⊙∘ f
   fst ⊙∘-lunit x = idp
   snd ⊙∘-lunit = ! (∙-unit-r (ap (λ x → x) (snd f)) ∙ ap-idf (snd f))
 
-  ⊙∘-runit : f ⊙-comp f ⊙∘ ⊙idf X
+  ⊙∘-runit : f ⊙-crd∼ f ⊙∘ ⊙idf X
   fst ⊙∘-runit x = idp
   snd ⊙∘-runit = idp
 
@@ -108,7 +108,7 @@ module _ {i j} {X : Ptd i} {Y : Ptd j} (f : X ⊙→ Y) where
 
 module _ {i j} {X : Ptd i} {Y : Ptd j} where
 
-  !-⊙∼ : {f₁ f₂ : X ⊙→ Y} (H : f₁ ⊙-comp f₂) → f₂ ⊙-comp f₁
+  !-⊙∼ : {f₁ f₂ : X ⊙→ Y} (H : f₁ ⊙-crd∼ f₂) → f₂ ⊙-crd∼ f₁
   fst (!-⊙∼ (H₀ , H₁)) x = ! (H₀ x)
   snd (!-⊙∼ {f₁} {f₂} (H₀ , H₁)) =
     ap (λ p → p ∙ snd f₂) (!-! (H₀ (pt (X)))) ∙
@@ -118,7 +118,7 @@ module _ {i j} {X : Ptd i} {Y : Ptd j} where
 
 -- identity homotopy of pointed maps
 
-  ⊙∼-id : (f : X ⊙→ Y) → f ⊙-comp f
+  ⊙∼-id : (f : X ⊙→ Y) → f ⊙-crd∼ f
   fst (⊙∼-id (f , fₚ)) x = idp
   snd (⊙∼-id (f , fₚ)) = idp
 
@@ -127,17 +127,17 @@ module _ {i j} {X : Ptd i} {Y : Ptd j} where
 module _ {i j} {X : Ptd i} {Y : Ptd j} where
 
   infixr 10 _⊙→∼_
-  _⊙→∼_ : {f g : X ⊙→ Y} (H₁ H₂ : f ⊙-comp g) → Type (lmax i j)
+  _⊙→∼_ : {f g : X ⊙→ Y} (H₁ H₂ : f ⊙-crd∼ g) → Type (lmax i j)
   _⊙→∼_ {f = f} H₁ H₂ =
     Σ (fst H₁ ∼ fst H₂)
       (λ K → ap (λ p →  ! p ∙ snd f) (K (pt X)) ∙ snd H₂ == snd H₁)
       
-  ⊙→∼-id : {f g : X ⊙→ Y} (H : f ⊙-comp g) → H ⊙→∼ H
+  ⊙→∼-id : {f g : X ⊙→ Y} (H : f ⊙-crd∼ g) → H ⊙→∼ H
   fst (⊙→∼-id H) = λ x → idp
   snd (⊙→∼-id H) = idp
 
   infixr 10 _⊙→∼◃_
-  _⊙→∼◃_ : {f g : X ⊙→ Y} (H₁ H₂ : f ⊙-comp g) → Type (lmax i j)
+  _⊙→∼◃_ : {f g : X ⊙→ Y} (H₁ H₂ : f ⊙-crd∼ g) → Type (lmax i j)
   _⊙→∼◃_ {f = f} H₁ H₂ =
     Σ (fst H₁ ∼ fst H₂)
       (λ K → ap (λ p →  ! p ∙ snd f) (K (pt X)) ◃∙ snd H₂ ◃∎ =ₛ snd H₁ ◃∎)
@@ -150,7 +150,7 @@ module _ {i j} {X : Ptd i} {Y : Ptd j} where
       r-inv : Y ⊙→ X
       sect⊙-eq : f ⊙∘ r-inv == ⊙idf Y
 
--- induction principle for ⊙-comp
+-- induction principle for ⊙-crd∼
 
 module _ {i j} {X : Ptd i} {Y : Ptd j} (f : X ⊙→ Y) where
 
@@ -165,14 +165,14 @@ module _ {i j} {X : Ptd i} {Y : Ptd j} (f : X ⊙→ Y) where
         (funhom-contr {f = fst f}))⁻¹)
 
   abstract
-    ⊙hom-contr : is-contr (Σ (X ⊙→ Y) (λ g → f ⊙-comp g))
+    ⊙hom-contr : is-contr (Σ (X ⊙→ Y) (λ g → f ⊙-crd∼ g))
     ⊙hom-contr = equiv-preserves-level lemma {{⊙hom-contr-aux }}
       where
         lemma :
           Σ (Σ (de⊙ X → de⊙ Y) (λ g → fst f ∼ g))
             (λ (h , K) → Σ (h (pt X) == pt Y) (λ p → (! (K (pt X)) ∙ snd f == p)))
             ≃
-          Σ (X ⊙→ Y) (λ g → f ⊙-comp g)
+          Σ (X ⊙→ Y) (λ g → f ⊙-crd∼ g)
         lemma =
           equiv
             (λ ((g , K) , (p , H)) → (g , p) , (K , H))
@@ -180,39 +180,39 @@ module _ {i j} {X : Ptd i} {Y : Ptd j} (f : X ⊙→ Y) where
             (λ ((h , p) , (H , K)) → idp)
             λ ((g , K) , (p , H)) → idp
 
-  ⊙hom-ind : ∀ {k} (P : (g : X ⊙→ Y) → (f ⊙-comp g → Type k))
-    → P f (⊙∼-id f) → {g : X ⊙→ Y} (p : f ⊙-comp g) → P g p
+  ⊙hom-ind : ∀ {k} (P : (g : X ⊙→ Y) → (f ⊙-crd∼ g → Type k))
+    → P f (⊙∼-id f) → {g : X ⊙→ Y} (p : f ⊙-crd∼ g) → P g p
   ⊙hom-ind P = ID-ind-map P ⊙hom-contr
 
-  ⊙hom-ind-β : ∀ {k} (P : (g : X ⊙→ Y) → (f ⊙-comp g → Type k))
+  ⊙hom-ind-β : ∀ {k} (P : (g : X ⊙→ Y) → (f ⊙-crd∼ g → Type k))
     → (r : P f (⊙∼-id f)) → ⊙hom-ind P r {f} (⊙∼-id f) == r
   ⊙hom-ind-β P = ID-ind-map-β P ⊙hom-contr
 
 module _ {i j} {X : Ptd i} {Y : Ptd j} where
 
-  ⊙-comp-to-== : {f : X ⊙→ Y} {g : X ⊙→ Y} → f ⊙-comp g → f == g
-  ⊙-comp-to-== {f} = ⊙hom-ind f (λ g _ → f == g) idp
+  ⊙-crd∼-to-== : {f : X ⊙→ Y} {g : X ⊙→ Y} → f ⊙-crd∼ g → f == g
+  ⊙-crd∼-to-== {f} = ⊙hom-ind f (λ g _ → f == g) idp
 
-  ⊙-comp-to-==-β : (f : X ⊙→ Y) → ⊙-comp-to-== (⊙∼-id f) == idp
-  ⊙-comp-to-==-β f = ⊙hom-ind-β f (λ g _ → f == g) idp
+  ⊙-crd∼-to-==-β : (f : X ⊙→ Y) → ⊙-crd∼-to-== (⊙∼-id f) == idp
+  ⊙-crd∼-to-==-β f = ⊙hom-ind-β f (λ g _ → f == g) idp
 
-  ==-to-⊙-comp : {f : X ⊙→ Y} {g : X ⊙→ Y} → f == g → f ⊙-comp g
-  ==-to-⊙-comp idp = ⊙∼-id _
+  ==-to-⊙-crd∼ : {f : X ⊙→ Y} {g : X ⊙→ Y} → f == g → f ⊙-crd∼ g
+  ==-to-⊙-crd∼ idp = ⊙∼-id _
 
-  ⊙-comp-==-≃ : {f : X ⊙→ Y} {g : X ⊙→ Y} → (f == g) ≃ (f ⊙-comp g)
-  ⊙-comp-==-≃ {f} {g} = equiv ==-to-⊙-comp ⊙-comp-to-== aux1 aux2
+  ⊙-crd∼-==-≃ : {f : X ⊙→ Y} {g : X ⊙→ Y} → (f == g) ≃ (f ⊙-crd∼ g)
+  ⊙-crd∼-==-≃ {f} {g} = equiv ==-to-⊙-crd∼ ⊙-crd∼-to-== aux1 aux2
     where
-      aux1 : {k : X ⊙→ Y} (H : f ⊙-comp k) → ==-to-⊙-comp (⊙-comp-to-== H) == H
+      aux1 : {k : X ⊙→ Y} (H : f ⊙-crd∼ k) → ==-to-⊙-crd∼ (⊙-crd∼-to-== H) == H
       aux1 =
-        ⊙hom-ind f (λ k H → ==-to-⊙-comp (⊙-comp-to-== H) == H)
-          (ap (==-to-⊙-comp) (⊙-comp-to-==-β f))
+        ⊙hom-ind f (λ k H → ==-to-⊙-crd∼ (⊙-crd∼-to-== H) == H)
+          (ap (==-to-⊙-crd∼) (⊙-crd∼-to-==-β f))
 
-      aux2 : {k : X ⊙→ Y} (p : f == k) → ⊙-comp-to-== (==-to-⊙-comp p) == p
-      aux2 idp = ⊙-comp-to-==-β f 
+      aux2 : {k : X ⊙→ Y} (p : f == k) → ⊙-crd∼-to-== (==-to-⊙-crd∼ p) == p
+      aux2 idp = ⊙-crd∼-to-==-β f 
 
 -- induction principle for ⊙∼→
 
-module _ {i j} {X : Ptd i} {Y : Ptd j} {f₁ f₂ : X ⊙→ Y} {H : f₁ ⊙-comp f₂} where
+module _ {i j} {X : Ptd i} {Y : Ptd j} {f₁ f₂ : X ⊙→ Y} {H : f₁ ⊙-crd∼ f₂} where
 
   ⊙→∼-contr-aux :
     is-contr $
@@ -226,7 +226,7 @@ module _ {i j} {X : Ptd i} {Y : Ptd j} {f₁ f₂ : X ⊙→ Y} {H : f₁ ⊙-co
           Σ (! (h (pt X)) ∙ snd f₁ == snd f₂) (λ L → ap (λ p →  ! p ∙ snd f₁) (k (pt X)) ∙ L == snd H)}
         (funhom-contr {f = fst H}))⁻¹)
 
-  ⊙→∼-contr : is-contr (Σ (f₁ ⊙-comp f₂) (λ K → H ⊙→∼ K))
+  ⊙→∼-contr : is-contr (Σ (f₁ ⊙-crd∼ f₂) (λ K → H ⊙→∼ K))
   ⊙→∼-contr = equiv-preserves-level lemma {{⊙→∼-contr-aux}}
     where
       lemma :
@@ -234,7 +234,7 @@ module _ {i j} {X : Ptd i} {Y : Ptd j} {f₁ f₂ : X ⊙→ Y} {H : f₁ ⊙-co
           (λ (h , k) → Σ (! (h (pt X)) ∙ snd f₁ == snd f₂)
             (λ L → ap (λ p →  ! p ∙ snd f₁) (k (pt X)) ∙ L == snd H))
           ≃
-        Σ (f₁ ⊙-comp f₂) (λ K → H ⊙→∼ K)
+        Σ (f₁ ⊙-crd∼ f₂) (λ K → H ⊙→∼ K)
       lemma =
         equiv
           (λ ((h , k) , (L , c)) → (h , L) , (k , c))
@@ -242,11 +242,11 @@ module _ {i j} {X : Ptd i} {Y : Ptd j} {f₁ f₂ : X ⊙→ Y} {H : f₁ ⊙-co
           (λ ((K₁ , K₂) , (c₁ , c₂)) → idp)
           λ ((h , k) , (L , c)) → idp
 
-  ⊙→∼-ind : ∀ {k} (P : (K : f₁ ⊙-comp f₂) → (H ⊙→∼ K → Type k))
-    → P H (⊙→∼-id H) → {K : f₁ ⊙-comp f₂} (p : H ⊙→∼ K) → P K p
+  ⊙→∼-ind : ∀ {k} (P : (K : f₁ ⊙-crd∼ f₂) → (H ⊙→∼ K → Type k))
+    → P H (⊙→∼-id H) → {K : f₁ ⊙-crd∼ f₂} (p : H ⊙→∼ K) → P K p
   ⊙→∼-ind P = ID-ind-map P ⊙→∼-contr
 
-module _ {i j} {X : Ptd i} {Y : Ptd j} {f g : X ⊙→ Y} {H₁ H₂ : f ⊙-comp g} where
+module _ {i j} {X : Ptd i} {Y : Ptd j} {f g : X ⊙→ Y} {H₁ H₂ : f ⊙-crd∼ g} where
 
   ⊙→∼-to-== : H₁ ⊙→∼ H₂ → H₁ == H₂
   ⊙→∼-to-== = ⊙→∼-ind {H = H₁} (λ H₂ _ → H₁ == H₂) idp 
@@ -256,14 +256,14 @@ module _ {i j} {X : Ptd i} {Y : Ptd j} where
  ∙⊙∼-! : (f : X ⊙→ Y) → !-⊙∼ (⊙∼-id f) == ⊙∼-id f
  ∙⊙∼-! (f₀ , idp) = ⊙→∼-to-== ((λ _ → idp) , idp)
 
- ∙⊙∼-unit-l : {f g : X ⊙→ Y} (H : f ⊙-comp g) → (⊙∼-id f ∙⊙∼ H) == H
+ ∙⊙∼-unit-l : {f g : X ⊙→ Y} (H : f ⊙-crd∼ g) → (⊙∼-id f ∙⊙∼ H) == H
  ∙⊙∼-unit-l {f = (f₀ , idp)} H = ⊙→∼-to-== ((λ _ → idp) , aux (snd H))
    where
      aux : ∀ {k} {A : Type k} {x y : A} {r : y == x} {q₂ : x == y} (q₁ : ! r ∙ idp == q₂) →
        q₁ == ap (λ p → ! p ∙ idp) (tri-exch q₁) ∙ ∙-unit-r (! (! q₂)) ∙ !-! q₂
      aux {r = idp} idp = idp
 
- ∙⊙∼-unit-r : {f g : X ⊙→ Y} (H : f ⊙-comp g)→ (H ∙⊙∼ ⊙∼-id g) == H
+ ∙⊙∼-unit-r : {f g : X ⊙→ Y} (H : f ⊙-crd∼ g)→ (H ∙⊙∼ ⊙∼-id g) == H
  ∙⊙∼-unit-r {g = (g₀ , idp)} H = ⊙→∼-to-== ((λ x → ∙-unit-r (fst H x)) , aux {r = fst H (pt X)} (snd H))
    where
      aux : ∀ {k} {A : Type k} {x y : A} {r q₂ : x == y} (q₁ : ! r ∙ q₂ == idp) →

--- a/HoTT-Agda/core/lib/types/PtdMap-conv.agda
+++ b/HoTT-Agda/core/lib/types/PtdMap-conv.agda
@@ -3,7 +3,7 @@
 open import lib.Basics
 open import lib.types.Pointed
 
--- preservation of groupoid structure by ⊙-comp-to-==
+-- preservation of groupoid structure by ⊙-crd∼-to-==
 
 module lib.types.PtdMap-conv where
 
@@ -11,145 +11,145 @@ module _ {i j} {X : Ptd i} {Y : Ptd j} where
 
   abstract
 
-    !⊙-conv : {f₁ f₂ : X ⊙→ Y} (h : f₁ ⊙-comp f₂) →
-      ⊙-comp-to-== (!-⊙∼ h) == ! (⊙-comp-to-== h)
+    !⊙-conv : {f₁ f₂ : X ⊙→ Y} (h : f₁ ⊙-crd∼ f₂) →
+      ⊙-crd∼-to-== (!-⊙∼ h) == ! (⊙-crd∼-to-== h)
     !⊙-conv {f₁} = 
       ⊙hom-ind f₁
-        (λ f₂ h → ⊙-comp-to-== (!-⊙∼ h) == ! (⊙-comp-to-== h))
-        (ap ⊙-comp-to-== (∙⊙∼-! f₁) ∙
-        ⊙-comp-to-==-β f₁ ∙
-        ap ! (! (⊙-comp-to-==-β f₁)))
+        (λ f₂ h → ⊙-crd∼-to-== (!-⊙∼ h) == ! (⊙-crd∼-to-== h))
+        (ap ⊙-crd∼-to-== (∙⊙∼-! f₁) ∙
+        ⊙-crd∼-to-==-β f₁ ∙
+        ap ! (! (⊙-crd∼-to-==-β f₁)))
 
-    ⊙∘-conv : {f₁ f₃ f₂ : X ⊙→ Y} (h₁ : f₁ ⊙-comp f₂) (h₂ : f₂ ⊙-comp f₃) →
-      ⊙-comp-to-== (h₁ ∙⊙∼ h₂) ◃∎ =ₛ ⊙-comp-to-== h₁ ◃∙ ⊙-comp-to-== h₂ ◃∎
+    ⊙∘-conv : {f₁ f₃ f₂ : X ⊙→ Y} (h₁ : f₁ ⊙-crd∼ f₂) (h₂ : f₂ ⊙-crd∼ f₃) →
+      ⊙-crd∼-to-== (h₁ ∙⊙∼ h₂) ◃∎ =ₛ ⊙-crd∼-to-== h₁ ◃∙ ⊙-crd∼-to-== h₂ ◃∎
     ⊙∘-conv {f₁} {f₃} =
       ⊙hom-ind f₁
         (λ f₂ h₁ →
-          ((h₂ : f₂ ⊙-comp f₃) →
-            ⊙-comp-to-== (h₁ ∙⊙∼ h₂) ◃∎ =ₛ ⊙-comp-to-== h₁ ◃∙ ⊙-comp-to-== h₂ ◃∎))
+          ((h₂ : f₂ ⊙-crd∼ f₃) →
+            ⊙-crd∼-to-== (h₁ ∙⊙∼ h₂) ◃∎ =ₛ ⊙-crd∼-to-== h₁ ◃∙ ⊙-crd∼-to-== h₂ ◃∎))
         λ h₂ → 
-          ⊙-comp-to-== (⊙∼-id f₁ ∙⊙∼ h₂) ◃∎
-            =ₛ₁⟨ ap ⊙-comp-to-== (∙⊙∼-unit-l h₂) ⟩
-          ⊙-comp-to-== h₂ ◃∎
-            =ₛ⟨ =ₛ-in (idp {a = ⊙-comp-to-== h₂}) ⟩
-          idp {a = f₁} ◃∙ ⊙-comp-to-== h₂ ◃∎
-            =ₛ₁⟨ 0 & 1 & ! (⊙-comp-to-==-β f₁) ⟩
-          ⊙-comp-to-== (⊙∼-id f₁) ◃∙ ⊙-comp-to-== h₂ ◃∎ ∎ₛ
+          ⊙-crd∼-to-== (⊙∼-id f₁ ∙⊙∼ h₂) ◃∎
+            =ₛ₁⟨ ap ⊙-crd∼-to-== (∙⊙∼-unit-l h₂) ⟩
+          ⊙-crd∼-to-== h₂ ◃∎
+            =ₛ⟨ =ₛ-in (idp {a = ⊙-crd∼-to-== h₂}) ⟩
+          idp {a = f₁} ◃∙ ⊙-crd∼-to-== h₂ ◃∎
+            =ₛ₁⟨ 0 & 1 & ! (⊙-crd∼-to-==-β f₁) ⟩
+          ⊙-crd∼-to-== (⊙∼-id f₁) ◃∙ ⊙-crd∼-to-== h₂ ◃∎ ∎ₛ
           
     ⊙∘-conv-tri : {f₁ f₂ f₃ f₄ : X ⊙→ Y}
-      (h₁ : f₁ ⊙-comp f₂) (h₂ : f₂ ⊙-comp f₃) (h₃ : f₃ ⊙-comp f₄) →
-      ⊙-comp-to-== (h₁ ∙⊙∼ h₂ ∙⊙∼ h₃) ◃∎
+      (h₁ : f₁ ⊙-crd∼ f₂) (h₂ : f₂ ⊙-crd∼ f₃) (h₃ : f₃ ⊙-crd∼ f₄) →
+      ⊙-crd∼-to-== (h₁ ∙⊙∼ h₂ ∙⊙∼ h₃) ◃∎
         =ₛ
-      ⊙-comp-to-== h₁ ◃∙ ⊙-comp-to-== h₂ ◃∙ ⊙-comp-to-== h₃ ◃∎
+      ⊙-crd∼-to-== h₁ ◃∙ ⊙-crd∼-to-== h₂ ◃∙ ⊙-crd∼-to-== h₃ ◃∎
     ⊙∘-conv-tri h₁ h₂ h₃ =
-      ⊙-comp-to-== (h₁ ∙⊙∼ h₂ ∙⊙∼ h₃) ◃∎
+      ⊙-crd∼-to-== (h₁ ∙⊙∼ h₂ ∙⊙∼ h₃) ◃∎
         =ₛ⟨ ⊙∘-conv h₁  (h₂ ∙⊙∼ h₃) ⟩
-      ⊙-comp-to-== h₁ ◃∙ ⊙-comp-to-== (h₂ ∙⊙∼ h₃) ◃∎
+      ⊙-crd∼-to-== h₁ ◃∙ ⊙-crd∼-to-== (h₂ ∙⊙∼ h₃) ◃∎
         =ₛ⟨ 1 & 1 & ⊙∘-conv h₂ h₃ ⟩
-      ⊙-comp-to-== h₁ ◃∙ ⊙-comp-to-== h₂ ◃∙ ⊙-comp-to-== h₃ ◃∎ ∎ₛ
+      ⊙-crd∼-to-== h₁ ◃∙ ⊙-crd∼-to-== h₂ ◃∙ ⊙-crd∼-to-== h₃ ◃∎ ∎ₛ
 
     ⊙∘-conv-quint : {f₁ f₂ f₃ f₄ f₅ f₆ : X ⊙→ Y}
-      (h₁ : _⊙-comp_ f₁ f₂) (h₂ : _⊙-comp_ f₂ f₃)
-      (h₃ : _⊙-comp_ f₃ f₄) (h₄ : _⊙-comp_ f₄ f₅)
-      (h₅ : _⊙-comp_ f₅ f₆) →
-      ⊙-comp-to-== h₁ ◃∙
-      ⊙-comp-to-== h₂ ◃∙
-      ⊙-comp-to-== h₃ ◃∙
-      ⊙-comp-to-== h₄ ◃∙
-      ⊙-comp-to-== h₅ ◃∎ 
+      (h₁ : _⊙-crd∼_ f₁ f₂) (h₂ : _⊙-crd∼_ f₂ f₃)
+      (h₃ : _⊙-crd∼_ f₃ f₄) (h₄ : _⊙-crd∼_ f₄ f₅)
+      (h₅ : _⊙-crd∼_ f₅ f₆) →
+      ⊙-crd∼-to-== h₁ ◃∙
+      ⊙-crd∼-to-== h₂ ◃∙
+      ⊙-crd∼-to-== h₃ ◃∙
+      ⊙-crd∼-to-== h₄ ◃∙
+      ⊙-crd∼-to-== h₅ ◃∎ 
         =ₛ
-      ⊙-comp-to-== (h₁ ∙⊙∼ h₂ ∙⊙∼ h₃ ∙⊙∼ h₄ ∙⊙∼ h₅) ◃∎
+      ⊙-crd∼-to-== (h₁ ∙⊙∼ h₂ ∙⊙∼ h₃ ∙⊙∼ h₄ ∙⊙∼ h₅) ◃∎
     ⊙∘-conv-quint h₁ h₂ h₃ h₄ h₅ = 
-      ⊙-comp-to-== h₁ ◃∙
-      ⊙-comp-to-== h₂ ◃∙
-      ⊙-comp-to-== h₃ ◃∙
-      ⊙-comp-to-== h₄ ◃∙
-      ⊙-comp-to-== h₅ ◃∎
+      ⊙-crd∼-to-== h₁ ◃∙
+      ⊙-crd∼-to-== h₂ ◃∙
+      ⊙-crd∼-to-== h₃ ◃∙
+      ⊙-crd∼-to-== h₄ ◃∙
+      ⊙-crd∼-to-== h₅ ◃∎
         =ₛ⟨ 2 & 3 & !ₛ (⊙∘-conv-tri h₃ h₄ h₅) ⟩
-      ⊙-comp-to-== h₁ ◃∙
-      ⊙-comp-to-== h₂ ◃∙
-      ⊙-comp-to-== (h₃ ∙⊙∼ h₄ ∙⊙∼ h₅) ◃∎
+      ⊙-crd∼-to-== h₁ ◃∙
+      ⊙-crd∼-to-== h₂ ◃∙
+      ⊙-crd∼-to-== (h₃ ∙⊙∼ h₄ ∙⊙∼ h₅) ◃∎
         =ₛ⟨ !ₛ (⊙∘-conv-tri h₁ h₂ (h₃ ∙⊙∼ h₄ ∙⊙∼ h₅)) ⟩
-      ⊙-comp-to-== (h₁ ∙⊙∼ h₂ ∙⊙∼ h₃ ∙⊙∼ h₄ ∙⊙∼ h₅) ◃∎ ∎ₛ
+      ⊙-crd∼-to-== (h₁ ∙⊙∼ h₂ ∙⊙∼ h₃ ∙⊙∼ h₄ ∙⊙∼ h₅) ◃∎ ∎ₛ
 
     ⊙∘-conv-sept : {f₁ f₂ f₃ f₄ f₅ f₆ f₇ f₈ : X ⊙→ Y}
-      (h₁ : _⊙-comp_ f₁ f₂) (h₂ : _⊙-comp_ f₂ f₃)
-      (h₃ : _⊙-comp_ f₃ f₄) (h₄ : _⊙-comp_ f₄ f₅)
-      (h₅ : _⊙-comp_ f₅ f₆) (h₆ : _⊙-comp_ f₆ f₇)
-      (h₇ : _⊙-comp_ f₇ f₈) →
-      ⊙-comp-to-== h₁ ◃∙
-      ⊙-comp-to-== h₂ ◃∙
-      ⊙-comp-to-== h₃ ◃∙
-      ⊙-comp-to-== h₄ ◃∙
-      ⊙-comp-to-== h₅ ◃∙
-      ⊙-comp-to-== h₆ ◃∙
-      ⊙-comp-to-== h₇ ◃∎
+      (h₁ : _⊙-crd∼_ f₁ f₂) (h₂ : _⊙-crd∼_ f₂ f₃)
+      (h₃ : _⊙-crd∼_ f₃ f₄) (h₄ : _⊙-crd∼_ f₄ f₅)
+      (h₅ : _⊙-crd∼_ f₅ f₆) (h₆ : _⊙-crd∼_ f₆ f₇)
+      (h₇ : _⊙-crd∼_ f₇ f₈) →
+      ⊙-crd∼-to-== h₁ ◃∙
+      ⊙-crd∼-to-== h₂ ◃∙
+      ⊙-crd∼-to-== h₃ ◃∙
+      ⊙-crd∼-to-== h₄ ◃∙
+      ⊙-crd∼-to-== h₅ ◃∙
+      ⊙-crd∼-to-== h₆ ◃∙
+      ⊙-crd∼-to-== h₇ ◃∎
         =ₛ
-      ⊙-comp-to-== (h₁ ∙⊙∼ h₂ ∙⊙∼ h₃ ∙⊙∼ h₄ ∙⊙∼ h₅ ∙⊙∼ h₆ ∙⊙∼ h₇) ◃∎
+      ⊙-crd∼-to-== (h₁ ∙⊙∼ h₂ ∙⊙∼ h₃ ∙⊙∼ h₄ ∙⊙∼ h₅ ∙⊙∼ h₆ ∙⊙∼ h₇) ◃∎
     ⊙∘-conv-sept h₁ h₂ h₃ h₄ h₅ h₆ h₇ = 
-      ⊙-comp-to-== h₁ ◃∙
-      ⊙-comp-to-== h₂ ◃∙
-      ⊙-comp-to-== h₃ ◃∙
-      ⊙-comp-to-== h₄ ◃∙
-      ⊙-comp-to-== h₅ ◃∙
-      ⊙-comp-to-== h₆ ◃∙
-      ⊙-comp-to-== h₇ ◃∎
+      ⊙-crd∼-to-== h₁ ◃∙
+      ⊙-crd∼-to-== h₂ ◃∙
+      ⊙-crd∼-to-== h₃ ◃∙
+      ⊙-crd∼-to-== h₄ ◃∙
+      ⊙-crd∼-to-== h₅ ◃∙
+      ⊙-crd∼-to-== h₆ ◃∙
+      ⊙-crd∼-to-== h₇ ◃∎
         =ₛ⟨ 2 & 5 & ⊙∘-conv-quint h₃ h₄ h₅ h₆ h₇ ⟩
-      ⊙-comp-to-== h₁ ◃∙
-      ⊙-comp-to-== h₂ ◃∙
-      ⊙-comp-to-== (h₃ ∙⊙∼ h₄ ∙⊙∼ h₅ ∙⊙∼ h₆ ∙⊙∼ h₇) ◃∎
+      ⊙-crd∼-to-== h₁ ◃∙
+      ⊙-crd∼-to-== h₂ ◃∙
+      ⊙-crd∼-to-== (h₃ ∙⊙∼ h₄ ∙⊙∼ h₅ ∙⊙∼ h₆ ∙⊙∼ h₇) ◃∎
         =ₛ⟨ !ₛ (⊙∘-conv-tri h₁ h₂ (h₃ ∙⊙∼ h₄ ∙⊙∼ h₅ ∙⊙∼ h₆ ∙⊙∼ h₇)) ⟩
-      ⊙-comp-to-== (h₁ ∙⊙∼ h₂ ∙⊙∼ h₃ ∙⊙∼ h₄ ∙⊙∼ h₅ ∙⊙∼ h₆ ∙⊙∼ h₇) ◃∎ ∎ₛ
+      ⊙-crd∼-to-== (h₁ ∙⊙∼ h₂ ∙⊙∼ h₃ ∙⊙∼ h₄ ∙⊙∼ h₅ ∙⊙∼ h₆ ∙⊙∼ h₇) ◃∎ ∎ₛ
 
 module _ {i j k} {X : Ptd i} {Y : Ptd j} {Z : Ptd k} where
 
   abstract
 
-    whisk⊙-conv-r : {f₁ : X ⊙→ Y} {f₂ f₂' : Y ⊙→ Z} (h : f₂ ⊙-comp f₂') →
-      ⊙-comp-to-== (⊙∘-pre f₁ h) == ap (λ m → m ⊙∘ f₁) (⊙-comp-to-== h)
+    whisk⊙-conv-r : {f₁ : X ⊙→ Y} {f₂ f₂' : Y ⊙→ Z} (h : f₂ ⊙-crd∼ f₂') →
+      ⊙-crd∼-to-== (⊙∘-pre f₁ h) == ap (λ m → m ⊙∘ f₁) (⊙-crd∼-to-== h)
     whisk⊙-conv-r {f₁} {f₂} =
       ⊙hom-ind f₂
-        (λ f₂' h → ⊙-comp-to-== (⊙∘-pre f₁ h) == ap (λ m → m ⊙∘ f₁) (⊙-comp-to-== h))
-        (ap ⊙-comp-to-== (∙⊙-pre {f = f₂}) ∙
-        ⊙-comp-to-==-β (f₂ ⊙∘ f₁) ∙
-        ! (ap (ap (λ m → m ⊙∘ f₁)) (⊙-comp-to-==-β f₂)))
+        (λ f₂' h → ⊙-crd∼-to-== (⊙∘-pre f₁ h) == ap (λ m → m ⊙∘ f₁) (⊙-crd∼-to-== h))
+        (ap ⊙-crd∼-to-== (∙⊙-pre {f = f₂}) ∙
+        ⊙-crd∼-to-==-β (f₂ ⊙∘ f₁) ∙
+        ! (ap (ap (λ m → m ⊙∘ f₁)) (⊙-crd∼-to-==-β f₂)))
 
-    whisk⊙-conv-l : {f₁ : Y ⊙→ Z} {f₂ f₂' : X ⊙→ Y} (h : f₂ ⊙-comp f₂') →
-      ⊙-comp-to-== (⊙∘-post f₁ h) == ap (λ m → f₁ ⊙∘ m) (⊙-comp-to-== h)
+    whisk⊙-conv-l : {f₁ : Y ⊙→ Z} {f₂ f₂' : X ⊙→ Y} (h : f₂ ⊙-crd∼ f₂') →
+      ⊙-crd∼-to-== (⊙∘-post f₁ h) == ap (λ m → f₁ ⊙∘ m) (⊙-crd∼-to-== h)
     whisk⊙-conv-l {f₁} {f₂} = 
       ⊙hom-ind f₂
-        (λ f₂' h → ⊙-comp-to-== (⊙∘-post f₁ h) == ap (λ m → f₁ ⊙∘ m) (⊙-comp-to-== h))
-        (ap ⊙-comp-to-== (∙⊙-post {f = f₂}) ∙ 
-        ⊙-comp-to-==-β (f₁ ⊙∘ f₂) ∙
-        ! (ap (ap (λ m → f₁ ⊙∘ m)) (⊙-comp-to-==-β f₂)))
+        (λ f₂' h → ⊙-crd∼-to-== (⊙∘-post f₁ h) == ap (λ m → f₁ ⊙∘ m) (⊙-crd∼-to-== h))
+        (ap ⊙-crd∼-to-== (∙⊙-post {f = f₂}) ∙ 
+        ⊙-crd∼-to-==-β (f₁ ⊙∘ f₂) ∙
+        ! (ap (ap (λ m → f₁ ⊙∘ m)) (⊙-crd∼-to-==-β f₂)))
 
-    ⊙-whisk⊙-conv-l-∙-aux : {f₁ : Y ⊙→ Z} {f₂ f₂' : X ⊙→ Y} (h : f₂ ⊙-comp f₂') →
-      ap (_⊙∘_ f₁) (⊙-comp-to-== (⊙∼-id f₂) ∙ ⊙-comp-to-== h)
+    ⊙-whisk⊙-conv-l-∙-aux : {f₁ : Y ⊙→ Z} {f₂ f₂' : X ⊙→ Y} (h : f₂ ⊙-crd∼ f₂') →
+      ap (_⊙∘_ f₁) (⊙-crd∼-to-== (⊙∼-id f₂) ∙ ⊙-crd∼-to-== h)
         ==
-      ⊙-comp-to-== (⊙∘-post f₁ (⊙∼-id f₂ ∙⊙∼ h))
+      ⊙-crd∼-to-== (⊙∘-post f₁ (⊙∼-id f₂ ∙⊙∼ h))
     ⊙-whisk⊙-conv-l-∙-aux {f₁@(_ , idp)} {f₂@(_ , idp)} =
       ⊙hom-ind f₂
         (λ f₂' h →
-          ap (_⊙∘_ f₁) (⊙-comp-to-== (⊙∼-id f₂) ∙ ⊙-comp-to-== h)
+          ap (_⊙∘_ f₁) (⊙-crd∼-to-== (⊙∼-id f₂) ∙ ⊙-crd∼-to-== h)
             ==
-          ⊙-comp-to-== (⊙∘-post f₁ (⊙∼-id f₂ ∙⊙∼ h)))
-        (ap (λ p → ap (_⊙∘_ f₁) (p ∙ p)) (⊙-comp-to-==-β f₂) ∙
-        ! (ap ⊙-comp-to-== (⊙→∼-to-== ((λ _ → idp) , idp )) ∙ ⊙-comp-to-==-β _))
+          ⊙-crd∼-to-== (⊙∘-post f₁ (⊙∼-id f₂ ∙⊙∼ h)))
+        (ap (λ p → ap (_⊙∘_ f₁) (p ∙ p)) (⊙-crd∼-to-==-β f₂) ∙
+        ! (ap ⊙-crd∼-to-== (⊙→∼-to-== ((λ _ → idp) , idp )) ∙ ⊙-crd∼-to-==-β _))
 
-    ⊙-whisk⊙-conv-l-∙ : {f₁ : Y ⊙→ Z} {f₂ f₂'' f₂' : X ⊙→ Y} (h₁ : f₂ ⊙-comp f₂') (h₂ : f₂' ⊙-comp f₂'') →
-      ap (λ m → f₁ ⊙∘ m) (⊙-comp-to-== h₁ ∙ ⊙-comp-to-== h₂)
+    ⊙-whisk⊙-conv-l-∙ : {f₁ : Y ⊙→ Z} {f₂ f₂'' f₂' : X ⊙→ Y} (h₁ : f₂ ⊙-crd∼ f₂') (h₂ : f₂' ⊙-crd∼ f₂'') →
+      ap (λ m → f₁ ⊙∘ m) (⊙-crd∼-to-== h₁ ∙ ⊙-crd∼-to-== h₂)
         ==
-      ⊙-comp-to-== (⊙∘-post f₁ (h₁ ∙⊙∼ h₂))
+      ⊙-crd∼-to-== (⊙∘-post f₁ (h₁ ∙⊙∼ h₂))
     ⊙-whisk⊙-conv-l-∙ {f₁} {f₂} {f₂''} =
       ⊙hom-ind f₂
-        (λ f₂' h₁ → (h₂ : f₂' ⊙-comp f₂'') →
-          ap (λ m → f₁ ⊙∘ m) (⊙-comp-to-== h₁ ∙ ⊙-comp-to-== h₂)
+        (λ f₂' h₁ → (h₂ : f₂' ⊙-crd∼ f₂'') →
+          ap (λ m → f₁ ⊙∘ m) (⊙-crd∼-to-== h₁ ∙ ⊙-crd∼-to-== h₂)
             ==
-          ⊙-comp-to-== (⊙∘-post f₁ (h₁ ∙⊙∼ h₂)))
+          ⊙-crd∼-to-== (⊙∘-post f₁ (h₁ ∙⊙∼ h₂)))
         ⊙-whisk⊙-conv-l-∙-aux
 
-    !⊙-whisk⊙-conv-l-∙ : {f₁ : Y ⊙→ Z} {f₂ f₂'' f₂' : X ⊙→ Y} (h₁ : f₂ ⊙-comp f₂') (h₂ : f₂' ⊙-comp f₂'') →
-      ! (ap (λ m → f₁ ⊙∘ m) (⊙-comp-to-== h₁ ∙ ⊙-comp-to-== h₂))
+    !⊙-whisk⊙-conv-l-∙ : {f₁ : Y ⊙→ Z} {f₂ f₂'' f₂' : X ⊙→ Y} (h₁ : f₂ ⊙-crd∼ f₂') (h₂ : f₂' ⊙-crd∼ f₂'') →
+      ! (ap (λ m → f₁ ⊙∘ m) (⊙-crd∼-to-== h₁ ∙ ⊙-crd∼-to-== h₂))
         ==
-      ⊙-comp-to-== (!-⊙∼ (⊙∘-post f₁ (h₁ ∙⊙∼ h₂)))
+      ⊙-crd∼-to-== (!-⊙∼ (⊙∘-post f₁ (h₁ ∙⊙∼ h₂)))
     !⊙-whisk⊙-conv-l-∙ {f₁} h₁ h₂ = ap ! (⊙-whisk⊙-conv-l-∙ h₁ h₂) ∙ ! (!⊙-conv (⊙∘-post f₁ (h₁ ∙⊙∼ h₂)))

--- a/HoTT-Agda/core/lib/types/Pushout.agda
+++ b/HoTT-Agda/core/lib/types/Pushout.agda
@@ -9,32 +9,30 @@ open import lib.types.Paths
 
 module lib.types.Pushout where
 
-module _ {i j k} where
+postulate  -- HIT
+  Pushout : ∀ {i j k} → Span {i} {j} {k} → Type (lmax (lmax i j) k)
+
+module _ {i j k} {d : Span {i} {j} {k}} where
 
   postulate  -- HIT
-    Pushout : Span {i} {j} {k} → Type (lmax (lmax i j) k)
+    left : Span.A d → Pushout d
+    right : Span.B d → Pushout d
+    glue : (c : Span.C d) → left (Span.f d c) == right (Span.g d c)
 
-  module _ {d : Span} where
+module PushoutElim {i j k} {d : Span {i} {j} {k}} {l} {P : Pushout {i} {j} {k} d → Type l}
+  (left* : (a : Span.A d) → P (left a))
+  (right* : (b : Span.B d) → P (right b))
+  (glue* : (c : Span.C d) → left* (Span.f d c) == right* (Span.g d c) [ P ↓ glue c ]) where
 
-    postulate  -- HIT
-      left : Span.A d → Pushout d
-      right : Span.B d → Pushout d
-      glue : (c : Span.C d) → left (Span.f d c) == right (Span.g d c)
+  postulate  -- HIT
+    f : Π (Pushout d) P
+    left-β : ∀ a → f (left a) ↦ left* a
+    right-β : ∀ b → f (right b) ↦ right* b
+  {-# REWRITE left-β #-}
+  {-# REWRITE right-β #-}
 
-  module PushoutElim {d : Span} {l} {P : Pushout d → Type l}
-    (left* : (a : Span.A d) → P (left a))
-    (right* : (b : Span.B d) → P (right b))
-    (glue* : (c : Span.C d) → left* (Span.f d c) == right* (Span.g d c) [ P ↓ glue c ]) where
-
-    postulate  -- HIT
-      f : Π (Pushout d) P
-      left-β : ∀ a → f (left a) ↦ left* a
-      right-β : ∀ b → f (right b) ↦ right* b
-    {-# REWRITE left-β #-}
-    {-# REWRITE right-β #-}
-
-    postulate  -- HIT
-      glue-β : (c : Span.C d) → apd f (glue c) == glue* c
+  postulate  -- HIT
+    glue-β : (c : Span.C d) → apd f (glue c) == glue* c
 
 Pushout-elim = PushoutElim.f
 

--- a/HoTT-Agda/core/lib/types/Suspension.agda
+++ b/HoTT-Agda/core/lib/types/Suspension.agda
@@ -163,7 +163,7 @@ module _ {i j k} {X : Type i} {Y : Type j} {Z : Type k} (g : Y → Z) (f : X →
 module _ {i j k} {X : Ptd i} {Y : Ptd j} {Z : Ptd k} (g : Y ⊙→ Z) (f : X ⊙→ Y) where
 
   ⊙Susp-fmap-∘ : ⊙Susp-fmap (g ⊙∘ f) == ⊙Susp-fmap g ⊙∘ ⊙Susp-fmap f
-  ⊙Susp-fmap-∘ = ⊙-comp-to-== ((Susp-fmap-∘-∼ (fst g) (fst f)) , idp)
+  ⊙Susp-fmap-∘ = ⊙-crd∼-to-== ((Susp-fmap-∘-∼ (fst g) (fst f)) , idp)
 
 {- Extract the 'glue component' of a pushout -}
 module _ {i j k} {s : Span {i} {j} {k}} where

--- a/HoTT-Agda/core/lib/wild-cats/Bicat.agda
+++ b/HoTT-Agda/core/lib/wild-cats/Bicat.agda
@@ -1,0 +1,272 @@
+{-# OPTIONS --without-K --rewriting #-}
+
+open import lib.Basics
+open import lib.wild-cats.WildCat
+
+-- two fundamental properties of the associator of a wild bicategory
+
+module lib.wild-cats.Bicat where
+
+module _ {i j} {C : WildCat {i} {j}} (trig : triangle-wc C) (pent : pentagon-wc C)
+  {a b c : ob C} (g : hom C b c) (f : hom C a b) where
+
+  private
+
+    trig-lamb-aux :
+      ap (λ m → ⟦ C ⟧ id₁ C c ◻ m) (ap (λ m → ⟦ C ⟧ m ◻ f) (lamb C g) ∙ α C (id₁ C c) g f) ◃∎
+        =ₛ
+      ap (λ m → ⟦ C ⟧ id₁ C c ◻ m) (lamb C (⟦ C ⟧ g ◻ f)) ◃∎
+    trig-lamb-aux =
+      ap (λ m → ⟦ C ⟧ id₁ C c ◻ m) (ap (λ m → ⟦ C ⟧ m ◻ f) (lamb C g) ∙ α C (id₁ C c) g f) ◃∎
+        =ₛ⟨ ap-∙◃ (λ m → ⟦ C ⟧ id₁ C c ◻ m) (ap (λ m → ⟦ C ⟧ m ◻ f) (lamb C g)) (α C (id₁ C c) g f) ⟩
+      ap (λ m → ⟦ C ⟧ id₁ C c ◻ m) (ap (λ m → ⟦ C ⟧ m ◻ f) (lamb C g)) ◃∙
+      ap (λ m → ⟦ C ⟧ id₁ C c ◻ m) (α C (id₁ C c) g f) ◃∎
+        =ₛ₁⟨ 0 & 1 & ∘-ap (λ m → ⟦ C ⟧ id₁ C c ◻ m) (λ m → ⟦ C ⟧ m ◻ f) (lamb C g) ⟩
+      ap (λ m → ⟦ C ⟧ id₁ C c ◻ ⟦ C ⟧ m ◻ f) (lamb C g) ◃∙
+      ap (λ m → ⟦ C ⟧ id₁ C c ◻ m) (α C (id₁ C c) g f) ◃∎
+        =ₛ⟨ 0 & 1 & apCommSq◃ (λ m → α C (id₁ C c) m f) (lamb C g) ⟩
+      ! (α C (id₁ C c) g f) ◃∙
+      ap (λ m → ⟦ C ⟧ ⟦ C ⟧ id₁ C c ◻ m ◻ f) (lamb C g) ◃∙
+      α C (id₁ C c) (⟦ C ⟧ id₁ C c ◻ g) f ◃∙
+      ap (λ m → ⟦ C ⟧ id₁ C c ◻ m) (α C (id₁ C c) g f) ◃∎
+        =ₛ₁⟨ 1 & 1 & ap-∘ (λ m → ⟦ C ⟧ m ◻ f) (λ m → ⟦ C ⟧ id₁ C c ◻ m) (lamb C g) ⟩
+      ! (α C (id₁ C c) g f) ◃∙
+      ap (λ m → ⟦ C ⟧ m ◻ f) (ap (λ m → ⟦ C ⟧ id₁ C c ◻ m) (lamb C g)) ◃∙
+      α C (id₁ C c) (⟦ C ⟧ id₁ C c ◻ g) f ◃∙
+      ap (λ m → ⟦ C ⟧ id₁ C c ◻ m) (α C (id₁ C c) g f) ◃∎
+        =ₛ⟨ 1 & 1 & !ₛ (ap-seq-=ₛ (λ m → ⟦ C ⟧ m ◻ f) (triangle-wc◃ {C = C} trig (id₁ C c) g)) ⟩
+      ! (α C (id₁ C c) g f) ◃∙
+      ap (λ m → ⟦ C ⟧ m ◻ f) (ap (λ m → ⟦ C ⟧ m ◻ g) (ρ C (id₁ C c))) ◃∙
+      ap (λ m → ⟦ C ⟧ m ◻ f) (α C (id₁ C c) (id₁ C c) g) ◃∙
+      α C (id₁ C c) (⟦ C ⟧ id₁ C c ◻ g) f ◃∙
+      ap (λ m → ⟦ C ⟧ id₁ C c ◻ m) (α C (id₁ C c) g f) ◃∎
+        =ₛ⟨ 0 & 1 & hmtpy-nat-!◃ (λ m → α C m g f) (ρ C (id₁ C c)) ⟩
+      ap (λ m → ⟦ C ⟧ m ◻ ⟦ C ⟧ g ◻ f) (ρ C (id₁ C c)) ◃∙
+      ! (α C (⟦ C ⟧ id₁ C c ◻ id₁ C c) g f) ◃∙
+      ! (ap (λ m → ⟦ C ⟧ ⟦ C ⟧ m ◻ g ◻ f) (ρ C (id₁ C c))) ◃∙
+      ap (λ m → ⟦ C ⟧ m ◻ f) (ap (λ m → ⟦ C ⟧ m ◻ g) (ρ C (id₁ C c))) ◃∙
+      ap (λ m → ⟦ C ⟧ m ◻ f) (α C (id₁ C c) (id₁ C c) g) ◃∙
+      α C (id₁ C c) (⟦ C ⟧ id₁ C c ◻ g) f ◃∙
+      ap (λ m → ⟦ C ⟧ id₁ C c ◻ m) (α C (id₁ C c) g f) ◃∎
+        =ₛ⟨ 1 & 1 & !ₛ (pentagon-wc-!-rot1 {C = C} pent (id₁ C c) (id₁ C c) g f) ⟩
+      ap (λ m → ⟦ C ⟧ m ◻ ⟦ C ⟧ g ◻ f) (ρ C (id₁ C c)) ◃∙
+      α C (id₁ C c) (id₁ C c) (⟦ C ⟧ g ◻ f) ◃∙
+      ! (ap (λ m → ⟦ C ⟧ (id₁ C c) ◻ m) (α C (id₁ C c) g f)) ◃∙
+      ! (α C (id₁ C c) (⟦ C ⟧ (id₁ C c) ◻ g) f) ◃∙
+      ! (ap (λ m → ⟦ C ⟧ m ◻ f) (α C (id₁ C c) (id₁ C c) g)) ◃∙
+      ! (ap (λ m → ⟦ C ⟧ ⟦ C ⟧ m ◻ g ◻ f) (ρ C (id₁ C c))) ◃∙
+      ap (λ m → ⟦ C ⟧ m ◻ f) (ap (λ m → ⟦ C ⟧ m ◻ g) (ρ C (id₁ C c))) ◃∙
+      ap (λ m → ⟦ C ⟧ m ◻ f) (α C (id₁ C c) (id₁ C c) g) ◃∙
+      α C (id₁ C c) (⟦ C ⟧ id₁ C c ◻ g) f ◃∙
+      ap (λ m → ⟦ C ⟧ id₁ C c ◻ m) (α C (id₁ C c) g f) ◃∎
+        =ₛ₁⟨ 6 & 1 & ∘-ap (λ m → ⟦ C ⟧ m ◻ f) (λ m → ⟦ C ⟧ m ◻ g) (ρ C (id₁ C c)) ⟩
+      ap (λ m → ⟦ C ⟧ m ◻ ⟦ C ⟧ g ◻ f) (ρ C (id₁ C c)) ◃∙
+      α C (id₁ C c) (id₁ C c) (⟦ C ⟧ g ◻ f) ◃∙
+      ! (ap (λ m → ⟦ C ⟧ (id₁ C c) ◻ m) (α C (id₁ C c) g f)) ◃∙
+      ! (α C (id₁ C c) (⟦ C ⟧ (id₁ C c) ◻ g) f) ◃∙
+      ! (ap (λ m → ⟦ C ⟧ m ◻ f) (α C (id₁ C c) (id₁ C c) g)) ◃∙
+      ! (ap (λ m → ⟦ C ⟧ ⟦ C ⟧ m ◻ g ◻ f) (ρ C (id₁ C c))) ◃∙
+      ap (λ m → ⟦ C ⟧ ⟦ C ⟧ m ◻ g ◻ f) (ρ C (id₁ C c)) ◃∙
+      ap (λ m → ⟦ C ⟧ m ◻ f) (α C (id₁ C c) (id₁ C c) g) ◃∙
+      α C (id₁ C c) (⟦ C ⟧ id₁ C c ◻ g) f ◃∙
+      ap (λ m → ⟦ C ⟧ id₁ C c ◻ m) (α C (id₁ C c) g f) ◃∎
+        =ₛ₁⟨ 5 & 2 & !-inv-l (ap (λ m → ⟦ C ⟧ ⟦ C ⟧ m ◻ g ◻ f) (ρ C (id₁ C c))) ⟩
+      ap (λ m → ⟦ C ⟧ m ◻ ⟦ C ⟧ g ◻ f) (ρ C (id₁ C c)) ◃∙
+      α C (id₁ C c) (id₁ C c) (⟦ C ⟧ g ◻ f) ◃∙
+      ! (ap (λ m → ⟦ C ⟧ (id₁ C c) ◻ m) (α C (id₁ C c) g f)) ◃∙
+      ! (α C (id₁ C c) (⟦ C ⟧ (id₁ C c) ◻ g) f) ◃∙
+      ! (ap (λ m → ⟦ C ⟧ m ◻ f) (α C (id₁ C c) (id₁ C c) g)) ◃∙
+      idp ◃∙
+      ap (λ m → ⟦ C ⟧ m ◻ f) (α C (id₁ C c) (id₁ C c) g) ◃∙
+      α C (id₁ C c) (⟦ C ⟧ id₁ C c ◻ g) f ◃∙
+      ap (λ m → ⟦ C ⟧ id₁ C c ◻ m) (α C (id₁ C c) g f) ◃∎
+        =ₛ₁⟨ 4 & 3 & !-inv-l (ap (λ m → ⟦ C ⟧ m ◻ f) (α C (id₁ C c) (id₁ C c) g)) ⟩
+      ap (λ m → ⟦ C ⟧ m ◻ ⟦ C ⟧ g ◻ f) (ρ C (id₁ C c)) ◃∙
+      α C (id₁ C c) (id₁ C c) (⟦ C ⟧ g ◻ f) ◃∙
+      ! (ap (λ m → ⟦ C ⟧ (id₁ C c) ◻ m) (α C (id₁ C c) g f)) ◃∙
+      ! (α C (id₁ C c) (⟦ C ⟧ (id₁ C c) ◻ g) f) ◃∙
+      idp ◃∙
+      α C (id₁ C c) (⟦ C ⟧ id₁ C c ◻ g) f ◃∙
+      ap (λ m → ⟦ C ⟧ id₁ C c ◻ m) (α C (id₁ C c) g f) ◃∎
+        =ₛ₁⟨ 3 & 3 & !-inv-l (α C (id₁ C c) (⟦ C ⟧ id₁ C c ◻ g) f) ⟩
+      ap (λ m → ⟦ C ⟧ m ◻ ⟦ C ⟧ g ◻ f) (ρ C (id₁ C c)) ◃∙
+      α C (id₁ C c) (id₁ C c) (⟦ C ⟧ g ◻ f) ◃∙
+      ! (ap (λ m → ⟦ C ⟧ (id₁ C c) ◻ m) (α C (id₁ C c) g f)) ◃∙
+      idp ◃∙
+      ap (λ m → ⟦ C ⟧ id₁ C c ◻ m) (α C (id₁ C c) g f) ◃∎
+        =ₛ₁⟨ 2 & 3 & !-inv-l (ap (λ m → ⟦ C ⟧ id₁ C c ◻ m) (α C (id₁ C c) g f)) ⟩
+      ap (λ m → ⟦ C ⟧ m ◻ ⟦ C ⟧ g ◻ f) (ρ C (id₁ C c)) ◃∙
+      α C (id₁ C c) (id₁ C c) (⟦ C ⟧ g ◻ f) ◃∙
+      idp ◃∎
+        =ₛ₁⟨ 1 & 2 & ∙-unit-r (α C (id₁ C c) (id₁ C c) (⟦ C ⟧ g ◻ f)) ⟩
+      ap (λ m → ⟦ C ⟧ m ◻ ⟦ C ⟧ g ◻ f) (ρ C (id₁ C c)) ◃∙
+      α C (id₁ C c) (id₁ C c) (⟦ C ⟧ g ◻ f) ◃∎
+        =ₛ₁⟨ trig (id₁ C c) (⟦ C ⟧ g ◻ f) ⟩
+      ap (λ m → ⟦ C ⟧ id₁ C c ◻ m) (lamb C (⟦ C ⟧ g ◻ f)) ◃∎ ∎ₛ
+
+    trig-ρ-aux :
+      ap (λ m → ⟦ C ⟧ m ◻ id₁ C a) (ap (λ m → ⟦ C ⟧ g ◻ m) (ρ C f) ∙ ! (α C g f (id₁ C a))) ◃∎
+        =ₛ
+      ap (λ m → ⟦ C ⟧ m ◻ id₁ C a) (ρ C (⟦ C ⟧ g ◻ f)) ◃∎
+    trig-ρ-aux =
+      ap (λ m → ⟦ C ⟧ m ◻ id₁ C a) (ap (λ m → ⟦ C ⟧ g ◻ m) (ρ C f) ∙ ! (α C g f (id₁ C a))) ◃∎
+        =ₛ⟨ =ₛ-in (! (!r-ap-∙ (λ m → ⟦ C ⟧ m ◻ id₁ C a) (ap (λ m → ⟦ C ⟧ g ◻ m) (ρ C f)) (α C g f (id₁ C a)))) ⟩
+      ap (λ m → ⟦ C ⟧ m ◻ id₁ C a) (ap (λ m → ⟦ C ⟧ g ◻ m) (ρ C f)) ◃∙
+      ! (ap (λ m → ⟦ C ⟧ m ◻ id₁ C a) (α C g f (id₁ C a))) ◃∎
+        =ₛ₁⟨ 0 & 1 & ∘-ap (λ m → ⟦ C ⟧ m ◻ id₁ C a) (λ m → ⟦ C ⟧ g ◻ m) (ρ C f) ⟩
+      ap (λ m → ⟦ C ⟧ ⟦ C ⟧ g ◻ m ◻ id₁ C a) (ρ C f) ◃∙
+      ! (ap (λ m → ⟦ C ⟧ m ◻ id₁ C a) (α C g f (id₁ C a))) ◃∎
+        =ₛ⟨ 0 & 1 & hmtpy-nat-∙◃ (λ m → α C g m (id₁ C a)) (ρ C f) ⟩
+      α C g f (id₁ C a) ◃∙
+      ap (λ m → ⟦ C ⟧ g ◻ ⟦ C ⟧ m ◻ id₁ C a) (ρ C f) ◃∙
+      ! (α C g (⟦ C ⟧ f ◻ id₁ C a) (id₁ C a)) ◃∙
+      ! (ap (λ m → ⟦ C ⟧ m ◻ id₁ C a) (α C g f (id₁ C a))) ◃∎
+        =ₛ₁⟨ 1 & 1 & ap-∘ (λ m → ⟦ C ⟧ g ◻ m) (λ m → ⟦ C ⟧ m ◻ id₁ C a) (ρ C f) ⟩
+      α C g f (id₁ C a) ◃∙
+      ap (λ m → ⟦ C ⟧ g ◻ m) (ap (λ m → ⟦ C ⟧ m ◻ id₁ C a) (ρ C f)) ◃∙
+      ! (α C g (⟦ C ⟧ f ◻ id₁ C a) (id₁ C a)) ◃∙
+      ! (ap (λ m → ⟦ C ⟧ m ◻ id₁ C a) (α C g f (id₁ C a))) ◃∎
+        =ₛ⟨ 1 & 1 & ap-seq-=ₛ (λ m → ⟦ C ⟧ g ◻ m) (triangle-wc-rot2 {C = C} trig f (id₁ C a)) ⟩
+      α C g f (id₁ C a) ◃∙
+      ap (λ m → ⟦ C ⟧ g ◻ m) (ap (λ m → ⟦ C ⟧ f ◻ m) (lamb C (id₁ C a))) ◃∙
+      ap (λ m → ⟦ C ⟧ g ◻ m) (! (α C f (id₁ C a) (id₁ C a))) ◃∙
+      ! (α C g (⟦ C ⟧ f ◻ id₁ C a) (id₁ C a)) ◃∙
+      ! (ap (λ m → ⟦ C ⟧ m ◻ id₁ C a) (α C g f (id₁ C a))) ◃∎
+        =ₛ⟨ 0 & 1 & apCommSq2◃ (λ m → α C g f m) (lamb C (id₁ C a)) ⟩
+      ap (λ m → ⟦ C ⟧ ⟦ C ⟧ g ◻ f ◻ m) (lamb C (id₁ C a)) ◃∙
+      α C g f (⟦ C ⟧ id₁ C a ◻ id₁ C a) ◃∙
+      ! (ap (λ m → ⟦ C ⟧ g ◻ ⟦ C ⟧ f ◻ m) (lamb C (id₁ C a))) ◃∙
+      ap (λ m → ⟦ C ⟧ g ◻ m) (ap (λ m → ⟦ C ⟧ f ◻ m) (lamb C (id₁ C a))) ◃∙
+      ap (λ m → ⟦ C ⟧ g ◻ m) (! (α C f (id₁ C a) (id₁ C a))) ◃∙
+      ! (α C g (⟦ C ⟧ f ◻ id₁ C a) (id₁ C a)) ◃∙
+      ! (ap (λ m → ⟦ C ⟧ m ◻ id₁ C a) (α C g f (id₁ C a))) ◃∎
+        =ₛ⟨ 1 & 1 & !ₛ (pentagon-wc-rot4 {C = C} pent g f (id₁ C a) (id₁ C a)) ⟩
+      ap (λ m → ⟦ C ⟧ ⟦ C ⟧ g ◻ f ◻ m) (lamb C (id₁ C a)) ◃∙
+      ! (α C (⟦ C ⟧ g ◻ f) (id₁ C a) (id₁ C a)) ◃∙
+      ap (λ m → ⟦ C ⟧ m ◻ (id₁ C a)) (α C g f (id₁ C a)) ◃∙
+      α C g (⟦ C ⟧ f ◻ (id₁ C a)) (id₁ C a) ◃∙
+      ap (λ m → ⟦ C ⟧ g ◻ m) (α C f (id₁ C a) (id₁ C a)) ◃∙
+      ! (ap (λ m → ⟦ C ⟧ g ◻ ⟦ C ⟧ f ◻ m) (lamb C (id₁ C a))) ◃∙
+      ap (λ m → ⟦ C ⟧ g ◻ m) (ap (λ m → ⟦ C ⟧ f ◻ m) (lamb C (id₁ C a))) ◃∙
+      ap (λ m → ⟦ C ⟧ g ◻ m) (! (α C f (id₁ C a) (id₁ C a))) ◃∙
+      ! (α C g (⟦ C ⟧ f ◻ id₁ C a) (id₁ C a)) ◃∙
+      ! (ap (λ m → ⟦ C ⟧ m ◻ id₁ C a) (α C g f (id₁ C a))) ◃∎
+        =ₛ₁⟨ 6 & 1 & ∘-ap (λ m → ⟦ C ⟧ g ◻ m) (λ m → ⟦ C ⟧ f ◻ m) (lamb C (id₁ C a)) ⟩
+      ap (λ m → ⟦ C ⟧ ⟦ C ⟧ g ◻ f ◻ m) (lamb C (id₁ C a)) ◃∙
+      ! (α C (⟦ C ⟧ g ◻ f) (id₁ C a) (id₁ C a)) ◃∙
+      ap (λ m → ⟦ C ⟧ m ◻ (id₁ C a)) (α C g f (id₁ C a)) ◃∙
+      α C g (⟦ C ⟧ f ◻ (id₁ C a)) (id₁ C a) ◃∙
+      ap (λ m → ⟦ C ⟧ g ◻ m) (α C f (id₁ C a) (id₁ C a)) ◃∙
+      ! (ap (λ m → ⟦ C ⟧ g ◻ ⟦ C ⟧ f ◻ m) (lamb C (id₁ C a))) ◃∙
+      ap (λ m → ⟦ C ⟧ g ◻ ⟦ C ⟧ f ◻ m) (lamb C (id₁ C a)) ◃∙
+      ap (λ m → ⟦ C ⟧ g ◻ m) (! (α C f (id₁ C a) (id₁ C a))) ◃∙
+      ! (α C g (⟦ C ⟧ f ◻ id₁ C a) (id₁ C a)) ◃∙
+      ! (ap (λ m → ⟦ C ⟧ m ◻ id₁ C a) (α C g f (id₁ C a))) ◃∎
+        =ₛ₁⟨ 5 & 2 & !-inv-l (ap (λ m → ⟦ C ⟧ g ◻ ⟦ C ⟧ f ◻ m) (lamb C (id₁ C a))) ⟩
+      ap (λ m → ⟦ C ⟧ ⟦ C ⟧ g ◻ f ◻ m) (lamb C (id₁ C a)) ◃∙
+      ! (α C (⟦ C ⟧ g ◻ f) (id₁ C a) (id₁ C a)) ◃∙
+      ap (λ m → ⟦ C ⟧ m ◻ (id₁ C a)) (α C g f (id₁ C a)) ◃∙
+      α C g (⟦ C ⟧ f ◻ (id₁ C a)) (id₁ C a) ◃∙
+      ap (λ m → ⟦ C ⟧ g ◻ m) (α C f (id₁ C a) (id₁ C a)) ◃∙
+      idp ◃∙
+      ap (λ m → ⟦ C ⟧ g ◻ m) (! (α C f (id₁ C a) (id₁ C a))) ◃∙
+      ! (α C g (⟦ C ⟧ f ◻ id₁ C a) (id₁ C a)) ◃∙
+      ! (ap (λ m → ⟦ C ⟧ m ◻ id₁ C a) (α C g f (id₁ C a))) ◃∎
+        =ₛ₁⟨ 5 & 2 & ap-! (λ m → ⟦ C ⟧ g ◻ m) (α C f (id₁ C a) (id₁ C a))  ⟩
+      ap (λ m → ⟦ C ⟧ ⟦ C ⟧ g ◻ f ◻ m) (lamb C (id₁ C a)) ◃∙
+      ! (α C (⟦ C ⟧ g ◻ f) (id₁ C a) (id₁ C a)) ◃∙
+      ap (λ m → ⟦ C ⟧ m ◻ (id₁ C a)) (α C g f (id₁ C a)) ◃∙
+      α C g (⟦ C ⟧ f ◻ (id₁ C a)) (id₁ C a) ◃∙
+      ap (λ m → ⟦ C ⟧ g ◻ m) (α C f (id₁ C a) (id₁ C a)) ◃∙
+      ! (ap (λ m → ⟦ C ⟧ g ◻ m) (α C f (id₁ C a) (id₁ C a))) ◃∙
+      ! (α C g (⟦ C ⟧ f ◻ id₁ C a) (id₁ C a)) ◃∙
+      ! (ap (λ m → ⟦ C ⟧ m ◻ id₁ C a) (α C g f (id₁ C a))) ◃∎
+        =ₛ₁⟨ 4 & 2 & !-inv-r (ap (λ m → ⟦ C ⟧ g ◻ m) (α C f (id₁ C a) (id₁ C a))) ⟩
+      ap (λ m → ⟦ C ⟧ ⟦ C ⟧ g ◻ f ◻ m) (lamb C (id₁ C a)) ◃∙
+      ! (α C (⟦ C ⟧ g ◻ f) (id₁ C a) (id₁ C a)) ◃∙
+      ap (λ m → ⟦ C ⟧ m ◻ (id₁ C a)) (α C g f (id₁ C a)) ◃∙
+      α C g (⟦ C ⟧ f ◻ (id₁ C a)) (id₁ C a) ◃∙
+      idp ◃∙
+      ! (α C g (⟦ C ⟧ f ◻ id₁ C a) (id₁ C a)) ◃∙
+      ! (ap (λ m → ⟦ C ⟧ m ◻ id₁ C a) (α C g f (id₁ C a))) ◃∎
+        =ₛ₁⟨ 3 & 3 & !-inv-r (α C g (⟦ C ⟧ f ◻ id₁ C a) (id₁ C a)) ⟩
+      ap (λ m → ⟦ C ⟧ ⟦ C ⟧ g ◻ f ◻ m) (lamb C (id₁ C a)) ◃∙
+      ! (α C (⟦ C ⟧ g ◻ f) (id₁ C a) (id₁ C a)) ◃∙
+      ap (λ m → ⟦ C ⟧ m ◻ (id₁ C a)) (α C g f (id₁ C a)) ◃∙
+      idp ◃∙
+      ! (ap (λ m → ⟦ C ⟧ m ◻ id₁ C a) (α C g f (id₁ C a))) ◃∎
+        =ₛ₁⟨ 2 & 3 & !-inv-r (ap (λ m → ⟦ C ⟧ m ◻ id₁ C a) (α C g f (id₁ C a))) ⟩
+      ap (λ m → ⟦ C ⟧ ⟦ C ⟧ g ◻ f ◻ m) (lamb C (id₁ C a)) ◃∙
+      ! (α C (⟦ C ⟧ g ◻ f) (id₁ C a) (id₁ C a)) ◃∙
+      idp ◃∎
+        =ₛ₁⟨ 1 & 2 & ∙-unit-r (! (α C (⟦ C ⟧ g ◻ f) (id₁ C a) (id₁ C a))) ⟩
+      ap (λ m → ⟦ C ⟧ ⟦ C ⟧ g ◻ f ◻ m) (lamb C (id₁ C a)) ◃∙
+      ! (α C (⟦ C ⟧ g ◻ f) (id₁ C a) (id₁ C a)) ◃∎
+        =ₛ⟨ !ₛ (triangle-wc-rot2 {C = C} trig (⟦ C ⟧ g ◻ f) (id₁ C a)) ⟩
+      ap (λ m → ⟦ C ⟧ m ◻ id₁ C a) (ρ C (⟦ C ⟧ g ◻ f)) ◃∎ ∎ₛ
+
+  trig-lamb :
+    ap (λ m → ⟦ C ⟧ m ◻ f) (lamb C g) ◃∙
+    α C (id₁ C c) g f ◃∎
+      =ₛ
+    lamb C (⟦ C ⟧ g ◻ f) ◃∎
+  trig-lamb = =ₛ-in (id₁-comm-reflect-l {C = C} (=ₛ-out (trig-lamb-aux)))
+
+  trig-lamb-rot1 :
+    ap (λ m → ⟦ C ⟧ m ◻ f) (lamb C g) ◃∎
+      =ₛ
+    lamb C (⟦ C ⟧ g ◻ f) ◃∙
+    ! (α C (id₁ C c) g f) ◃∎
+  trig-lamb-rot1 = post-rotate-in trig-lamb
+
+  trig-lamb-rot2 :
+    α C (id₁ C c) g f ◃∙
+    ! (lamb C (⟦ C ⟧ g ◻ f)) ◃∎
+      =ₛ
+    ap (λ m → ⟦ C ⟧ m ◻ f) (! (lamb C g)) ◃∎
+  trig-lamb-rot2 =
+    α C (id₁ C c) g f ◃∙
+    ! (lamb C (⟦ C ⟧ g ◻ f)) ◃∎
+      =ₛ⟨ post-rotate'-in (pre-rotate-in trig-lamb) ⟩
+    ! (ap (λ m → ⟦ C ⟧ m ◻ f) (lamb C g)) ◃∎
+      =ₛ₁⟨ !-ap (λ m → ⟦ C ⟧ m ◻ f) (lamb C g) ⟩
+    ap (λ m → ⟦ C ⟧ m ◻ f) (! (lamb C g)) ◃∎ ∎ₛ
+
+  trig-ρ :
+    ap (λ m → ⟦ C ⟧ g ◻ m) (ρ C f) ◃∙
+    ! (α C g f (id₁ C a)) ◃∎
+      =ₛ
+    ρ C (⟦ C ⟧ g ◻ f) ◃∎
+  trig-ρ = =ₛ-in (id₁-comm-reflect-r {C = C} (=ₛ-out (trig-ρ-aux)))
+
+  trig-ρ-rot1 :
+    ap (λ m → ⟦ C ⟧ g ◻ m) (ρ C f) ◃∙
+    ! (α C g f (id₁ C a)) ◃∙
+    ! (ρ C (⟦ C ⟧ g ◻ f)) ◃∎
+      =ₛ
+    []
+  trig-ρ-rot1 = post-rotate'-in trig-ρ
+
+module _ {i j} {C : WildCat {i} {j}} (trig : triangle-wc C) (pent : pentagon-wc C) where
+
+  private
+    lamb-ρ-id₁-aux : {a : ob C} → ap (λ m → ⟦ C ⟧ m ◻ id₁ C a) (lamb C (id₁ C a)) ◃∎ =ₛ ap (λ m → ⟦ C ⟧ m ◻ id₁ C a) (ρ C (id₁ C a)) ◃∎
+    lamb-ρ-id₁-aux {a} = 
+      ap (λ m → ⟦ C ⟧ m ◻ id₁ C a) (lamb C (id₁ C a)) ◃∎
+        =ₛ⟨ trig-lamb-rot1 {C = C} trig pent (id₁ C a) (id₁ C a) ⟩
+      lamb C (⟦ C ⟧ id₁ C a ◻ id₁ C a) ◃∙
+      ! (α C (id₁ C a) (id₁ C a) (id₁ C a)) ◃∎
+        =ₛ⟨ 0 & 1 & apCommSq2◃-rev (lamb C) (lamb C (id₁ C a))  ⟩
+      ! (ap (λ m → m) (lamb C (id₁ C a))) ◃∙
+      lamb C (id₁ C a) ◃∙
+      ap (λ m → ⟦ C ⟧ id₁ C a ◻ m) (lamb C (id₁ C a)) ◃∙
+      ! (α C (id₁ C a) (id₁ C a) (id₁ C a)) ◃∎
+        =ₛ₁⟨ 0 & 2 & !-ap-idf-l (lamb C (id₁ C a)) ⟩
+      idp ◃∙
+      ap (λ m → ⟦ C ⟧ id₁ C a ◻ m) (lamb C (id₁ C a)) ◃∙
+      ! (α C (id₁ C a) (id₁ C a) (id₁ C a)) ◃∎
+        =ₛ₁⟨ ! (=ₛ-out (triangle-wc-rot2 {C = C} trig (id₁ C a) (id₁ C a))) ⟩
+      ap (λ m → ⟦ C ⟧ m ◻ id₁ C a) (ρ C (id₁ C a)) ◃∎ ∎ₛ
+
+  lamb-ρ-id₁ : {a : ob C} → lamb C (id₁ C a) == ρ C (id₁ C a)
+  lamb-ρ-id₁ {a} = id₁-comm-reflect-r {C = C} (=ₛ-out (lamb-ρ-id₁-aux))

--- a/HoTT-Agda/core/lib/wild-cats/Colim-wc.agda
+++ b/HoTT-Agda/core/lib/wild-cats/Colim-wc.agda
@@ -83,7 +83,7 @@ module _ {i j} {C : WildCat {i} {j}} {ℓv ℓe} {G : Graph ℓv ℓe} where
         []) where
 
       abstract
-        colim-act-dmap : {Δ₁ Δ₂ : Diagram G C} ((μ , _) : diag-eqv Δ₁ Δ₂)
+        colim-act-dmap : {Δ₁ Δ₂ : Diagram G C} ((μ , _) : diag-ueqv Δ₁ Δ₂)
           → {a : ob C} (K : Cocone-wc Δ₂ a) → is-colim K → is-colim (act-dmap-coc μ K)
         colim-act-dmap {Δ₁} = diag-ind (λ Δ₂ (μ , _) → ∀ {a} K → is-colim K → is-colim (act-dmap-coc μ K))
           λ K cl → λ b → coe (ap is-equiv (app= (ap post-cmp-coc (act-dmap-coc-id trig trig-ρ K)) b)) (cl b) 

--- a/HoTT-Agda/core/lib/wild-cats/Colim-wc.agda
+++ b/HoTT-Agda/core/lib/wild-cats/Colim-wc.agda
@@ -6,6 +6,7 @@ open import lib.Equivalence2
 open import lib.types.Sigma
 open import lib.types.Graph
 open import lib.wild-cats.WildCat
+open import lib.wild-cats.Bicat
 open import lib.wild-cats.Diagram-wc
 open import lib.wild-cats.Diag-coher-wc
 open import lib.wild-cats.Diagram-wc-SIP
@@ -36,22 +37,18 @@ module _ {i j} {C : WildCat {i} {j}} {ℓv ℓe} {G : Graph ℓv ℓe} where
 
     module _ {a₁ a₂ : ob C} {K₁ : Cocone-wc D a₁} {K₂ : Cocone-wc D a₂} (pent : pentagon-wc C) where
 
-      module _ (trig : {a b c : ob C} (g : hom C b c) (f : hom C a b) →
-        α C (id₁ C c) g f ◃∙
-        ! (lamb C (⟦ C ⟧ g ◻ f)) ◃∎
-          =ₛ
-        ap (λ m → ⟦ C ⟧ m ◻ f) (! (lamb C g)) ◃∎) where
+      module _ (trig : triangle-wc C) where
 
         abstract
           col-wc-unq : (cl : is-colim K₁) → is-colim K₂ → equiv-wc C (cogap-map-wc cl K₂)
           fst (col-wc-unq cl1 cl2) = cogap-map-wc cl2 K₁
           fst (snd (col-wc-unq cl1 cl2)) = equiv-is-inj (cl1 a₁) (id₁ C a₁) (⟦ C ⟧ cogap-map-wc cl2 K₁ ◻ cogap-map-wc cl1 K₂)
-            (pst-cmp-id trig K₁ ∙
+            (pst-cmp-id trig pent K₁ ∙
             ! (pst-cmp-∘ pent (cogap-map-wc cl2 K₁) (cogap-map-wc cl1 K₂) K₁ ∙
             ap (λ K → post-cmp-coc K a₁ (cogap-map-wc cl2 K₁)) (cogap-map-wc-β cl1) ∙
             cogap-map-wc-β cl2))
           snd (snd (col-wc-unq cl1 cl2)) = equiv-is-inj (cl2 a₂) (id₁ C a₂) (⟦ C ⟧ cogap-map-wc cl1 K₂ ◻ cogap-map-wc cl2 K₁)
-            (pst-cmp-id trig K₂ ∙
+            (pst-cmp-id trig pent K₂ ∙
             ! (pst-cmp-∘ pent (cogap-map-wc cl1 K₂) (cogap-map-wc cl2 K₁) K₂ ∙
             ap (λ K → post-cmp-coc K a₂ (cogap-map-wc cl1 K₂)) (cogap-map-wc-β cl2) ∙
             cogap-map-wc-β cl1))
@@ -73,17 +70,11 @@ module _ {i j} {C : WildCat {i} {j}} {ℓv ℓe} {G : Graph ℓv ℓe} where
 
     open SIP-Diag {G = G} {C = C} P id₁-eqv idsys public
 
-    module _ (trig : triangle-wc C)
-      -- we also assume a standard property of bicategories
-      (trig-ρ : {a b c : ob C} (g : hom C b c) (f : hom C a b) →
-        ap (λ m → ⟦ C ⟧ g ◻ m) (ρ C f) ◃∙
-        ! (α C g f (id₁ C a)) ◃∙
-        ! (ρ C (⟦ C ⟧ g ◻ f)) ◃∎
-          =ₛ
-        []) where
+    module _ (trig : triangle-wc C) (pent : pentagon-wc C) where
 
       abstract
         colim-act-dmap : {Δ₁ Δ₂ : Diagram G C} ((μ , _) : diag-ueqv Δ₁ Δ₂)
           → {a : ob C} (K : Cocone-wc Δ₂ a) → is-colim K → is-colim (act-dmap-coc μ K)
         colim-act-dmap {Δ₁} = diag-ind (λ Δ₂ (μ , _) → ∀ {a} K → is-colim K → is-colim (act-dmap-coc μ K))
-          λ K cl → λ b → coe (ap is-equiv (app= (ap post-cmp-coc (act-dmap-coc-id trig trig-ρ K)) b)) (cl b) 
+          λ K cl → λ b → coe (ap is-equiv (app= (ap post-cmp-coc (act-dmap-coc-id trig pent K)) b)) (cl b) 
+

--- a/HoTT-Agda/core/lib/wild-cats/Diag-coher-wc.agda
+++ b/HoTT-Agda/core/lib/wild-cats/Diag-coher-wc.agda
@@ -3,6 +3,7 @@
 open import lib.Basics
 open import lib.types.Graph
 open import lib.wild-cats.WildCat
+open import lib.wild-cats.Bicat
 open import lib.wild-cats.Diagram-wc
 open import lib.wild-cats.Cone-wc-SIP
 open import lib.wild-cats.Cocone-wc-SIP
@@ -17,14 +18,7 @@ open Map-diag
 
 module _ {ℓv ℓe ℓc₁ ℓc₂} {G : Graph ℓv ℓe} {C : WildCat {ℓc₁} {ℓc₂}} where
 
-  module _ (trig : triangle-wc C)
-    -- we also assume a standard property of bicategories
-    (trig-ρ : {a b c : ob C} (g : hom C b c) (f : hom C a b) →
-      ap (λ m → ⟦ C ⟧ g ◻ m) (ρ C f) ◃∙
-      ! (α C g f (id₁ C a)) ◃∙
-      ! (ρ C (⟦ C ⟧ g ◻ f)) ◃∎
-        =ₛ
-      []) where
+  module _ (trig : triangle-wc C) (pent : pentagon-wc C) where
 
     abstract
       act-dmap-coc-id : {a : ob C} {Δ : Diagram G C} (K : Cocone-wc Δ a)
@@ -78,18 +72,10 @@ module _ {ℓv ℓe ℓc₁ ℓc₂} {G : Graph ℓv ℓe} {C : WildCat {ℓc₁
             ! (α C (leg K y) (D₁ Δ f) (id₁ C (D₀ Δ x))) ◃∙
             ! (ρ C (⟦ C ⟧ leg K y ◻ D₁ Δ f)) ◃∙
             ap (λ m → m) (tri K f) ◃∙ ρ C (leg K x) ◃∎
-              =ₛ⟨ 0 & 3 & trig-ρ (leg K y) (D₁ Δ f) ⟩
+              =ₛ⟨ 0 & 3 & trig-ρ-rot1 {C = C} trig pent (leg K y) (D₁ Δ f) ⟩
             ap (λ m → m) (tri K f) ◃∙ ρ C (leg K x) ◃∎
               =ₛ₁⟨ 0 & 1 & ap-idf (tri K f) ⟩
             tri K f ◃∙ ρ C (leg K x) ◃∎ ∎ₛ
-
-  -- we assume a standard property of bicategories
-  module _ (trig-lamb : {a b c : ob C} (g : hom C b c) (f : hom C a b) →
-      α C (id₁ C c) g f ◃∙ 
-      ! (lamb C (⟦ C ⟧ g ◻ f)) ◃∎
-        =ₛ
-      ap (λ m → ⟦ C ⟧ m ◻ f) (! (lamb C g)) ◃∎)
-    where
 
     abstract
 
@@ -114,11 +100,11 @@ module _ {ℓv ℓe ℓc₁ ℓc₂} {G : Graph ℓv ℓe} {C : WildCat {ℓc₁
           α C (id₁ C a) (leg K y) (D₁ Δ f) ◃∙
           ! (lamb C (⟦ C ⟧ leg K y ◻ D₁ Δ f)) ◃∙
           tri K f ◃∎
-            =ₛ⟨ 0 & 2 & trig-lamb (leg K y) (D₁ Δ f) ⟩
+            =ₛ⟨ 0 & 2 & trig-lamb-rot2 {C = C} trig pent (leg K y) (D₁ Δ f) ⟩
           ap (λ m → ⟦ C ⟧ m ◻ D₁ Δ f) (! (lamb C (leg K y))) ◃∙
           tri K f ◃∎ ∎ₛ))
 
-  -- we assume the pentagon identity of a bicat
+  -- we now assume just the pentagon identity of a bicat
   module _ (pent : pentagon-wc C) where
 
     abstract

--- a/HoTT-Agda/core/lib/wild-cats/Diag-coher-wc.agda
+++ b/HoTT-Agda/core/lib/wild-cats/Diag-coher-wc.agda
@@ -84,7 +84,7 @@ module _ {ℓv ℓe ℓc₁ ℓc₂} {G : Graph ℓv ℓe} {C : WildCat {ℓc₁
             tri K f ◃∙ ρ C (leg K x) ◃∎ ∎ₛ
 
   -- we assume a standard property of bicategories
-  module _ (trig : {a b c : ob C} (g : hom C b c) (f : hom C a b) →
+  module _ (trig-lamb : {a b c : ob C} (g : hom C b c) (f : hom C a b) →
       α C (id₁ C c) g f ◃∙ 
       ! (lamb C (⟦ C ⟧ g ◻ f)) ◃∎
         =ₛ
@@ -114,7 +114,7 @@ module _ {ℓv ℓe ℓc₁ ℓc₂} {G : Graph ℓv ℓe} {C : WildCat {ℓc₁
           α C (id₁ C a) (leg K y) (D₁ Δ f) ◃∙
           ! (lamb C (⟦ C ⟧ leg K y ◻ D₁ Δ f)) ◃∙
           tri K f ◃∎
-            =ₛ⟨ 0 & 2 & trig (leg K y) (D₁ Δ f) ⟩
+            =ₛ⟨ 0 & 2 & trig-lamb (leg K y) (D₁ Δ f) ⟩
           ap (λ m → ⟦ C ⟧ m ◻ D₁ Δ f) (! (lamb C (leg K y))) ◃∙
           tri K f ◃∎ ∎ₛ))
 

--- a/HoTT-Agda/core/lib/wild-cats/Diagram-wc-SIP.agda
+++ b/HoTT-Agda/core/lib/wild-cats/Diagram-wc-SIP.agda
@@ -23,12 +23,12 @@ module _ {ℓv ℓe} {G : Graph ℓv ℓe} where
     (P : ∀ {a b} (f : hom C a b) → Type ℓ) (id₁-eqv : ∀ a → P (id₁ C a))
     (idsys : ∀ a → ID-sys _ (λ b → Σ (hom C a b) P) a (id₁ C a , id₁-eqv a)) where
 
-    diag-eqv : Diagram G C → Diagram G C → Type (lmax (lmax (lmax (lmax ℓv ℓe) ℓ₁) ℓ₂) ℓ)
-    diag-eqv Δ₁ Δ₂ = Σ (Map-diag Δ₁ Δ₂) (λ μ → ∀ x → P (map-comp μ x))
+    diag-ueqv : Diagram G C → Diagram G C → Type (lmax (lmax (lmax (lmax ℓv ℓe) ℓ₁) ℓ₂) ℓ)
+    diag-ueqv Δ₁ Δ₂ = Σ (Map-diag Δ₁ Δ₂) (λ μ → ∀ x → P (map-comp μ x))
 
-    diag-eqv-id : {Δ : Diagram G C} → diag-eqv Δ Δ
-    fst (diag-eqv-id {Δ}) = diag-map-id Δ
-    snd diag-eqv-id _ = id₁-eqv _
+    diag-ueqv-id : {Δ : Diagram G C} → diag-ueqv Δ Δ
+    fst (diag-ueqv-id {Δ}) = diag-map-id Δ
+    snd diag-ueqv-id _ = id₁-eqv _
 
     module _ {Δ₁ : Diagram G C} where
 
@@ -49,7 +49,7 @@ module _ {ℓv ℓe} {G : Graph ℓv ℓe} where
                 {{pathto-is-contr (⟦ C ⟧ id₁ C _ ◻ D₁ Δ₁ f)}}}}
 
       abstract
-        diag-contr : is-contr (Σ (Diagram G C) (λ Δ₂ → diag-eqv Δ₁ Δ₂))
+        diag-contr : is-contr (Σ (Diagram G C) (λ Δ₂ → diag-ueqv Δ₁ Δ₂))
         diag-contr = equiv-preserves-level lemma {{diag-contr-aux}}
           where
             lemma :
@@ -58,7 +58,7 @@ module _ {ℓv ℓe} {G : Graph ℓv ℓe} where
                   Σ (hom C (fst (M x)) (fst (M y))) (λ k →
                     ⟦ C ⟧ k ◻ fst (snd (M x)) == ⟦ C ⟧ fst (snd (M y)) ◻ D₁ Δ₁ f))
                 ≃
-              Σ (Diagram G C) (λ Δ₂ → diag-eqv Δ₁ Δ₂)
+              Σ (Diagram G C) (λ Δ₂ → diag-ueqv Δ₁ Δ₂)
             lemma =
               equiv
                (λ (M , sq) →
@@ -67,8 +67,8 @@ module _ {ℓv ℓe} {G : Graph ℓv ℓe} where
                (λ _ → idp)
                λ _ → idp
 
-      diag-ind : ∀ {k} (Q : (Δ₂ : Diagram G C) → (diag-eqv Δ₁ Δ₂ → Type k))
-        → Q Δ₁ diag-eqv-id → {Δ₂ : Diagram G C} (e : diag-eqv Δ₁ Δ₂) → Q Δ₂ e
+      diag-ind : ∀ {k} (Q : (Δ₂ : Diagram G C) → (diag-ueqv Δ₁ Δ₂ → Type k))
+        → Q Δ₁ diag-ueqv-id → {Δ₂ : Diagram G C} (e : diag-ueqv Δ₁ Δ₂) → Q Δ₂ e
       diag-ind Q = ID-ind-map Q diag-contr
 
   -- SIP for maps of diagrams valued in an arbitrary wild category

--- a/HoTT-Agda/core/lib/wild-cats/Ptd-wc.agda
+++ b/HoTT-Agda/core/lib/wild-cats/Ptd-wc.agda
@@ -11,9 +11,9 @@ module lib.wild-cats.Ptd-wc where
   hom (Ptd-wc _) X Y = X ⊙→ Y
   id₁ (Ptd-wc _) X = ⊙idf X
   _◻_ (Ptd-wc _) g f = g ⊙∘ f
-  ρ (Ptd-wc _) f = ⊙-comp-to-== (⊙∘-runit f) 
-  lamb (Ptd-wc _) f = ⊙-comp-to-== (⊙∘-lunit f)
-  α (Ptd-wc _) h g f = ⊙-comp-to-== (⊙∘-assoc-comp h g f)
+  ρ (Ptd-wc _) f = ⊙-crd∼-to-== (⊙∘-runit f) 
+  lamb (Ptd-wc _) f = ⊙-crd∼-to-== (⊙∘-lunit f)
+  α (Ptd-wc _) h g f = ⊙-crd∼-to-== (⊙∘-assoc-comp h g f)
 
   PtdFunctor : (i j : ULevel) → Type (lsucc (lmax i j))
   PtdFunctor i j = Functor-wc (Ptd-wc i) (Ptd-wc j)

--- a/HoTT-Agda/core/lib/wild-cats/Ptd-wc.agda
+++ b/HoTT-Agda/core/lib/wild-cats/Ptd-wc.agda
@@ -13,7 +13,7 @@ module lib.wild-cats.Ptd-wc where
   _◻_ (Ptd-wc _) g f = g ⊙∘ f
   ρ (Ptd-wc _) f = ⊙-crd∼-to-== (⊙∘-runit f) 
   lamb (Ptd-wc _) f = ⊙-crd∼-to-== (⊙∘-lunit f)
-  α (Ptd-wc _) h g f = ⊙-crd∼-to-== (⊙∘-assoc-comp h g f)
+  α (Ptd-wc _) h g f = ⊙-crd∼-to-== (⊙∘-assoc-crd h g f)
 
   PtdFunctor : (i j : ULevel) → Type (lsucc (lmax i j))
   PtdFunctor i j = Functor-wc (Ptd-wc i) (Ptd-wc j)

--- a/HoTT-Agda/core/lib/wild-cats/WildCat.agda
+++ b/HoTT-Agda/core/lib/wild-cats/WildCat.agda
@@ -28,6 +28,22 @@ infixr 82 ⟦_⟧_◻_
 ⟦_⟧_◻_ : ∀ {i j} (C : WildCat {i} {j}) {a b c : ob C} → hom C b c → hom C a b → hom C a c
 ⟦_⟧_◻_ ξ g f = _◻_ ξ g f 
 
+id₁-lft-≃ : ∀ {i j} {C : WildCat {i} {j}} → ∀ {x y} → hom C x y ≃ hom C x y
+fst (id₁-lft-≃ {C = C}) f = ⟦ C ⟧ id₁ C _ ◻ f
+snd (id₁-lft-≃ {C = C}) = ∼-preserves-equiv (λ x → lamb C x) (idf-is-equiv _)
+
+id₁-rght-≃ : ∀ {i j} {C : WildCat {i} {j}} → ∀ {x y} → hom C x y ≃ hom C x y
+fst (id₁-rght-≃ {C = C}) f = ⟦ C ⟧ f ◻ id₁ C _
+snd (id₁-rght-≃ {C = C}) = ∼-preserves-equiv (λ x → ρ C x) (idf-is-equiv _)
+
+id₁-comm-reflect-l : ∀ {i j} {C : WildCat {i} {j}} → ∀ {x y} {f₁ f₂ : hom C x y} {p₁ p₂ : f₁ == f₂}
+  → ap (λ m → ⟦ C ⟧ id₁ C _ ◻ m) p₁ == ap (λ m → ⟦ C ⟧ id₁ C _ ◻ m) p₂ → p₁ == p₂
+id₁-comm-reflect-l {C = C} e = equiv-is-inj (ap-is-equiv (snd (id₁-lft-≃ {C = C})) _ _) _ _ e
+
+id₁-comm-reflect-r : ∀ {i j} {C : WildCat {i} {j}} → ∀ {x y} {f₁ f₂ : hom C x y} {p₁ p₂ : f₁ == f₂}
+  → ap (λ m → ⟦ C ⟧ m ◻ id₁ C _) p₁ == ap (λ m → ⟦ C ⟧ m ◻ id₁ C _) p₂ → p₁ == p₂
+id₁-comm-reflect-r {C = C} e = equiv-is-inj (ap-is-equiv (snd (id₁-rght-≃ {C = C})) _ _) _ _ e
+
 record Functor-wc {i₁ j₁ i₂ j₂} (B : WildCat {i₁} {j₁}) (C : WildCat {i₂} {j₂}) :
   Type (lmax (lmax i₁ j₁) (lmax i₂ j₂)) where
   constructor functor-wc
@@ -138,6 +154,14 @@ module _ {i j} {C : WildCat {i} {j}} (trig : triangle-wc C)
         =ₛ
       []
     triangle-wc-rot1 = post-rotate'-in triangle-wc◃
+    
+    triangle-wc-rot2 :
+      ap (λ m → ⟦ C ⟧ m ◻ f) (ρ C g) ◃∎
+        =ₛ
+      ap (λ m → ⟦ C ⟧ g ◻ m) (lamb C f) ◃∙
+      ! (α C g (id₁ C b) f) ◃∎
+    triangle-wc-rot2 = post-rotate-in triangle-wc◃
+
 
 -- pentagon identity
 
@@ -181,6 +205,12 @@ module _ {i j} {C : WildCat {i} {j}} (pent : pentagon-wc C)
       ! (α C k g (⟦ C ⟧ h ◻ f)) ◃∙ ! (α C (⟦ C ⟧ k ◻ g) h f) ◃∎
     pentagon-wc-! = !-=ₛ pentagon-wc◃
 
+    pentagon-wc-!-rot1 :
+      α C k g (⟦ C ⟧ h ◻ f) ◃∙ ! (ap (λ m → ⟦ C ⟧ k ◻ m) (α C g h f)) ◃∙ ! (α C k (⟦ C ⟧ g ◻ h) f) ◃∙ ! (ap (λ m → ⟦ C ⟧ m ◻ f) (α C k g h)) ◃∎ 
+        =ₛ
+      ! (α C (⟦ C ⟧ k ◻ g) h f) ◃∎
+    pentagon-wc-!-rot1 = pre-rotate-out pentagon-wc-!
+
     pentagon-wc-rot1 : 
       ! (α C (⟦ C ⟧ k ◻ g) h f) ◃∙ ap (λ m → ⟦ C ⟧ m ◻ f) (α C k g h) ◃∙ α C k (⟦ C ⟧ g ◻ h) f ◃∎
         =ₛ
@@ -216,6 +246,12 @@ module _ {i j} {C : WildCat {i} {j}} (pent : pentagon-wc C)
           ! (α C k (⟦ C ⟧ g ◻ h) f) ◃∙ ! (ap (λ m → ⟦ C ⟧ m ◻ f) (α C k g h)) ◃∙ α C (⟦ C ⟧ k ◻ g) h f ◃∙ α C k g (⟦ C ⟧ h ◻ f) ◃∎
             =ₛ₁⟨ 1 & 1 & !-ap (λ m → ⟦ C ⟧ m ◻ f) (α C k g h) ⟩
           ! (α C k (⟦ C ⟧ g ◻ h) f) ◃∙ ap (λ m → ⟦ C ⟧ m ◻ f) (! (α C k g h)) ◃∙ α C (⟦ C ⟧ k ◻ g) h f ◃∙ α C k g (⟦ C ⟧ h ◻ f) ◃∎ ∎ₛ
+
+    pentagon-wc-rot4 :
+      ! (α C (⟦ C ⟧ k ◻ g) h f) ◃∙ ap (λ m → ⟦ C ⟧ m ◻ f) (α C k g h) ◃∙ α C k (⟦ C ⟧ g ◻ h) f ◃∙ ap (λ m → ⟦ C ⟧ k ◻ m) (α C g h f) ◃∎
+        =ₛ
+      α C k g (⟦ C ⟧ h ◻ f) ◃∎
+    pentagon-wc-rot4 = pre-rotate'-in pentagon-wc◃ 
 
 module _ {i₁ i₂ j₁ j₂} {C₁ : WildCat {i₁} {j₁}} {C₂ : WildCat {i₂} {j₂}} {F : Functor-wc C₁ C₂} (F-assoc : F-α-wc F)
   {a b c d : ob C₁} (h : hom C₁ c d) (g : hom C₁ b c) (f : hom C₁ a b) where

--- a/HoTT-Agda/core/lib/wild-cats/WildCat.agda
+++ b/HoTT-Agda/core/lib/wild-cats/WildCat.agda
@@ -162,7 +162,6 @@ module _ {i j} {C : WildCat {i} {j}} (trig : triangle-wc C)
       ! (α C g (id₁ C b) f) ◃∎
     triangle-wc-rot2 = post-rotate-in triangle-wc◃
 
-
 -- pentagon identity
 
 pentagon-wc : ∀ {i j} (C : WildCat {i} {j}) → Type (lmax i j)

--- a/HoTT-Agda/core/lib/wild-cats/WildCats.agda
+++ b/HoTT-Agda/core/lib/wild-cats/WildCats.agda
@@ -3,6 +3,7 @@
 module lib.wild-cats.WildCats where
 
 open import lib.wild-cats.Adjoint public
+open import lib.wild-cats.Bicat public
 open import lib.wild-cats.Colim-wc public
 open import lib.wild-cats.Counit-unit public
 open import lib.wild-cats.Diagram-wc public

--- a/HoTT-Agda/theorems/homotopy/Susp-2coher.agda
+++ b/HoTT-Agda/theorems/homotopy/Susp-2coher.agda
@@ -457,10 +457,10 @@ module 2-coher-cmp {i₁ i₂ i₃ i₄} {X : Ptd i₁} {Y : Ptd i₂} {Z : Ptd 
 
   abstract
     2-coher-Susp-cmp : (h₁ : ⊙Susp X ⊙→ Y) (h₂ : Z ⊙→ X) (h₃ : W ⊙→ Z) →
-      !-⊙∼ (⊙∘-assoc-comp (into X Y h₁) h₂ h₃) ∙⊙∼
+      !-⊙∼ (⊙∘-assoc-crd (into X Y h₁) h₂ h₃) ∙⊙∼
       ⊙∘-pre h₃ (nat-dom-cmp h₂ h₁) ∙⊙∼
       nat-dom-cmp h₃ (h₁ ⊙∘ ⊙Susp-fmap h₂) ∙⊙∼
-      ap-cmp-into W Y (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃) ∙⊙∼
+      ap-cmp-into W Y (⊙∘-assoc-crd h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃) ∙⊙∼
         ⊙∘-post h₁ (!-⊙∼ (Susp-fmap-∘-∼ (fst h₂) (fst h₃) , idp))) ∙⊙∼
       !-⊙∼ (nat-dom-cmp (h₂ ⊙∘ h₃) h₁)
         ⊙→∼
@@ -475,85 +475,85 @@ module _ {i₁ i₂ i₃ i₄} {X : Ptd i₁} {Y : Ptd i₂} {Z : Ptd i₃} {W :
   -- converting 2-coherence property via the SIP
   abstract
     2-coher-Susp : (h₁ : ⊙Susp X ⊙→ Y) (h₂ : Z ⊙→ X) (h₃ : W ⊙→ Z) →
-      ! (⊙-crd∼-to-== (⊙∘-assoc-comp (into X Y h₁) h₂ h₃)) ∙
+      ! (⊙-crd∼-to-== (⊙∘-assoc-crd (into X Y h₁) h₂ h₃)) ∙
       ap (λ m → m ⊙∘ h₃) (⊙-crd∼-to-== (nat-dom-cmp h₂ h₁)) ∙
       ⊙-crd∼-to-== (nat-dom-cmp h₃ (h₁ ⊙∘ ⊙Susp-fmap h₂)) ∙
       ap (into W Y)
-        (⊙-crd∼-to-== (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃)) ∙
+        (⊙-crd∼-to-== (⊙∘-assoc-crd h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃)) ∙
         ap (λ m →  h₁ ⊙∘ m) (! (⊙Susp-fmap-∘ h₂ h₃))) ∙
       ! (⊙-crd∼-to-== (nat-dom-cmp (h₂ ⊙∘ h₃) h₁))
         ==
       idp
     2-coher-Susp h₁ h₂ h₃ = =ₛ-out $
-      ! (⊙-crd∼-to-== (⊙∘-assoc-comp (into X Y h₁) h₂ h₃)) ◃∙
+      ! (⊙-crd∼-to-== (⊙∘-assoc-crd (into X Y h₁) h₂ h₃)) ◃∙
       ap (λ m → m ⊙∘ h₃) (⊙-crd∼-to-== (nat-dom-cmp h₂ h₁)) ◃∙
       ⊙-crd∼-to-== (nat-dom-cmp h₃ (h₁ ⊙∘ ⊙Susp-fmap h₂)) ◃∙
       ap (into W Y)
-        (⊙-crd∼-to-== (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃)) ∙
+        (⊙-crd∼-to-== (⊙∘-assoc-crd h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃)) ∙
         ap (λ m →  h₁ ⊙∘ m) (! (⊙Susp-fmap-∘ h₂ h₃))) ◃∙
       ! (⊙-crd∼-to-== (nat-dom-cmp (h₂ ⊙∘ h₃) h₁)) ◃∎
-        =ₛ₁⟨ 0 & 1 & ! (!⊙-conv (⊙∘-assoc-comp (into X Y h₁) h₂ h₃)) ⟩
-      ⊙-crd∼-to-== (!-⊙∼ (⊙∘-assoc-comp (into X Y h₁) h₂ h₃)) ◃∙
+        =ₛ₁⟨ 0 & 1 & ! (!⊙-conv (⊙∘-assoc-crd (into X Y h₁) h₂ h₃)) ⟩
+      ⊙-crd∼-to-== (!-⊙∼ (⊙∘-assoc-crd (into X Y h₁) h₂ h₃)) ◃∙
       ap (λ m → m ⊙∘ h₃) (⊙-crd∼-to-== (nat-dom-cmp h₂ h₁)) ◃∙
       ⊙-crd∼-to-== (nat-dom-cmp h₃ (h₁ ⊙∘ ⊙Susp-fmap h₂)) ◃∙
       ap (into W Y)
-        (⊙-crd∼-to-== (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃)) ∙
+        (⊙-crd∼-to-== (⊙∘-assoc-crd h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃)) ∙
         ap (λ m →  h₁ ⊙∘ m) (! (⊙Susp-fmap-∘ h₂ h₃))) ◃∙
       ! (⊙-crd∼-to-== (nat-dom-cmp (h₂ ⊙∘ h₃) h₁)) ◃∎
         =ₛ₁⟨ 1 & 1 & ! (whisk⊙-conv-r (nat-dom-cmp h₂ h₁)) ⟩
-      ⊙-crd∼-to-== (!-⊙∼ (⊙∘-assoc-comp (into X Y h₁) h₂ h₃)) ◃∙
+      ⊙-crd∼-to-== (!-⊙∼ (⊙∘-assoc-crd (into X Y h₁) h₂ h₃)) ◃∙
       ⊙-crd∼-to-== (⊙∘-pre h₃ (nat-dom-cmp h₂ h₁)) ◃∙
       ⊙-crd∼-to-== (nat-dom-cmp h₃ (h₁ ⊙∘ ⊙Susp-fmap h₂)) ◃∙
       ap (into W Y)
-        (⊙-crd∼-to-== (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃)) ∙
+        (⊙-crd∼-to-== (⊙∘-assoc-crd h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃)) ∙
         ap (λ m →  h₁ ⊙∘ m) (! (⊙Susp-fmap-∘ h₂ h₃))) ◃∙
       ! (⊙-crd∼-to-== (nat-dom-cmp (h₂ ⊙∘ h₃) h₁)) ◃∎
         =ₛ₁⟨ 4 & 1 & ! (!⊙-conv (nat-dom-cmp (h₂ ⊙∘ h₃) h₁)) ⟩
-      ⊙-crd∼-to-== (!-⊙∼ (⊙∘-assoc-comp (into X Y h₁) h₂ h₃)) ◃∙
+      ⊙-crd∼-to-== (!-⊙∼ (⊙∘-assoc-crd (into X Y h₁) h₂ h₃)) ◃∙
       ⊙-crd∼-to-== (⊙∘-pre h₃ (nat-dom-cmp h₂ h₁)) ◃∙
       ⊙-crd∼-to-== (nat-dom-cmp h₃ (h₁ ⊙∘ ⊙Susp-fmap h₂)) ◃∙
       ap (into W Y)
-        (⊙-crd∼-to-== (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃)) ∙
+        (⊙-crd∼-to-== (⊙∘-assoc-crd h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃)) ∙
         ap (λ m →  h₁ ⊙∘ m) (! (⊙Susp-fmap-∘ h₂ h₃))) ◃∙
       ⊙-crd∼-to-== (!-⊙∼ (nat-dom-cmp (h₂ ⊙∘ h₃) h₁)) ◃∎
         =ₛ₁⟨ 3 & 1 & ap (ap (into W Y)) (
-          ap (λ p → ⊙-crd∼-to-== (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃)) ∙ p)
+          ap (λ p → ⊙-crd∼-to-== (⊙∘-assoc-crd h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃)) ∙ p)
             (ap (ap (_⊙∘_ h₁)) (! (!⊙-conv (Susp-fmap-∘-∼ (fst h₂) (fst h₃) , idp))) ∙
             ! (whisk⊙-conv-l (!-⊙∼ (Susp-fmap-∘-∼ (fst h₂) (fst h₃) , idp)))) ∙
           ! (=ₛ-out (⊙∘-conv
-            (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃))
+            (⊙∘-assoc-crd h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃))
             (⊙∘-post h₁ (!-⊙∼ (Susp-fmap-∘-∼ (fst h₂) (fst h₃) , idp)))))) ⟩
-      ⊙-crd∼-to-== (!-⊙∼ (⊙∘-assoc-comp (into X Y h₁) h₂ h₃)) ◃∙
+      ⊙-crd∼-to-== (!-⊙∼ (⊙∘-assoc-crd (into X Y h₁) h₂ h₃)) ◃∙
       ⊙-crd∼-to-== (⊙∘-pre h₃ (nat-dom-cmp h₂ h₁)) ◃∙
       ⊙-crd∼-to-== (nat-dom-cmp h₃ (h₁ ⊙∘ ⊙Susp-fmap h₂)) ◃∙
       ap (into W Y) (⊙-crd∼-to-==
-        (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃) ∙⊙∼
+        (⊙∘-assoc-crd h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃) ∙⊙∼
         ⊙∘-post h₁ (!-⊙∼ (Susp-fmap-∘-∼ (fst h₂) (fst h₃) , idp)))) ◃∙
       ⊙-crd∼-to-== (!-⊙∼ (nat-dom-cmp (h₂ ⊙∘ h₃) h₁)) ◃∎
         =ₛ₁⟨ 3 & 1 & ap-cmp-into-agree W Y
-          (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃) ∙⊙∼
+          (⊙∘-assoc-crd h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃) ∙⊙∼
           ⊙∘-post h₁ (!-⊙∼ (Susp-fmap-∘-∼ (fst h₂) (fst h₃) , idp))) ⟩
-      ⊙-crd∼-to-== (!-⊙∼ (⊙∘-assoc-comp (into X Y h₁) h₂ h₃)) ◃∙
+      ⊙-crd∼-to-== (!-⊙∼ (⊙∘-assoc-crd (into X Y h₁) h₂ h₃)) ◃∙
       ⊙-crd∼-to-== (⊙∘-pre h₃ (nat-dom-cmp h₂ h₁)) ◃∙
       ⊙-crd∼-to-== (nat-dom-cmp h₃ (h₁ ⊙∘ ⊙Susp-fmap h₂)) ◃∙
       ⊙-crd∼-to-== (ap-cmp-into W Y
-        (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃) ∙⊙∼
+        (⊙∘-assoc-crd h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃) ∙⊙∼
         ⊙∘-post h₁ (!-⊙∼ (Susp-fmap-∘-∼ (fst h₂) (fst h₃) , idp)))) ◃∙
       ⊙-crd∼-to-== (!-⊙∼ (nat-dom-cmp (h₂ ⊙∘ h₃) h₁)) ◃∎
         =ₛ⟨ ⊙∘-conv-quint
-              (!-⊙∼ (⊙∘-assoc-comp (into X Y h₁) h₂ h₃))
+              (!-⊙∼ (⊙∘-assoc-crd (into X Y h₁) h₂ h₃))
               (⊙∘-pre h₃ (nat-dom-cmp h₂ h₁))
               (nat-dom-cmp h₃ (h₁ ⊙∘ ⊙Susp-fmap h₂))
               (ap-cmp-into W Y
-                (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃) ∙⊙∼
+                (⊙∘-assoc-crd h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃) ∙⊙∼
                 ⊙∘-post h₁ (!-⊙∼ (Susp-fmap-∘-∼ (fst h₂) (fst h₃) , idp))))
               (!-⊙∼ (nat-dom-cmp (h₂ ⊙∘ h₃) h₁)) ⟩
       ⊙-crd∼-to-==
-        (!-⊙∼ (⊙∘-assoc-comp (into X Y h₁) h₂ h₃) ∙⊙∼
+        (!-⊙∼ (⊙∘-assoc-crd (into X Y h₁) h₂ h₃) ∙⊙∼
         ⊙∘-pre h₃ (nat-dom-cmp h₂ h₁) ∙⊙∼
         nat-dom-cmp h₃ (h₁ ⊙∘ ⊙Susp-fmap h₂) ∙⊙∼
         ap-cmp-into W Y
-          (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃) ∙⊙∼
+          (⊙∘-assoc-crd h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃) ∙⊙∼
           ⊙∘-post h₁ (!-⊙∼ (Susp-fmap-∘-∼ (fst h₂) (fst h₃) , idp))) ∙⊙∼
         !-⊙∼ (nat-dom-cmp (h₂ ⊙∘ h₃) h₁)) ◃∎
         =ₛ₁⟨ ap ⊙-crd∼-to-== (⊙→∼-to-== (2-coher-Susp-cmp h₁ h₂ h₃)) ⟩

--- a/HoTT-Agda/theorems/homotopy/Susp-2coher.agda
+++ b/HoTT-Agda/theorems/homotopy/Susp-2coher.agda
@@ -475,71 +475,71 @@ module _ {i₁ i₂ i₃ i₄} {X : Ptd i₁} {Y : Ptd i₂} {Z : Ptd i₃} {W :
   -- converting 2-coherence property via the SIP
   abstract
     2-coher-Susp : (h₁ : ⊙Susp X ⊙→ Y) (h₂ : Z ⊙→ X) (h₃ : W ⊙→ Z) →
-      ! (⊙-comp-to-== (⊙∘-assoc-comp (into X Y h₁) h₂ h₃)) ∙
-      ap (λ m → m ⊙∘ h₃) (⊙-comp-to-== (nat-dom-cmp h₂ h₁)) ∙
-      ⊙-comp-to-== (nat-dom-cmp h₃ (h₁ ⊙∘ ⊙Susp-fmap h₂)) ∙
+      ! (⊙-crd∼-to-== (⊙∘-assoc-comp (into X Y h₁) h₂ h₃)) ∙
+      ap (λ m → m ⊙∘ h₃) (⊙-crd∼-to-== (nat-dom-cmp h₂ h₁)) ∙
+      ⊙-crd∼-to-== (nat-dom-cmp h₃ (h₁ ⊙∘ ⊙Susp-fmap h₂)) ∙
       ap (into W Y)
-        (⊙-comp-to-== (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃)) ∙
+        (⊙-crd∼-to-== (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃)) ∙
         ap (λ m →  h₁ ⊙∘ m) (! (⊙Susp-fmap-∘ h₂ h₃))) ∙
-      ! (⊙-comp-to-== (nat-dom-cmp (h₂ ⊙∘ h₃) h₁))
+      ! (⊙-crd∼-to-== (nat-dom-cmp (h₂ ⊙∘ h₃) h₁))
         ==
       idp
     2-coher-Susp h₁ h₂ h₃ = =ₛ-out $
-      ! (⊙-comp-to-== (⊙∘-assoc-comp (into X Y h₁) h₂ h₃)) ◃∙
-      ap (λ m → m ⊙∘ h₃) (⊙-comp-to-== (nat-dom-cmp h₂ h₁)) ◃∙
-      ⊙-comp-to-== (nat-dom-cmp h₃ (h₁ ⊙∘ ⊙Susp-fmap h₂)) ◃∙
+      ! (⊙-crd∼-to-== (⊙∘-assoc-comp (into X Y h₁) h₂ h₃)) ◃∙
+      ap (λ m → m ⊙∘ h₃) (⊙-crd∼-to-== (nat-dom-cmp h₂ h₁)) ◃∙
+      ⊙-crd∼-to-== (nat-dom-cmp h₃ (h₁ ⊙∘ ⊙Susp-fmap h₂)) ◃∙
       ap (into W Y)
-        (⊙-comp-to-== (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃)) ∙
+        (⊙-crd∼-to-== (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃)) ∙
         ap (λ m →  h₁ ⊙∘ m) (! (⊙Susp-fmap-∘ h₂ h₃))) ◃∙
-      ! (⊙-comp-to-== (nat-dom-cmp (h₂ ⊙∘ h₃) h₁)) ◃∎
+      ! (⊙-crd∼-to-== (nat-dom-cmp (h₂ ⊙∘ h₃) h₁)) ◃∎
         =ₛ₁⟨ 0 & 1 & ! (!⊙-conv (⊙∘-assoc-comp (into X Y h₁) h₂ h₃)) ⟩
-      ⊙-comp-to-== (!-⊙∼ (⊙∘-assoc-comp (into X Y h₁) h₂ h₃)) ◃∙
-      ap (λ m → m ⊙∘ h₃) (⊙-comp-to-== (nat-dom-cmp h₂ h₁)) ◃∙
-      ⊙-comp-to-== (nat-dom-cmp h₃ (h₁ ⊙∘ ⊙Susp-fmap h₂)) ◃∙
+      ⊙-crd∼-to-== (!-⊙∼ (⊙∘-assoc-comp (into X Y h₁) h₂ h₃)) ◃∙
+      ap (λ m → m ⊙∘ h₃) (⊙-crd∼-to-== (nat-dom-cmp h₂ h₁)) ◃∙
+      ⊙-crd∼-to-== (nat-dom-cmp h₃ (h₁ ⊙∘ ⊙Susp-fmap h₂)) ◃∙
       ap (into W Y)
-        (⊙-comp-to-== (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃)) ∙
+        (⊙-crd∼-to-== (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃)) ∙
         ap (λ m →  h₁ ⊙∘ m) (! (⊙Susp-fmap-∘ h₂ h₃))) ◃∙
-      ! (⊙-comp-to-== (nat-dom-cmp (h₂ ⊙∘ h₃) h₁)) ◃∎
+      ! (⊙-crd∼-to-== (nat-dom-cmp (h₂ ⊙∘ h₃) h₁)) ◃∎
         =ₛ₁⟨ 1 & 1 & ! (whisk⊙-conv-r (nat-dom-cmp h₂ h₁)) ⟩
-      ⊙-comp-to-== (!-⊙∼ (⊙∘-assoc-comp (into X Y h₁) h₂ h₃)) ◃∙
-      ⊙-comp-to-== (⊙∘-pre h₃ (nat-dom-cmp h₂ h₁)) ◃∙
-      ⊙-comp-to-== (nat-dom-cmp h₃ (h₁ ⊙∘ ⊙Susp-fmap h₂)) ◃∙
+      ⊙-crd∼-to-== (!-⊙∼ (⊙∘-assoc-comp (into X Y h₁) h₂ h₃)) ◃∙
+      ⊙-crd∼-to-== (⊙∘-pre h₃ (nat-dom-cmp h₂ h₁)) ◃∙
+      ⊙-crd∼-to-== (nat-dom-cmp h₃ (h₁ ⊙∘ ⊙Susp-fmap h₂)) ◃∙
       ap (into W Y)
-        (⊙-comp-to-== (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃)) ∙
+        (⊙-crd∼-to-== (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃)) ∙
         ap (λ m →  h₁ ⊙∘ m) (! (⊙Susp-fmap-∘ h₂ h₃))) ◃∙
-      ! (⊙-comp-to-== (nat-dom-cmp (h₂ ⊙∘ h₃) h₁)) ◃∎
+      ! (⊙-crd∼-to-== (nat-dom-cmp (h₂ ⊙∘ h₃) h₁)) ◃∎
         =ₛ₁⟨ 4 & 1 & ! (!⊙-conv (nat-dom-cmp (h₂ ⊙∘ h₃) h₁)) ⟩
-      ⊙-comp-to-== (!-⊙∼ (⊙∘-assoc-comp (into X Y h₁) h₂ h₃)) ◃∙
-      ⊙-comp-to-== (⊙∘-pre h₃ (nat-dom-cmp h₂ h₁)) ◃∙
-      ⊙-comp-to-== (nat-dom-cmp h₃ (h₁ ⊙∘ ⊙Susp-fmap h₂)) ◃∙
+      ⊙-crd∼-to-== (!-⊙∼ (⊙∘-assoc-comp (into X Y h₁) h₂ h₃)) ◃∙
+      ⊙-crd∼-to-== (⊙∘-pre h₃ (nat-dom-cmp h₂ h₁)) ◃∙
+      ⊙-crd∼-to-== (nat-dom-cmp h₃ (h₁ ⊙∘ ⊙Susp-fmap h₂)) ◃∙
       ap (into W Y)
-        (⊙-comp-to-== (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃)) ∙
+        (⊙-crd∼-to-== (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃)) ∙
         ap (λ m →  h₁ ⊙∘ m) (! (⊙Susp-fmap-∘ h₂ h₃))) ◃∙
-      ⊙-comp-to-== (!-⊙∼ (nat-dom-cmp (h₂ ⊙∘ h₃) h₁)) ◃∎
+      ⊙-crd∼-to-== (!-⊙∼ (nat-dom-cmp (h₂ ⊙∘ h₃) h₁)) ◃∎
         =ₛ₁⟨ 3 & 1 & ap (ap (into W Y)) (
-          ap (λ p → ⊙-comp-to-== (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃)) ∙ p)
+          ap (λ p → ⊙-crd∼-to-== (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃)) ∙ p)
             (ap (ap (_⊙∘_ h₁)) (! (!⊙-conv (Susp-fmap-∘-∼ (fst h₂) (fst h₃) , idp))) ∙
             ! (whisk⊙-conv-l (!-⊙∼ (Susp-fmap-∘-∼ (fst h₂) (fst h₃) , idp)))) ∙
           ! (=ₛ-out (⊙∘-conv
             (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃))
             (⊙∘-post h₁ (!-⊙∼ (Susp-fmap-∘-∼ (fst h₂) (fst h₃) , idp)))))) ⟩
-      ⊙-comp-to-== (!-⊙∼ (⊙∘-assoc-comp (into X Y h₁) h₂ h₃)) ◃∙
-      ⊙-comp-to-== (⊙∘-pre h₃ (nat-dom-cmp h₂ h₁)) ◃∙
-      ⊙-comp-to-== (nat-dom-cmp h₃ (h₁ ⊙∘ ⊙Susp-fmap h₂)) ◃∙
-      ap (into W Y) (⊙-comp-to-==
+      ⊙-crd∼-to-== (!-⊙∼ (⊙∘-assoc-comp (into X Y h₁) h₂ h₃)) ◃∙
+      ⊙-crd∼-to-== (⊙∘-pre h₃ (nat-dom-cmp h₂ h₁)) ◃∙
+      ⊙-crd∼-to-== (nat-dom-cmp h₃ (h₁ ⊙∘ ⊙Susp-fmap h₂)) ◃∙
+      ap (into W Y) (⊙-crd∼-to-==
         (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃) ∙⊙∼
         ⊙∘-post h₁ (!-⊙∼ (Susp-fmap-∘-∼ (fst h₂) (fst h₃) , idp)))) ◃∙
-      ⊙-comp-to-== (!-⊙∼ (nat-dom-cmp (h₂ ⊙∘ h₃) h₁)) ◃∎
+      ⊙-crd∼-to-== (!-⊙∼ (nat-dom-cmp (h₂ ⊙∘ h₃) h₁)) ◃∎
         =ₛ₁⟨ 3 & 1 & ap-cmp-into-agree W Y
           (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃) ∙⊙∼
           ⊙∘-post h₁ (!-⊙∼ (Susp-fmap-∘-∼ (fst h₂) (fst h₃) , idp))) ⟩
-      ⊙-comp-to-== (!-⊙∼ (⊙∘-assoc-comp (into X Y h₁) h₂ h₃)) ◃∙
-      ⊙-comp-to-== (⊙∘-pre h₃ (nat-dom-cmp h₂ h₁)) ◃∙
-      ⊙-comp-to-== (nat-dom-cmp h₃ (h₁ ⊙∘ ⊙Susp-fmap h₂)) ◃∙
-      ⊙-comp-to-== (ap-cmp-into W Y
+      ⊙-crd∼-to-== (!-⊙∼ (⊙∘-assoc-comp (into X Y h₁) h₂ h₃)) ◃∙
+      ⊙-crd∼-to-== (⊙∘-pre h₃ (nat-dom-cmp h₂ h₁)) ◃∙
+      ⊙-crd∼-to-== (nat-dom-cmp h₃ (h₁ ⊙∘ ⊙Susp-fmap h₂)) ◃∙
+      ⊙-crd∼-to-== (ap-cmp-into W Y
         (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃) ∙⊙∼
         ⊙∘-post h₁ (!-⊙∼ (Susp-fmap-∘-∼ (fst h₂) (fst h₃) , idp)))) ◃∙
-      ⊙-comp-to-== (!-⊙∼ (nat-dom-cmp (h₂ ⊙∘ h₃) h₁)) ◃∎
+      ⊙-crd∼-to-== (!-⊙∼ (nat-dom-cmp (h₂ ⊙∘ h₃) h₁)) ◃∎
         =ₛ⟨ ⊙∘-conv-quint
               (!-⊙∼ (⊙∘-assoc-comp (into X Y h₁) h₂ h₃))
               (⊙∘-pre h₃ (nat-dom-cmp h₂ h₁))
@@ -548,7 +548,7 @@ module _ {i₁ i₂ i₃ i₄} {X : Ptd i₁} {Y : Ptd i₂} {Z : Ptd i₃} {W :
                 (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃) ∙⊙∼
                 ⊙∘-post h₁ (!-⊙∼ (Susp-fmap-∘-∼ (fst h₂) (fst h₃) , idp))))
               (!-⊙∼ (nat-dom-cmp (h₂ ⊙∘ h₃) h₁)) ⟩
-      ⊙-comp-to-==
+      ⊙-crd∼-to-==
         (!-⊙∼ (⊙∘-assoc-comp (into X Y h₁) h₂ h₃) ∙⊙∼
         ⊙∘-pre h₃ (nat-dom-cmp h₂ h₁) ∙⊙∼
         nat-dom-cmp h₃ (h₁ ⊙∘ ⊙Susp-fmap h₂) ∙⊙∼
@@ -556,9 +556,9 @@ module _ {i₁ i₂ i₃ i₄} {X : Ptd i₁} {Y : Ptd i₂} {Z : Ptd i₃} {W :
           (⊙∘-assoc-comp h₁ (⊙Susp-fmap h₂) (⊙Susp-fmap h₃) ∙⊙∼
           ⊙∘-post h₁ (!-⊙∼ (Susp-fmap-∘-∼ (fst h₂) (fst h₃) , idp))) ∙⊙∼
         !-⊙∼ (nat-dom-cmp (h₂ ⊙∘ h₃) h₁)) ◃∎
-        =ₛ₁⟨ ap ⊙-comp-to-== (⊙→∼-to-== (2-coher-Susp-cmp h₁ h₂ h₃)) ⟩
-      ⊙-comp-to-== (⊙∼-id ((into X Y h₁) ⊙∘ h₂ ⊙∘ h₃)) ◃∎
-        =ₛ₁⟨ ⊙-comp-to-==-β (into X Y h₁ ⊙∘ h₂ ⊙∘ h₃) ⟩
+        =ₛ₁⟨ ap ⊙-crd∼-to-== (⊙→∼-to-== (2-coher-Susp-cmp h₁ h₂ h₃)) ⟩
+      ⊙-crd∼-to-== (⊙∼-id ((into X Y h₁) ⊙∘ h₂ ⊙∘ h₃)) ◃∎
+        =ₛ₁⟨ ⊙-crd∼-to-==-β (into X Y h₁ ⊙∘ h₂ ⊙∘ h₃) ⟩
       idp ◃∎ ∎ₛ
 
 abstract

--- a/HoTT-Agda/theorems/homotopy/SuspAdjointLoop.agda
+++ b/HoTT-Agda/theorems/homotopy/SuspAdjointLoop.agda
@@ -108,6 +108,7 @@ module _ {i} where
 
 module _ {i j} (X : Ptd i) (U : Ptd j) where
 
+  -- component morphism of adjunction
   into : ⊙Susp X ⊙→ U → X ⊙→ ⊙Ω U
   into r = ⊙Ω-fmap r ⊙∘ ⊙η X
 
@@ -154,7 +155,7 @@ module _ {i j} (X : Ptd i) (U : Ptd j) where
       ap (Ω-fmap (g , gₚ)) (!-inv-r (glue (pt X))) ∙ snd (⊙Ω-fmap (g , gₚ))
   ap-cmp-into-coher H₀ idp = ap-cmp-into-coher-aux H₀ (glue (pt X))
 
-  ap-cmp-into : {f₁ f₂ : ⊙Susp X ⊙→ U} (H : f₁ ⊙-comp f₂) → into f₁ ⊙-comp into f₂
+  ap-cmp-into : {f₁ f₂ : ⊙Susp X ⊙→ U} (H : f₁ ⊙-crd∼ f₂) → into f₁ ⊙-crd∼ into f₂
   fst (ap-cmp-into {f₁ = (f , idp)} {f₂} H) x =
     (hmtpy-nat-∙' (fst H) (glue x ∙ ! (glue (pt X))) ∙
       ap (λ p → p ∙ ap (λ z → fst f₂ z) (glue x ∙ ! (glue (pt X))) ∙' ! (fst H (left unit)))
@@ -186,12 +187,12 @@ module _ {i j} (X : Ptd i) (U : Ptd j) where
         ap-cmp-into-coher-aux (λ x → idp) v
       lemma idp = idp
 
-  ap-cmp-into-agree : {f* g* : ⊙Susp X ⊙→ U} (H : f* ⊙-comp g*)
-    → ap into (⊙-comp-to-== H) == ⊙-comp-to-== (ap-cmp-into H)
+  ap-cmp-into-agree : {f* g* : ⊙Susp X ⊙→ U} (H : f* ⊙-crd∼ g*)
+    → ap into (⊙-crd∼-to-== H) == ⊙-crd∼-to-== (ap-cmp-into H)
   ap-cmp-into-agree {f*} = ⊙hom-ind f*
-    (λ g* H → ap into (⊙-comp-to-== H) == ⊙-comp-to-== (ap-cmp-into H))
-    (ap (ap into) (⊙-comp-to-==-β f*) ∙
-    ! (ap ⊙-comp-to-== (⊙→∼-to-== (ap-cmp-into-id f*)) ∙ ⊙-comp-to-==-β (into f*)))
+    (λ g* H → ap into (⊙-crd∼-to-== H) == ⊙-crd∼-to-== (ap-cmp-into H))
+    (ap (ap into) (⊙-crd∼-to-==-β f*) ∙
+    ! (ap ⊙-crd∼-to-== (⊙→∼-to-== (ap-cmp-into-id f*)) ∙ ⊙-crd∼-to-==-β (into f*)))
 
 {-
   an explicit component-based homotopy witnessing the
@@ -237,7 +238,7 @@ module _ {i i' j} {X : Ptd i} {Y : Ptd i'} {U : Ptd j} where
     nat-dom-aux-l = nat-dom-aux-l2 (SuspFmap.merid-β h₀ (pt X)) 
 
   nat-dom-cmp : (h : X ⊙→ Y) (r : ⊙Susp Y ⊙→ U)
-    → (into Y U) r ⊙∘ h ⊙-comp (into X U) (r ⊙∘ ⊙Susp-fmap h)
+    → (into Y U) r ⊙∘ h ⊙-crd∼ (into X U) (r ⊙∘ ⊙Susp-fmap h)
   fst (nat-dom-cmp (h₀ , idp) (r₀ , idp)) x = ↯ $
     ap-∙ r₀ (glue (h₀ x)) (! (glue (pt Y))) ◃∙
     ! (ap (λ p → ap r₀ (glue (h₀ x)) ∙ p) (ap (λ p → ap r₀ (! p)) (SuspFmap.merid-β h₀ (pt X)))) ◃∙
@@ -268,4 +269,4 @@ module _ {i i' j} {X : Ptd i} {Y : Ptd i'} {U : Ptd j} where
 SuspLoopAdj-exp : ∀ {i} → Adjunction (SuspFunctor {i}) (LoopFunctor {i})
 iso SuspLoopAdj-exp = iso SuspLoopAdj
 nat-cod SuspLoopAdj-exp = nat-cod SuspLoopAdj
-nat-dom SuspLoopAdj-exp h r = ⊙-comp-to-== (nat-dom-cmp h r)
+nat-dom SuspLoopAdj-exp h r = ⊙-crd∼-to-== (nat-dom-cmp h r)

--- a/HoTT-Agda/theorems/modality/Mod-colim.agda
+++ b/HoTT-Agda/theorems/modality/Mod-colim.agda
@@ -31,18 +31,6 @@ module _ {ℓ j} (μ : Modality (lmax ℓ j)) (A : Type j) where
   open Mod-Prsrv {lmax ℓ j} μ A
   open MapsCos A
 
-  private
-    -- a standard property of a bicategory
-    trig-ρ-Cos : {X Y Z : Coslice (lmax ℓ j) j A} (g : Y *→ Z) (f : X *→ Y) →
-      ap (λ m → g ∘* m) (ρ (Coslice-wc A (lmax ℓ j)) f) ◃∙
-      ! (α (Coslice-wc A (lmax ℓ j)) g f (id₁ (Coslice-wc A (lmax ℓ j)) X)) ◃∙
-      ! (ρ (Coslice-wc A (lmax ℓ j)) (g ∘* f)) ◃∎
-        =ₛ
-      []
-    trig-ρ-Cos g f = =ₛ-in $
-      ∙-unit-r (! (UndFun∼-to-== (*→-assoc g f id-cos))) ∙
-      ap ! (ap UndFun∼-to-== (∼∼-cos∼-to-== ((λ _ → idp) , (λ _ → idp))) ∙ UndFun∼-β)
-
   module _ {ℓv ℓe} {G : Graph ℓv ℓe} (Δ : Diagram G (Coslice-loc-wc μ A)) where
 
     open Col-Dmap {C = Coslice-loc-wc μ A} {G = G} (iso-cos A) (id-sys-iso-cos-loc μ A)
@@ -62,7 +50,7 @@ module _ {ℓ j} (μ : Modality (lmax ℓ j)) (A : Type j) where
       -- construction of graph-indexed colimits in Coslice-loc-wc μ A
       CosCol-loc : is-colim {D = Δ} $
         act-dmap-coc (fst Mod-nat-eqv-η) (F-coc Mod-cos-fctr (CosCoc-to-wc (ColCoC-cos (Diag-to-grhom (F-diag Loc-cos-forg-fctr Δ)))))
-      CosCol-loc = colim-act-dmap (triangle-wc-Cos A {i = lmax ℓ j}) trig-ρ-Cos
+      CosCol-loc = colim-act-dmap (triangle-wc-Cos A {i = lmax ℓ j}) (pentagon-wc-Cos A {i = lmax ℓ j})
         Mod-nat-eqv-η
         (F-coc Mod-cos-fctr (CosCoc-to-wc (ColCoC-cos (Diag-to-grhom (F-diag Loc-cos-forg-fctr Δ)))))
         (Mod-prsrv-colim {Δ = F-diag Loc-cos-forg-fctr Δ} {X = po-CosCol {ℓd = lmax ℓ j} (Diag-to-grhom (F-diag Loc-cos-forg-fctr Δ))}

--- a/HoTT-Agda/theorems/modality/Mod-colim.agda
+++ b/HoTT-Agda/theorems/modality/Mod-colim.agda
@@ -49,7 +49,7 @@ module _ {ℓ j} (μ : Modality (lmax ℓ j)) (A : Type j) where
 
     open Map-diag
     
-    Mod-nat-eqv-η : diag-eqv Δ (F-diag (Mod-cos-fctr ∘WC Loc-cos-forg-fctr) Δ)
+    Mod-nat-eqv-η : diag-ueqv Δ (F-diag (Mod-cos-fctr ∘WC Loc-cos-forg-fctr) Δ)
     map-comp (fst Mod-nat-eqv-η) x = η , λ a → idp
     map-sq (fst Mod-nat-eqv-η) {x} {y} f = UndFun∼-to-== ((λ z → ◯-fmap-β (fst (D₁ Δ f)) z) , (λ a →
       !-inv-l-assoc (◯-fmap-β (fst (D₁ Δ f)) (str (fst (D₀ Δ x)) a)) (ap η (snd (D₁ Δ f) a)) ∙

--- a/Pullback-stability/AuxPaths-pb.agda
+++ b/Pullback-stability/AuxPaths-pb.agda
@@ -4,32 +4,10 @@ open import lib.Basics
 open import lib.types.Cospan
 open import lib.types.Pullback
 
-module Path-alg where
+module AuxPaths-pb where
 
-module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄} {A₁ : Type ℓ₁} {A₂ : Type ℓ₂} (B : A₁ → A₂ → Type ℓ₃) (C : Type ℓ₄) where
-
-  -- a rule for Transport of dependent functions that are independent of the third argument
-  dpr-transp-eq : {a b : A₁} (p : a == b) (f : (y : A₂) → B a y → C) (g : (y : A₂) → B b y → C)
-    → Π A₂ (λ y → (x : B b y) → f y (transport (λ v → B v y) (! p) x) == g y x)
-    → transport (λ (z : A₁) → (y : A₂) → B z y → C) p f == g
-  dpr-transp-eq idp f g H = λ= λ x → λ= (H x)
-
-module _ {ℓ₁ ℓ₂ ℓ₃} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type ℓ₃} {k : A → C} (f : B → C) where
-
-  -- a naturality law for transports of paths 
-  transp-nat-cnstR : {b : B} {x y : A} (p : x == y) (q : k y == f b)
-    → transport (λ v → k v == f b) (! p) q == ap k p ∙ q
-  transp-nat-cnstR idp q = idp
-
-module _ {ℓ} {A : Type ℓ} where
-
-  -- an ad-hoc computation
-  !-inv-l-∙ : {x y z : A} (q : x == y) (p : y == z) → ! q ∙ q ∙ p == p 
-  !-inv-l-∙ idp p = idp
-
+-- some ad-hoc computations
 module _ {ℓ₁ ℓ₂} {A : Type ℓ₁} {B : Type ℓ₂} {f : A → B} where
-
-  -- more ad-hoc computations
   
   !-ap-!-∙ : {x y : A} {w : B} (p₁ : x == y) (p₂ : f y == w)
     → ! (ap f (! p₁ ∙ p₁) ∙ p₂) ∙ p₂ == idp
@@ -43,6 +21,21 @@ module _ {ℓ₁ ℓ₂} {A : Type ℓ₁} {B : Type ℓ₂} {f : A → B} where
     → h ∙ idp == ap f p ∙ ! (ap f p) ∙ h
   ∙-unit-r-!-inv-r-ap idp h = ∙-unit-r h
 
+module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄} {A₁ : Type ℓ₁} {A₂ : Type ℓ₂} (B : A₁ → A₂ → Type ℓ₃) (C : Type ℓ₄) where
+
+  -- a rule for transport of dependent functions that are independent of the third argument
+  dpr-transp-eq : {a b : A₁} (p : a == b) (f : (y : A₂) → B a y → C) (g : (y : A₂) → B b y → C)
+    → Π A₂ (λ y → (x : B b y) → f y (transport (λ v → B v y) (! p) x) == g y x)
+    → transport (λ (z : A₁) → (y : A₂) → B z y → C) p f == g
+  dpr-transp-eq idp f g H = λ= λ x → λ= (H x)
+
+module _ {ℓ₁ ℓ₂ ℓ₃} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type ℓ₃} {k : A → C} (f : B → C) where
+
+  -- a naturality law for transports of paths 
+  transp-nat-cnstR : {b : B} {x y : A} (p : x == y) (q : k y == f b)
+    → transport (λ v → k v == f b) (! p) q == ap k p ∙ q
+  transp-nat-cnstR idp q = idp
+
 module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄} (D : Cospan {ℓ₁} {ℓ₂} {ℓ₃}) (E : Type ℓ₄)  where
 
   open Cospan D
@@ -51,12 +44,11 @@ module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄} (D : Cospan {ℓ₁} {ℓ₂} {ℓ₃}) (
   dpr-transp-β-pb : {a b : A} (p : a == b) (h : (z : A) (y : B) → f z == g y → E)
     (κ : Π B (λ y → (x : f b == g y) → h a y (transport (λ v → f v == g y) (! p) x) == h b y x))
     (q : apd-tr h p == dpr-transp-eq (λ v y → f v == g y) E p (λ y w → h a y w) (λ y w → h b y w) κ)
-    {y₀ : B} {x₁ : f b == g y₀} {x₂ : f a == g y₀} (τ : x₂ ∙ idp == ap f p ∙ x₁)
-    → ap (λ (pullback z y x) → h z y x) (pullback= D p idp τ) ◃∎
+    {y₀ : B} {x₁ : f b == g y₀} {x₂ : f a == g y₀} (τ : x₂ ∙ idp == ap f p ∙ x₁) →
+      ap (λ (pullback z y x) → h z y x) (pullback= D p idp τ) ◃∎
         =ₛ
       ap (h a y₀) (! (∙-unit-r x₂) ∙  τ)  ◃∙ ! (ap (h a y₀) (transp-nat-cnstR g p x₁)) ◃∙ κ y₀ x₁ ◃∎
-  dpr-transp-β-pb {a = a} idp h κ q {y₀ = y₀} {x₁ = x₁} {x₂ = x₂} τ =
-    =ₛ-in (lemma1 (! (∙-unit-r x₂)) τ (lemma2 q))
+  dpr-transp-β-pb {a = a} idp h κ q {y₀ = y₀} {x₁ = x₁} {x₂ = x₂} τ = =ₛ-in (lemma1 (! (∙-unit-r x₂)) τ (lemma2 q))
     where
     
       lemma1 : {m₁ m₂ : f a == g y₀} (u : m₁ == x₂ ∙ idp) (τ : x₂ ∙ idp == m₂)
@@ -71,7 +63,7 @@ module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄} (D : Cospan {ℓ₁} {ℓ₂} {ℓ₃}) (
   transp-id-pb-idf : (f₁ : E → Pullback D) (f₂ : Pullback D → E) {a b : A} (p : a == b)
     (e₁ : (y : B) (h : f a == g y) → f₁ (f₂ (pullback a y h)) == pullback a y h)
     (e₂ : (y : B) (h : f b == g y) → f₁ (f₂ (pullback b y h)) == pullback b y h)
-    → ((y : B) (h : f a == g y)  →
+    → ((y : B) (h : f a == g y) →
       ! (ap f₁ (ap f₂ (pullback= D p idp {h' = ! (ap f p) ∙ h} (∙-unit-r-!-inv-r-ap p h)))) ◃∙
       e₁ y h ◃∙
       pullback= D p idp (∙-unit-r-!-inv-r-ap p h) ◃∎
@@ -80,10 +72,11 @@ module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄} (D : Cospan {ℓ₁} {ℓ₂} {ℓ₃}) (
     → transport (λ z → (y : B) (h : f z == g y) → f₁ (f₂ (pullback z y h)) == pullback z y h) p e₁ == e₂
   transp-id-pb-idf f₁ f₂ {a = a} idp e₁ e₂ K = λ= (λ y → λ= (λ h → =ₛ-out (lemma y h) ∙ =ₛ-out (K y h)))
     where
-      lemma : (y : B) (h : f a == g y)
-        → e₁ y h ◃∎ =ₛ
+      lemma : (y : B) (h : f a == g y) →
+        e₁ y h ◃∎
+          =ₛ
         ! (ap f₁ (ap f₂ (ap (pullback a y) (! (∙-unit-r h) ∙ ∙-unit-r h)))) ◃∙ e₁ y h ◃∙
-          ap (pullback a y) (! (∙-unit-r h) ∙ ∙-unit-r h) ◃∎
+        ap (pullback a y) (! (∙-unit-r h) ∙ ∙-unit-r h) ◃∎
       lemma y h =
         e₁ y h ◃∎
           =ₛ⟨ =ₛ-in (! (∙-unit-r (e₁ y h))) ⟩

--- a/Pullback-stability/Stability-ord.agda
+++ b/Pullback-stability/Stability-ord.agda
@@ -6,7 +6,7 @@ open import lib.types.Pullback
 open import lib.types.Colim
 open import lib.types.Graph
 open import lib.types.Diagram
-open import Path-alg
+open import AuxPaths-pb
 
 -- pullback stability for ordinary colimits
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     [On Left Adjoints Preserving Colimits in HoTT](https://phart3.github.io/2coher-preprint.pdf)
     (based on the [HoTT/UF 2025 extended abstract](https://hott-uf.github.io/2025/abstracts/HoTTUF_2025_paper_9.pdf))
   
-  It has been checked with Agda 2.6.3 and 2.6.4.
+  It has been checked with Agda 2.6.3 and 2.6.4.3
 
 ## Organization
 
@@ -55,7 +55,7 @@ We have successfully tested the following Docker container on Linux but not on o
    docker build . -t colimit
    ```
 
-   The build installs Agda 2.6.4 and type checks our whole development.
+   The build installs Agda 2.6.4.3 and type checks our whole development.
    The entire build may take over an hour. The type checking of all our
    Agda code takes about 49 minutes on our host Ubuntu with 16 GB of RAM.
 


### PR DESCRIPTION
This PR proves fundamental coherence lemmas of wild bicategories (`HoTT-Agda/core/lib/wild-cats/Bicat.agda`) and removes the ad-hoc assumptions of them from various proofs about specific wild bicategories (like coslices of the universe).